### PR TITLE
Fixed Z-Index of Inspect Window's select elements 

### DIFF
--- a/packages/editor/src/components/Select/Select.tsx
+++ b/packages/editor/src/components/Select/Select.tsx
@@ -128,7 +128,6 @@ const BasicSelect = ({
     valueContainer: () => ({
       width: '100%',
       display: 'flex',
-      zIndex: 10,
       flex: '1',
       alignItems: 'center',
       fontFamily: 'IBM Plex Mono',


### PR DESCRIPTION
There was an issue with the z-index of one of the Inspect Window's inspect elements. 

It was causing it to draw on top of top File dropdown, blocking the Save button.

Before: 
<img width="374" alt="select_borked" src="https://user-images.githubusercontent.com/45219403/220503874-d4f20d40-085e-412d-935d-cb798836f93c.png">

After:
<img width="200" alt="select_fixed" src="https://user-images.githubusercontent.com/45219403/220503873-47136831-d577-4bf3-9889-1e3120a021ad.png">

