### PR TITLE
ID based key for spells

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Default settings, override in .env.local file that is auto-generated on install
 # NOTE: The default database is provided to get you up and running but is not secure!
-DATABASE_URL=postgresql://postgres:ZTE*meq1mzh3abn!cmk@db.xnzvmluhwpbngdufsbrd.supabase.co:5432/postgres
+DATABASE_URL=postgres://postgres:ZTE*meq1mzh3abn!cmk@db.xbolptvmhqplniydcjcz.supabase.co:5432/postgres
 PLUGINS=@magickml/plugin-discord
 
 # if you want to override OpenAI's endpoint with another URL that matches the same API

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Default settings, override in .env.local file that is auto-generated on install
 # NOTE: The default database is provided to get you up and running but is not secure!
-DATABASE_URL=postgres://postgres:ZTE*meq1mzh3abn!cmk@db.xbolptvmhqplniydcjcz.supabase.co:5432/postgres
+DATABASE_URL=postgres://postgres:P8Pwj96n38ilb5a2@db.ageqtrdagwgucljhwtab.supabase.co:6543/postgres
 PLUGINS=@magickml/plugin-discord
 
 # if you want to override OpenAI's endpoint with another URL that matches the same API

--- a/apps/server/migrations/20230224084646_spell.ts
+++ b/apps/server/migrations/20230224084646_spell.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('spells', (table) => {
-    table.increments('id')
+    table.uuid('id').primary()
     table.string('name')
     table.string('projectId')
     table.string('hash')

--- a/apps/server/src/World.ts
+++ b/apps/server/src/World.ts
@@ -181,6 +181,7 @@ export class World {
     const agents = (await app.service('agents').find()).data
     for (const i in agents) {
       // rewrite as a feathers service call to empty
+      //@ts-ignore
       await app.service('agents').patch(agents[i].id, {
         spells: [],
       })

--- a/apps/server/src/World.ts
+++ b/apps/server/src/World.ts
@@ -83,17 +83,21 @@ export class World {
       } catch {
         console.log("Client Does not exist")
       }
-      if (newAgents[i].data.discord_enabled){
-        try {
-          //Get the agent which was updated.
-          let temp_agent = this.getAgent(newAgents[i].id)
-          //Delete the Agent
-          await temp_agent.onDestroy()
-        } catch(e) {
-          console.log("Couldn't delete the Discord Client.!! Caught Error: ",e)
-        }
-        this.addAgent(newAgents[i])
-      } 
+      try {
+        if (newAgents[i].data.discord_enabled){
+          try {
+            //Get the agent which was updated.
+            let temp_agent = this.getAgent(newAgents[i].id)
+            //Delete the Agent
+            await temp_agent.onDestroy()
+          } catch(e) {
+            console.log("Couldn't delete the Discord Client.!! Caught Error: ",e)
+          }
+          this.addAgent(newAgents[i])
+        } 
+      } catch {
+        console.log("No Agents Present")
+      }
     }
     // If an entry exists in oldAgents but not in newAgents, it has been deleted
     for (const i in oldAgents) {

--- a/apps/server/src/buildMagickInterface.ts
+++ b/apps/server/src/buildMagickInterface.ts
@@ -10,9 +10,9 @@ export const buildMagickInterface = (overrides: Record<string, Function> = {}) =
 
   return {
     env,
-    runSpell: async ({spellName, inputs, projectId}) => {
+    runSpell: async ({id, inputs, projectId}) => {
       const { outputs } = await runSpell({
-        spellName,
+        id,
         inputs,
         projectId
       })

--- a/apps/server/src/buildMagickInterface.ts
+++ b/apps/server/src/buildMagickInterface.ts
@@ -22,6 +22,12 @@ export const buildMagickInterface = (overrides: Record<string, Function> = {}) =
       const spell = await app.service('spells').find({ query: { projectId, name: spellName } })
 
       return spell
+    },
+
+    getSpellbyId: async ({spellName, projectId, Id}) => {
+      const spell = await app.service('spells').find({ query: { projectId, name: spellName, id: Id } })
+
+      return spell
     }
   }
 }

--- a/apps/server/src/services/spell-runner/spell-runner.class.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.class.ts
@@ -26,7 +26,7 @@ const getSpell = async ({app, spellName, projectId}) => {
   const spell = await app.service('spells').find({
     query: {
       projectId,
-      name: spellName
+      Id: spellName
     }
   })
 

--- a/apps/server/src/services/spell-runner/spell-runner.class.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.class.ts
@@ -90,9 +90,10 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
     data: { diff: Record<string, unknown> },
     params?: SpellRunnerParams
   ): Promise<Data> {
+    console.log("ID is ",id)
     if (!app.userSpellManagers) return {}
     if (!params) throw new Error('No params present in service')
-
+    
     const { user } = params as any
 
     if (!user) throw new Error('No user present in service')

--- a/apps/server/src/services/spell-runner/spell-runner.class.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.class.ts
@@ -18,18 +18,22 @@ interface Data {}
 
 interface CreateData {
   inputs: Record<string, any>
+  id: string
   spellName: string
   projectId: string
 }
 
-const getSpell = async ({app, spellName, projectId}) => {
+const getSpell = async ({app, id, projectId}) => {
+  
   const spell = await app.service('spells').find({
     query: {
       projectId,
-      Id: spellName
+      id: id
     }
   })
-
+  console.log("Inside Load Spell")
+  console.log(projectId,id)
+  console.log(spell.data[0])
   return spell.data[0]
 }
 
@@ -50,8 +54,9 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
     const spellManager = app.userSpellManagers.get(user.id.toString())
 
     if (!spellManager) throw new Error('No spell manager created for user!')
-
-    const spell = await getSpell({app, spellName: id as string, projectId: query.projectId})
+    console.log(id)
+    let decoded_id = id.slice(0,36)
+    const spell = await getSpell({app, id: decoded_id as string, projectId: query.projectId})
 
     // Load the spell into the spellManager. If there is no spell runner, we make one.
     await spellManager.load(spell as Spell)
@@ -68,18 +73,18 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
 
     if (!user) throw new Error('No user is present in service')
 
-    const { inputs, spellName, projectId } = data
-
+    const { inputs, projectId, id, spellName } = data
     const spellManager = app.userSpellManagers.get(user.id)
 
     if (!spellManager) throw new Error('No spell manager found for user!')
 
-    if (!spellManager.hasSpellRunner(spellName)) {
-      const spell = await getSpell({app, spellName: spellName, projectId})
+    if (!spellManager.hasSpellRunner(id)) {
+      const spell = await getSpell({app, id: id, projectId})
       await spellManager.load(spell as Spell)
+      console.log("SPELL Loaded")
     }
 
-    const result = await spellManager.run(spellName, inputs)
+    const result = await spellManager.run(id, inputs)
 
     return result || {}
   }

--- a/apps/server/src/services/spell-runner/spell-runner.class.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.class.ts
@@ -31,9 +31,6 @@ const getSpell = async ({app, id, projectId}) => {
       id: id
     }
   })
-  console.log("Inside Load Spell")
-  console.log(projectId,id)
-  console.log(spell.data[0])
   return spell.data[0]
 }
 
@@ -44,7 +41,7 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
   ServiceParams,
   SpellRunnerPatch
 > {
-  async get(id: Id, params?: SpellRunnerParams): Promise<any | {}> {
+  async get(id: string, params?: SpellRunnerParams): Promise<any | {}> {
     if (!app.userSpellManagers) return {}
     if (!params) throw new Error('No params present in service')
     const { user, query } = params as any;
@@ -54,7 +51,6 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
     const spellManager = app.userSpellManagers.get(user.id.toString())
 
     if (!spellManager) throw new Error('No spell manager created for user!')
-    console.log(id)
     let decoded_id = id.slice(0,36)
     const spell = await getSpell({app, id: decoded_id as string, projectId: query.projectId})
 
@@ -81,7 +77,7 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
     if (!spellManager.hasSpellRunner(id)) {
       const spell = await getSpell({app, id: id, projectId})
       await spellManager.load(spell as Spell)
-      console.log("SPELL Loaded")
+
     }
 
     const result = await spellManager.run(id, inputs)

--- a/apps/server/src/services/spell-runner/spell-runner.class.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.class.ts
@@ -86,7 +86,7 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
   }
 
   async update(
-    spellName: string,
+    id: string,
     data: { diff: Record<string, unknown> },
     params?: SpellRunnerParams
   ): Promise<Data> {
@@ -99,12 +99,12 @@ export class SpellRunnerService<ServiceParams extends Params = SpellRunnerParams
 
     const { diff } = data
 
-    console.log('updated spell, diff is', spellName, diff)
+    console.log('updated spell, diff is', id, diff)
 
     const spellManager = app.userSpellManagers.get(user.id)
     if (!spellManager) throw new Error('No spell manager found for user!')
 
-    const spellRunner = spellManager.getSpellRunner(spellName)
+    const spellRunner = spellManager.getSpellRunner(id)
     if (!spellRunner) throw new Error('No spell runner found!')
 
     const spell = spellRunner.currentSpell

--- a/apps/server/src/services/spell-runner/spell-runner.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.ts
@@ -20,10 +20,16 @@ export const spellRunner = (app: Application) => {
       ]
     },
     before: {
-      all: [],
+      all: [
+        
+      ],
       find: [],
       get: [],
-      create: [],
+      create: [
+        async (context:any) => {
+          console.log(context.data)
+        }
+      ],
       patch: [],
       remove: []
     },

--- a/apps/server/src/services/spell-runner/spell-runner.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.ts
@@ -21,20 +21,18 @@ export const spellRunner = (app: Application) => {
     },
     before: {
       all: [
-        async (context:any) => {
-          console.log(context.data)
-        }
+        
         
       ],
       find: [],
       get: [],
       create: [
+        
+      ],
+      patch: [
         async (context:any) => {
           console.log(context.data)
         }
-      ],
-      patch: [
-        
       ],
       remove: []
     },

--- a/apps/server/src/services/spell-runner/spell-runner.ts
+++ b/apps/server/src/services/spell-runner/spell-runner.ts
@@ -21,6 +21,9 @@ export const spellRunner = (app: Application) => {
     },
     before: {
       all: [
+        async (context:any) => {
+          console.log(context.data)
+        }
         
       ],
       find: [],
@@ -30,7 +33,9 @@ export const spellRunner = (app: Application) => {
           console.log(context.data)
         }
       ],
-      patch: [],
+      patch: [
+        
+      ],
       remove: []
     },
     after: {

--- a/apps/server/src/services/spells/spells.schema.ts
+++ b/apps/server/src/services/spells/spells.schema.ts
@@ -8,7 +8,7 @@ import { dataValidator, queryValidator } from '../../validators'
 // Main data model schema
 export const spellSchema = Type.Object(
   {
-    id: Type.Number(),
+    id: Type.String(),
     projectId: Type.String(),
     name: Type.String(),
     hash: Type.String(),

--- a/apps/server/src/services/spells/spells.ts
+++ b/apps/server/src/services/spells/spells.ts
@@ -1,6 +1,6 @@
 // For more information about this file see https://dove.feathersjs.com/guides/cli/service.html
 import { hooks as schemaHooks } from '@feathersjs/schema'
-
+import { randomUUID } from 'crypto'
 import {
   spellDataValidator,
   spellPatchValidator,
@@ -39,15 +39,35 @@ export const spell = (app: Application) => {
       all: [schemaHooks.validateQuery(spellQueryValidator), schemaHooks.resolveQuery(spellQueryResolver)],
       find: [],
       get: [],
-      create: [schemaHooks.validateData(spellDataValidator), schemaHooks.resolveData(spellDataResolver)],
+      create: [schemaHooks.validateData(spellDataValidator), schemaHooks.resolveData(spellDataResolver),
+        
+        async (context:any) => {
+          const { data, service } = context;
+          context.data = {
+            [service.id]:randomUUID(),
+            ...data
+          }
+        },
+        async (context: any) => {
+          
+          console.log(context.data)
+        },
+      ],
       patch: [schemaHooks.validateData(spellPatchValidator), schemaHooks.resolveData(spellPatchResolver)],
       remove: []
     },
     after: {
       all: [],
+      create: [
+        async (context: any) => {
+          console.log("AFTER")
+          console.log(context.data)
+        }
+      ],
       patch: [
         // after saving a spell, we need to update the spell cache
         async (context: any) => {
+          console.log("ISNIDE")
           const { app } = context
           const { id } = context.result
           const spell = await app.service('spells').get(id)

--- a/apps/server/src/services/spells/spells.ts
+++ b/apps/server/src/services/spells/spells.ts
@@ -67,7 +67,6 @@ export const spell = (app: Application) => {
       patch: [
         // after saving a spell, we need to update the spell cache
         async (context: any) => {
-          console.log("ISNIDE")
           const { app } = context
           const { id } = context.result
           const spell = await app.service('spells').get(id)

--- a/apps/server/src/utils/runSpell.ts
+++ b/apps/server/src/utils/runSpell.ts
@@ -4,7 +4,7 @@ import { buildMagickInterface } from '../buildMagickInterface'
 import { ServerError } from '@magickml/server-core'
 
 export type RunSpellArgs = {
-  spellName: string
+  id: string
   inputs?: Record<string, unknown>
   inputFormatter?: (graph: GraphData) => Record<string, unknown>
   projectId: string

--- a/apps/server/src/utils/runSpell.ts
+++ b/apps/server/src/utils/runSpell.ts
@@ -10,13 +10,13 @@ export type RunSpellArgs = {
   projectId: string
 }
 
-export const runSpell = async ({ spellName, inputs, inputFormatter, projectId }: RunSpellArgs) => {
-  let spell = (await app.service('spells').find({ query: { projectId, name: spellName } })).data[0] as any
+export const runSpell = async ({ id, inputs, inputFormatter, projectId }: RunSpellArgs) => {
+  let spell = (await app.service('spells').find({ query: { projectId, id: id } })).data[0] as any
 
   console.log('spell', spell)
   
   if (!spell?.graph) {
-    throw new ServerError('not-found', `Spell with name ${spellName} not found`)
+    throw new ServerError('not-found', `Spell with id ${id} not found`)
   }
 
   const graph = spell.graph as unknown as GraphData

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -54,7 +54,7 @@ function App() {
 
           <Route path="/" element={<Magick />} />
           <Route path="/magick/*" element={<Magick />} />
-          <Route path="/magick/:spellName" element={<Magick />} />
+          <Route path="/magick/:URI" element={<Magick />} />
           <Route
             path="/contract/:chain/:address/:function"
             element={<Contract />}

--- a/packages/editor/src/components/MenuBar/MenuBar.tsx
+++ b/packages/editor/src/components/MenuBar/MenuBar.tsx
@@ -53,9 +53,11 @@ const MenuBar = () => {
   const [menuVisibility, togglemenuVisibility] = useToggle()
 
   const onSave = () => {
+    console.log(activeTabRef.current?.id)
     console.log('SAVING')
-    if (!activeTabRef.current) return
-    publish($SAVE_SPELL(activeTabRef.current.id))
+   // if (!activeTabRef.current) return
+    console.log("GONNA")
+    publish($SAVE_SPELL(activeTabRef.current?.id))
   }
 
   const onSaveAs = () => {

--- a/packages/editor/src/components/MenuBar/MenuBar.tsx
+++ b/packages/editor/src/components/MenuBar/MenuBar.tsx
@@ -25,7 +25,7 @@ const MenuBar = () => {
   const activeTabRef = useRef<Tab | null>(null)
 
   useEffect(() => {
-    if (!activeTab || !activeTab.spellName) return
+    if (!activeTab || !activeTab.name) return
     activeTabRef.current = activeTab
     console.log('changing current to ', activeTabRef.current)
   }, [activeTab])

--- a/packages/editor/src/components/Modals/EditSpellModal.tsx
+++ b/packages/editor/src/components/Modals/EditSpellModal.tsx
@@ -9,6 +9,7 @@ import Modal from '../Modal/Modal'
 import css from './modalForms.module.css'
 import { useConfig } from '../../contexts/ConfigProvider'
 import { getSpellApi } from '../../state/api/spells'
+import { getStore } from '../../state/store'
 
 const EditSpellModal = ({ closeModal, spellName, name, tab }) => {
   const config = useConfig()
@@ -16,6 +17,7 @@ const EditSpellModal = ({ closeModal, spellName, name, tab }) => {
   
   const [error, setError] = useState('')
   const [patchSpell, { isLoading }] = spellApi.usePatchSpellMutation()
+
   const { enqueueSnackbar } = useSnackbar()
   const dispatch = useDispatch()
 
@@ -27,16 +29,16 @@ const EditSpellModal = ({ closeModal, spellName, name, tab }) => {
   console.log('tab ::: ', tab)
 
   const onSubmit = handleSubmit(async data => {
+    let name = data.name
+    data.name = tab.id + "-" + btoa(data.name)
     console.log('data ::: ', data)
-
-    const spell = await spellApi.getSpell({ spellName: atob(tab.name.split('--')[0].slice(37)), id: tab.id })
-
-    console.log('spell ::: ', spell)
+    console.log(spellApi)
+    //console.log('spell ::: ', spell)
 
     const response: any = await patchSpell({
-      id: spell.id,
+      id: tab.id,
       update: {
-        name: data.name,
+        name: name,
       },
     })
 

--- a/packages/editor/src/components/Modals/EditSpellModal.tsx
+++ b/packages/editor/src/components/Modals/EditSpellModal.tsx
@@ -29,7 +29,7 @@ const EditSpellModal = ({ closeModal, spellName, name, tab }) => {
   const onSubmit = handleSubmit(async data => {
     console.log('data ::: ', data)
 
-    const spell = await spellApi.getSpell({ spellName: tab.spellName })
+    const spell = await spellApi.getSpell({ spellName: atob(tab.name.split('--')[0].slice(37)), id: tab.id })
 
     console.log('spell ::: ', spell)
 

--- a/packages/editor/src/components/Modals/EditSpellModal.tsx
+++ b/packages/editor/src/components/Modals/EditSpellModal.tsx
@@ -30,7 +30,7 @@ const EditSpellModal = ({ closeModal, spellName, name, tab }) => {
 
   const onSubmit = handleSubmit(async data => {
     let name = data.name
-    data.name = tab.id + "-" + btoa(data.name)
+    data.name = tab.id + "-" + encodeURIComponent(btoa(data.name))
     console.log('data ::: ', data)
     console.log(spellApi)
     //console.log('spell ::: ', spell)

--- a/packages/editor/src/components/Modals/SaveAsModal.tsx
+++ b/packages/editor/src/components/Modals/SaveAsModal.tsx
@@ -19,7 +19,7 @@ const EditSpellModal = ({ tab, closeModal }) => {
   const [saveSpell, { isLoading }] = spellApi.useSaveSpellMutation()
   const { data: spell } = spellApi.useGetSpellQuery(
     {
-      spellName: tab.spellName,
+      spellName: atob(tab.name.split('--')[0].slice(37)),
       projectId: config.projectId,
     },
     {

--- a/packages/editor/src/components/Modals/SaveAsModal.tsx
+++ b/packages/editor/src/components/Modals/SaveAsModal.tsx
@@ -36,6 +36,7 @@ const EditSpellModal = ({ tab, closeModal }) => {
   } = useForm()
 
   const onSubmit = handleSubmit(async data => {
+    console.log("Inside Spell SUbmit")
     const saveResponse: any = await saveSpell({
       spell: {...spell, name: data.name},
       projectId: config.projectId

--- a/packages/editor/src/components/Modals/SaveAsModal.tsx
+++ b/packages/editor/src/components/Modals/SaveAsModal.tsx
@@ -19,11 +19,11 @@ const EditSpellModal = ({ tab, closeModal }) => {
   const [saveSpell, { isLoading }] = spellApi.useSaveSpellMutation()
   const { data: spell } = spellApi.useGetSpellQuery(
     {
-      spellName: atob(tab.name.split('--')[0].slice(37)),
+      spellName: tab.name,
       projectId: config.projectId,
     },
     {
-      skip: !tab.spellName,
+      skip: !tab.name,
     }
   )
   const { enqueueSnackbar } = useSnackbar()
@@ -38,10 +38,10 @@ const EditSpellModal = ({ tab, closeModal }) => {
   const onSubmit = handleSubmit(async data => {
     console.log("Inside Spell SUbmit")
     const saveResponse: any = await saveSpell({
-      spell: {...spell, name: data.name},
+      spell: {...spell.data[0], name: data.name},
       projectId: config.projectId
     })
-
+    console.log(saveResponse)
     if (saveResponse.error) {
       // show snackbar
       enqueueSnackbar('Error saving spell', {
@@ -55,7 +55,7 @@ const EditSpellModal = ({ tab, closeModal }) => {
 
     // close current tab and navigate to the new spell
     dispatch(closeTab(tab.id))
-    navigate(`/magick/${data.name}`)
+    navigate(`/magick/${tab.id}-${encodeURIComponent(atob(data.name))}`)
 
     closeModal()
   })
@@ -82,7 +82,7 @@ const EditSpellModal = ({ tab, closeModal }) => {
             <input
               type="text"
               className={css['input']}
-              defaultValue={tab.spellName}
+              defaultValue={tab.name}
               {...register('name')}
             />
           </div>

--- a/packages/editor/src/components/Modals/SaveAsModal.tsx
+++ b/packages/editor/src/components/Modals/SaveAsModal.tsx
@@ -7,9 +7,9 @@ import css from './modalForms.module.css'
 import { closeTab } from '../../state/tabs'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router'
-
+import defaultGraph from '../../data/graphs/default'
 import { useConfig } from '../../contexts/ConfigProvider'
-
+import md5 from 'md5'
 const EditSpellModal = ({ tab, closeModal }) => {
   const config = useConfig()
   const spellApi = getSpellApi(config)
@@ -17,9 +17,12 @@ const EditSpellModal = ({ tab, closeModal }) => {
   const dispatch = useDispatch()
   const [error, setError] = useState('')
   const [saveSpell, { isLoading }] = spellApi.useSaveSpellMutation()
-  const { data: spell } = spellApi.useGetSpellQuery(
+  const [newSpell] = spellApi.useNewSpellMutation()
+  console.log(tab)
+  const { data: spell } = spellApi.useGetSpellByIdQuery(
     {
       spellName: tab.name,
+      Id: tab.id,
       projectId: config.projectId,
     },
     {
@@ -37,8 +40,15 @@ const EditSpellModal = ({ tab, closeModal }) => {
 
   const onSubmit = handleSubmit(async data => {
     console.log("Inside Spell SUbmit")
+    console.log(spell)
+    const response = await newSpell({
+      graph: defaultGraph,
+      name: data.name,
+      projectId: config.projectId,
+      hash: md5(JSON.stringify(defaultGraph.nodes)),
+    })
     const saveResponse: any = await saveSpell({
-      spell: {...spell.data[0], name: data.name},
+      spell: {...spell.data[0], name: data.name, id: response.data.id},
       projectId: config.projectId
     })
     console.log(saveResponse)
@@ -54,8 +64,8 @@ const EditSpellModal = ({ tab, closeModal }) => {
     enqueueSnackbar('Spell saved', { variant: 'success' })
 
     // close current tab and navigate to the new spell
-    dispatch(closeTab(tab.id))
-    navigate(`/magick/${tab.id}-${encodeURIComponent(atob(data.name))}`)
+    //dispatch(closeTab(tab.id))
+    navigate(`/magick/${response.data.id +"-"+ encodeURIComponent(btoa(data.name))}`)
 
     closeModal()
   })

--- a/packages/editor/src/components/TabBar/TabBar.tsx
+++ b/packages/editor/src/components/TabBar/TabBar.tsx
@@ -15,9 +15,10 @@ const Tab = ({ tab, activeTab }) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const tabs = useSelector((state: RootState) => selectAllTabs(state.tabs))
+  console.log(tabs)
   const active = tab.id === activeTab?.id
 
-  const title = `${atob(tab.name.split('--')[0].slice(37))}`
+  const title = `${tab.name.split('--')[0]}`
   const tabClass = classnames({
     [css['tabbar-tab']]: true,
     [css['active']]: active,
@@ -41,7 +42,8 @@ const Tab = ({ tab, activeTab }) => {
           }
     )
     dispatch(changeActive(updatedTabs))
-    navigate(`/magick/${tab.name}`)
+    console.log(tab.URI)
+    navigate(`/magick/${tab.URI}`)
   }
 
   // Handle selecting the next tab down is none are active.

--- a/packages/editor/src/components/TabBar/TabBar.tsx
+++ b/packages/editor/src/components/TabBar/TabBar.tsx
@@ -17,7 +17,7 @@ const Tab = ({ tab, activeTab }) => {
   const tabs = useSelector((state: RootState) => selectAllTabs(state.tabs))
   const active = tab.id === activeTab?.id
 
-  const title = `${tab.name.split('--')[0]}`
+  const title = `${atob(tab.name.split('--')[0].slice(37))}`
   const tabClass = classnames({
     [css['tabbar-tab']]: true,
     [css['active']]: active,

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -146,7 +146,7 @@ export const initEditor = function ({
     server: false,
   }) as MagickEngineClient
   engine.magick = magick
-
+  
   if (client) {
     editor.use(ModulePlugin, { engine } as unknown as void)
     editor.use<Plugin, SocketPluginArgs>(SocketPlugin, { client })

--- a/packages/editor/src/plugins/reactRenderPlugin/index.tsx
+++ b/packages/editor/src/plugins/reactRenderPlugin/index.tsx
@@ -4,7 +4,7 @@ import { Node } from './Node'
 const SUPPRESSED_WARNINGS = ['ReactDOM.render'];
 const consoleError = console.error;
 console.error = function filterWarnings(msg, ...args) {
-  if (!SUPPRESSED_WARNINGS.some((entry) => msg.includes(entry))) {
+  if (!SUPPRESSED_WARNINGS.some((entry) => typeof msg === 'string' ?  msg.includes(entry) : false)) {
     consoleError(msg, ...args);
   }
 };

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -79,7 +79,7 @@ const StartScreen = () => {
 
   const openSpell = async spell => {
     // dispatch(openTab({ name: spell.name, spellName: spell.name, type: 'spell' }))
-    navigate(`/magick/${spell.name}`)
+    navigate(`/magick/${spell.id}-${encodeURIComponent(btoa(spell.name))}`)
   }
 
   const [selectedSpell, setSelectedSpell] = useState(null)

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -42,16 +42,16 @@ const StartScreen = () => {
     console.log('spellData', spellData)
 
     // Create new spell
-    await newSpell({
+    const response = await newSpell({
       graph: spellData.graph,
       name: spellData.name,
       projectId: config.projectId,
+      hash: spellData.hash
     })
 
     dispatch(
       openTab({
-        name: spellData.name,
-        spellName: spellData.name,
+        name: response.data.id +"-"+ encodeURIComponent(btoa(spellData.name)),
         type: 'spell',
       })
     )

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -68,7 +68,7 @@ const StartScreen = () => {
   const onDelete = async spellName => {
     try {
       await deleteSpell({ spellName, projectId: config.projectId })
-      const [tab] = tabs.filter(tab => tab.spellName === spellName)
+      const [tab] = tabs.filter(tab => tab.URI === spellName)
       if (tab) {
         dispatch(closeTab(tab.id))
       }

--- a/packages/editor/src/screens/HomeScreen/components/ProjectRow.tsx
+++ b/packages/editor/src/screens/HomeScreen/components/ProjectRow.tsx
@@ -29,6 +29,7 @@ const ProjectRow = ({
         css[selectedSpell?.name === label ? 'selected' : '']
       }`}
       onClick={e => {
+        console.log(selectedSpell)
         onClick(e)
       }}
       style={style}

--- a/packages/editor/src/screens/HomeScreen/screens/CreateNew.tsx
+++ b/packages/editor/src/screens/HomeScreen/screens/CreateNew.tsx
@@ -18,6 +18,7 @@ import defaultGraph from '../../../data/graphs/default'
 import threeovGraph from '../../../data/graphs/threeov'
 import md5 from 'md5'
 import { useConfig } from '../../../contexts/ConfigProvider'
+import { uuidv4 } from 'packages/editor/src/utils/uuid'
 
 const customConfig = {
   dictionaries: [adjectives, colors],
@@ -65,6 +66,8 @@ const CreateNew = () => {
         projectId: config.projectId,
         hash: md5(JSON.stringify(selectedTemplate?.graph.nodes)),
       })
+      console.log(name)
+      console.log(response)
 
       if ('error' in response) {
         console.log('error in response', response.error)
@@ -80,7 +83,7 @@ const CreateNew = () => {
         }
       }
 
-      navigate(`/magick/${name}`)
+      navigate(`/magick/${response.data.id}?${name}`)
     } catch (err) {
       console.log('ERROR!!', err)
     }

--- a/packages/editor/src/screens/HomeScreen/screens/CreateNew.tsx
+++ b/packages/editor/src/screens/HomeScreen/screens/CreateNew.tsx
@@ -83,7 +83,7 @@ const CreateNew = () => {
         }
       }
 
-      navigate(`/magick/${response.data.id}?${name}`)
+      navigate(`/magick/${response.data.id +"-"+ encodeURIComponent(btoa(name))}`)
     } catch (err) {
       console.log('ERROR!!', err)
     }

--- a/packages/editor/src/screens/Magick/Magick.tsx
+++ b/packages/editor/src/screens/Magick/Magick.tsx
@@ -24,8 +24,7 @@ const Magick = ({ empty = false }) => {
   const activeTab = useSelector(activeTabSelector)
 
   const pubSub = usePubSub()
-  const { spellName } = useParams()
-
+  const { URI } = useParams()
   const { events, publish, subscribe } = pubSub
 
   // Handle open tab events
@@ -42,32 +41,31 @@ const Magick = ({ empty = false }) => {
     // If there are still tabs, grab one at random to open to for now.
     // We should do better at this.  Probably with some kind of tab ordering.
     // Could fit in well with drag and drop for tabs
-    if (tabs.length > 0 && !activeTab && !spellName) {
-      navigate(`/magick/${tabs[0].name}`)
+    if (tabs.length > 0 && !activeTab && !URI) {
+      navigate(`/magick/${tabs[0].URI}`)
     }
 
-    if (tabs.length === 0 && !activeTab && !spellName) navigate('/home')
+    if (tabs.length === 0 && !activeTab && !URI) navigate('/home')
   }, [tabs])
 
   useEffect(() => {
-    if (!spellName) return
+    if (!URI) return
 
     // Return if navigating to the spell that is already active
-    if (activeTab && activeTab.spellName === spellName) return
+    if (activeTab && activeTab.URI === URI) return
     // Close spell tab if it is exists
-    let spellNameTab = tabs.filter(tab => tab.spellName === spellName)
+    let spellNameTab = tabs.filter(tab => tab.URI === URI)
     let isSpellNameTabPresent = spellNameTab.length
     if (isSpellNameTabPresent) dispatch(closeTab(spellNameTab[0].id))
 
     dispatch(
       openTab({
-        spellName: spellName,
-        name: spellName,
+        name: URI,
         openNew: false,
         type: 'spell',
       })
     )
-  }, [spellName])
+  }, [URI])
 
   useHotkeys(
     'Control+z',

--- a/packages/editor/src/screens/Magick/components/EventHandler.tsx
+++ b/packages/editor/src/screens/Magick/components/EventHandler.tsx
@@ -25,7 +25,7 @@ const EventHandler = ({ pubSub, tab }) => {
   const [saveSpellMutation] = spellApi.useSaveSpellMutation()
   const [saveDiff] = spellApi.useSaveDiffMutation()
   const { data: spell } = spellApi.useGetSpellByIdQuery({
-    spellName: atob(tab.name.split('--')[0].slice(37)),
+    spellName: tab.name.split('--')[0],
     Id: tab.id,
     projectId: config.projectId,
   })

--- a/packages/editor/src/screens/Magick/components/EventHandler.tsx
+++ b/packages/editor/src/screens/Magick/components/EventHandler.tsx
@@ -88,7 +88,7 @@ const EventHandler = ({ pubSub, tab }) => {
     if (jsonDiff.length !== 0) {
       console.log('Sending json diff to spell runner!')
       // save diff to spell runner if something has changed.  Will update spell in spell runner session
-      client.service('spell-runner').update(currentSpell.name, {
+      client.service('spell-runner').update(currentSpell.id, {
         diff: jsonDiff,
         projectId: config.projectId,
       })
@@ -122,7 +122,7 @@ const EventHandler = ({ pubSub, tab }) => {
     if (jsonDiff.length === 0) return
 
     try {
-      await client.service('spell-runner').update(currentSpell.name, {
+      await client.service('spell-runner').update(currentSpell.id, {
         diff: jsonDiff,
         projectId: config.projectId,
       })

--- a/packages/editor/src/screens/Magick/components/EventHandler.tsx
+++ b/packages/editor/src/screens/Magick/components/EventHandler.tsx
@@ -25,7 +25,7 @@ const EventHandler = ({ pubSub, tab }) => {
   const [saveSpellMutation] = spellApi.useSaveSpellMutation()
   const [saveDiff] = spellApi.useSaveDiffMutation()
   const { data: spell } = spellApi.useGetSpellByIdQuery({
-    spellName: tab.name,
+    spellName: atob(tab.name.split('--')[0].slice(37)),
     Id: tab.id,
     projectId: config.projectId,
   })

--- a/packages/editor/src/screens/Magick/components/EventHandler.tsx
+++ b/packages/editor/src/screens/Magick/components/EventHandler.tsx
@@ -24,8 +24,9 @@ const EventHandler = ({ pubSub, tab }) => {
 
   const [saveSpellMutation] = spellApi.useSaveSpellMutation()
   const [saveDiff] = spellApi.useSaveDiffMutation()
-  const { data: spell } = spellApi.useGetSpellQuery({
-    spellName: tab.spellName,
+  const { data: spell } = spellApi.useGetSpellByIdQuery({
+    spellName: tab.name,
+    Id: tab.id,
     projectId: config.projectId,
   })
   const preferences = useSelector(
@@ -66,7 +67,8 @@ const EventHandler = ({ pubSub, tab }) => {
   const saveSpell = async () => {
     const currentSpell = spellRef.current
     const graph = serialize() as GraphData
-
+    console.log("RECEIVED")
+    console.log(spellRef)
     if (!currentSpell) return
 
     const updatedSpell = {

--- a/packages/editor/src/state/api/spells.ts
+++ b/packages/editor/src/state/api/spells.ts
@@ -63,6 +63,15 @@ export const getSpellApi = (config) => {
           }
         },
       }),
+      getSpellByJustId: builder.query({
+        providesTags: ['Spell'],
+        query: ({projectId, Id }) => {
+          return {
+            url: `spells?projectId=${projectId}&id=${Id}`,
+            params: {},
+          }
+        },
+      }),
       runSpell: builder.mutation({
         query: ({ spellName, inputs, state = {}, projectId }) => ({
           url: `spells/${spellName}`,

--- a/packages/editor/src/state/api/spells.ts
+++ b/packages/editor/src/state/api/spells.ts
@@ -54,6 +54,15 @@ export const getSpellApi = (config) => {
           }
         },
       }),
+      getSpellById: builder.query({
+        providesTags: ['Spell'],
+        query: ({ spellName, projectId, Id }) => {
+          return {
+            url: `spells?name=${spellName}&projectId=${projectId}&id=${Id}`,
+            params: {},
+          }
+        },
+      }),
       runSpell: builder.mutation({
         query: ({ spellName, inputs, state = {}, projectId }) => ({
           url: `spells/${spellName}`,
@@ -87,6 +96,7 @@ export const getSpellApi = (config) => {
         // needed to use queryFn as query option didnt seem to allow async functions.
         async queryFn({ spell, projectId, }, { dispatch }, extraOptions, baseQuery) {
           // make a copy of spell but remove the id
+          console.log(spell)
           const spellCopy = { ...spell } as any
           if (spellCopy.id) delete spellCopy.id
           if (Object.keys(spellCopy).includes('modules')) delete spellCopy.modules

--- a/packages/editor/src/state/localState.ts
+++ b/packages/editor/src/state/localState.ts
@@ -6,13 +6,13 @@ import {
 } from '@reduxjs/toolkit'
 
 export interface LocalState {
-  spellName: string
+  id: string
   playtestData: string
 }
 
 // Entity adapter
 const localAdapater = createEntityAdapter<LocalState>({
-  selectId: localState => localState.spellName,
+  selectId: localState => localState.id,
 })
 const localSelectors = localAdapater.getSelectors()
 
@@ -35,10 +35,15 @@ export const { addLocalState, deleteLocalState, upsertLocalState } =
   localStateSlice.actions
 
 // selectors
-export const selectStateBySpellId = createDraftSafeSelector(
+/* export const selectStateBySpellId = createDraftSafeSelector(
   [state => localSelectors.selectAll(state), (_, spellName) => spellName],
   (states, spellName) =>
     Object.values(states).find(state => state.spellName === spellName)
-)
+) */
 
+export const selectStateBytabId = createDraftSafeSelector(
+  [state => localSelectors.selectAll(state), (_, id) => id],
+  (states, id) => 
+    Object.values(states).find(state => state.id === id)
+)
 export default localStateSlice.reducer

--- a/packages/editor/src/state/tabs.ts
+++ b/packages/editor/src/state/tabs.ts
@@ -15,12 +15,13 @@ const workspaceMap = {
 export interface Tab {
   id: string
   name: string
+  URI: string
   active: boolean
   layoutJson: Record<string, unknown>
   type?: 'spell' | 'module'
   // probably going to need to insert a proper spell type in here
   spell?: string
-  spellName: string
+  spellName:string
   // this will also be a ref to a property somewhere else
   module: string
 }
@@ -40,14 +41,18 @@ const _activeTabSelector = createDraftSafeSelector(
   }
 )
 
-const selectTabBySpellId = createDraftSafeSelector(
+/* const selectTabBySpellId = createDraftSafeSelector(
   [state => tabSelectors.selectAll(state), (_, spellName) => spellName],
   (tabs, spellName) => Object.values(tabs).find(tab => tab.spellName === spellName)
+) */
+const selectTabBySpellUUID = createDraftSafeSelector(
+  [state => tabSelectors.selectAll(state), (_, id) => id],
+  (tabs, id) => Object.values(tabs).find(tab => tab.id === id)
 )
 
 const encodedToName = (uri: string) => {
   uri = decodeURIComponent(uri)
-  return uri.slice(36)
+  return atob(uri.slice(37))
 } 
 
 const encodedToId = (uri: string) => {
@@ -59,7 +64,8 @@ const encodedToId = (uri: string) => {
 const buildTab = (tab, properties = {}) => ({
   ...tab,
   id: encodedToId(tab.name),
-  name: decodeURIComponent(tab.name),
+  URI: encodeURIComponent(tab.name),
+  name: encodedToName(tab.name),
   layoutJson: workspaceMap[tab.workspace || 'default'],
   spell: tab?.spell || null,
   type: tab?.type || 'module',
@@ -84,8 +90,9 @@ export const tabSlice = createSlice({
         })
 
       // Check if the tab is already open.
-      const existingTab = selectTabBySpellId(state, action.payload.spellName)
+      //const existingTab = selectTabBySpellId(state, action.payload.spellName)
 
+      const existingTab = selectTabBySpellUUID(state, encodedToId(action.payload.name) )
       if (existingTab && !switchActive) return
 
       if (existingTab && !action.payload.openNew) {

--- a/packages/editor/src/state/tabs.ts
+++ b/packages/editor/src/state/tabs.ts
@@ -8,8 +8,6 @@ import {
 
 import { RootState } from './store'
 import defaultJson from '../data/layouts/defaultLayout.json'
-import { getSpellApi } from './api/spells'
-import { useConfig } from '../contexts/ConfigProvider'
 // Used to set workspaces to tabs
 const workspaceMap = {
   default: defaultJson,
@@ -47,12 +45,21 @@ const selectTabBySpellId = createDraftSafeSelector(
   (tabs, spellName) => Object.values(tabs).find(tab => tab.spellName === spellName)
 )
 
+const encodedToName = (uri: string) => {
+  uri = decodeURIComponent(uri)
+  return uri.slice(36)
+} 
+
+const encodedToId = (uri: string) => {
+  uri = decodeURIComponent(uri)
+  return uri.slice(0,36)
+}
 
 // Used to build a tab with various defaults set, as well as workspace json and UUID
 const buildTab = (tab, properties = {}) => ({
   ...tab,
-  name: "sdbot",
-  id: tab.name,
+  id: encodedToId(tab.name),
+  name: decodeURIComponent(tab.name),
   layoutJson: workspaceMap[tab.workspace || 'default'],
   spell: tab?.spell || null,
   type: tab?.type || 'module',

--- a/packages/editor/src/state/tabs.ts
+++ b/packages/editor/src/state/tabs.ts
@@ -8,7 +8,8 @@ import {
 
 import { RootState } from './store'
 import defaultJson from '../data/layouts/defaultLayout.json'
-
+import { getSpellApi } from './api/spells'
+import { useConfig } from '../contexts/ConfigProvider'
 // Used to set workspaces to tabs
 const workspaceMap = {
   default: defaultJson,
@@ -46,11 +47,12 @@ const selectTabBySpellId = createDraftSafeSelector(
   (tabs, spellName) => Object.values(tabs).find(tab => tab.spellName === spellName)
 )
 
+
 // Used to build a tab with various defaults set, as well as workspace json and UUID
 const buildTab = (tab, properties = {}) => ({
   ...tab,
-  name: tab.name || 'Untitled',
-  id: uuidv4(),
+  name: "sdbot",
+  id: tab.name,
   layoutJson: workspaceMap[tab.workspace || 'default'],
   spell: tab?.spell || null,
   type: tab?.type || 'module',

--- a/packages/editor/src/workspaces/contexts/EditorProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/EditorProvider.tsx
@@ -87,7 +87,7 @@ const EditorProvider = ({ children }) => {
 
     // set editor to the map
     setEditor(newEditor)
-
+    console.log(_spell)
     // copy spell in case it is read onl
     const spell = JSON.parse(JSON.stringify(_spell))
 
@@ -172,19 +172,20 @@ const RawEditor = ({ tab, children }) => {
   const config = useConfig()
   const spellApi = getSpellApi(config)
 
-  const [getSpell, { data: spell, isLoading }] = spellApi.useLazyGetSpellQuery()
+  const [getSpell, { data: spell, isLoading }] = spellApi.useLazyGetSpellByIdQuery()
   const [loaded, setLoaded] = useState(false)
   const { buildEditor } = useEditor()
   // This will be the main interface between magick and rete
   const reteInterface = useMagickInterface()
-
+  console.log(tab)
   useEffect(() => {
     if (!tab || loaded) return
 
     if (tab?.spellName)
       getSpell({
-        spellName: tab.spellName,
-        projectId: config.projectId
+        spellName: tab.name,
+        Id: tab.id,
+        projectId: config.projectId,
       })
   }, [tab])
 

--- a/packages/editor/src/workspaces/contexts/EditorProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/EditorProvider.tsx
@@ -74,6 +74,7 @@ const EditorProvider = ({ children }) => {
 
   const buildEditor = async (container, _spell, tab, magick) => {
     // eslint-disable-next-line no-console
+    console.log("tab:: ", tab)
     const newEditor = await initEditor({
       container,
       pubSub,
@@ -182,7 +183,6 @@ const RawEditor = ({ tab, children }) => {
     console.log(loaded)
     console.log(tab)
     if (!tab || loaded) return
-
     getSpell({
       spellName: tab.name,
       Id: tab.id,

--- a/packages/editor/src/workspaces/contexts/EditorProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/EditorProvider.tsx
@@ -179,14 +179,16 @@ const RawEditor = ({ tab, children }) => {
   const reteInterface = useMagickInterface()
   console.log(tab)
   useEffect(() => {
+    console.log(loaded)
+    console.log(tab)
     if (!tab || loaded) return
 
-    if (tab?.spellName)
-      getSpell({
-        spellName: atob(tab.name.split('--')[0].slice(37)),
-        Id: tab.id,
-        projectId: config.projectId,
-      })
+    getSpell({
+      spellName: tab.name,
+      Id: tab.id,
+      projectId: config.projectId,
+    })
+    console.log(spell)
   }, [tab])
 
   if (!tab || (tab.type === 'spell' && (isLoading || !spell)))

--- a/packages/editor/src/workspaces/contexts/EditorProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/EditorProvider.tsx
@@ -183,7 +183,7 @@ const RawEditor = ({ tab, children }) => {
 
     if (tab?.spellName)
       getSpell({
-        spellName: tab.name,
+        spellName: atob(tab.name.split('--')[0].slice(37)),
         Id: tab.id,
         projectId: config.projectId,
       })

--- a/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
@@ -41,7 +41,7 @@ const MagickInterfaceProvider = ({ children, tab }) => {
     APP_SEARCH_SERVER_URL: import.meta.env.APP_SEARCH_SERVER_URL,
   }
   console.log("Inside Magick Interface")
-  
+  console.log(tab)
   useEffect(() => {
     if (!_spell) return
     spellRef.current = _spell.data[0]

--- a/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
@@ -27,12 +27,12 @@ const MagickInterfaceProvider = ({ children, tab }) => {
   const [_getSpell] = spellApi.useLazyGetSpellByIdQuery()
   const { data: _spell } = spellApi.useGetSpellByIdQuery(
     {
-      spellName: atob(tab.name.split('--')[0].slice(37)),
+      spellName: tab.name.split('--')[0],
       Id: tab.id,
       projectId: config.projectId,
     },
     {
-      skip: !tab.spellName,
+      skip: !tab.name.split('--')[0],
     }
   )
 
@@ -40,10 +40,12 @@ const MagickInterfaceProvider = ({ children, tab }) => {
     API_ROOT_URL: import.meta.env.API_ROOT_URL,
     APP_SEARCH_SERVER_URL: import.meta.env.APP_SEARCH_SERVER_URL,
   }
-
+  console.log("Inside Magick Interface")
+  
   useEffect(() => {
     if (!_spell) return
     spellRef.current = _spell.data[0]
+    console.log(spellRef.current)
   }, [_spell])
 
   const {
@@ -65,9 +67,10 @@ const MagickInterfaceProvider = ({ children, tab }) => {
   } = events
 
   const getCurrentSpell = () => {
+    console.log(spellRef.current)
     return spellRef.current
   }
-
+  console.log(getCurrentSpell())
   const onTrigger = (node, callback) => {
     let isDefault = node === 'default' ? 'default' : null
     return subscribe($TRIGGER(tab.id, isDefault ?? node.id), (event, data) => {

--- a/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
+++ b/packages/editor/src/workspaces/contexts/MagickInterfaceProvider.tsx
@@ -24,10 +24,11 @@ const MagickInterfaceProvider = ({ children, tab }) => {
   const { events, publish, subscribe } = usePubSub()
   const spellRef = useRef<Spell | null>(null)
   const [_runSpell] = spellApi.useRunSpellMutation()
-  const [_getSpell] = spellApi.useLazyGetSpellQuery()
-  const { data: _spell } = spellApi.useGetSpellQuery(
+  const [_getSpell] = spellApi.useLazyGetSpellByIdQuery()
+  const { data: _spell } = spellApi.useGetSpellByIdQuery(
     {
-      spellName: tab.spellName,
+      spellName: atob(tab.name.split('--')[0].slice(37)),
+      Id: tab.id,
       projectId: config.projectId,
     },
     {
@@ -143,7 +144,7 @@ const MagickInterfaceProvider = ({ children, tab }) => {
   }
 
   const getSpell = async spellName => {
-    const spell = await _getSpell({ spellName, projectId: config.projectId })
+    const spell = await _getSpell({ spellName, Id: tab.id, projectId: config.projectId })
 
     if (!spell.data) return null
 

--- a/packages/editor/src/workspaces/spells/index.tsx
+++ b/packages/editor/src/workspaces/spells/index.tsx
@@ -77,7 +77,7 @@ const Workspace = ({ tab, tabs, pubSub }) => {
     if (!tab || !tab.spellName) return
     console.log("Inside Load Spell !!")
     loadSpell({
-      spellName: "sdbot",
+      spellName: atob(tab.name.split('--')[0].slice(37)),
       projectId: config.projectId,
       Id: tab.id,
     })

--- a/packages/editor/src/workspaces/spells/index.tsx
+++ b/packages/editor/src/workspaces/spells/index.tsx
@@ -64,7 +64,7 @@ const Workspace = ({ tab, tabs, pubSub }) => {
         ...spellRef.current,
         graph: editor.toJSON(),
       }
-      publish(events.$SUBSPELL_UPDATED(spellRef.current.name), spell)
+      publish(events.$SUBSPELL_UPDATED(spellRef.current.id), spell)
     }) as unknown as Function
   }, [editor])
 
@@ -96,6 +96,7 @@ const Workspace = ({ tab, tabs, pubSub }) => {
           },
         }
       )
+      console.log("Spell Runner for: ", tab.id)
     })()
   }, [client])
 

--- a/packages/editor/src/workspaces/spells/index.tsx
+++ b/packages/editor/src/workspaces/spells/index.tsx
@@ -28,7 +28,7 @@ const Workspace = ({ tab, tabs, pubSub }) => {
 
   const spellRef = useRef<Spell>()
   const { events, publish } = usePubSub()
-  const [loadSpell, { data: spellData }] = spellApi.useLazyGetSpellQuery()
+  const [loadSpell, { data: spellData }] = spellApi.useLazyGetSpellByIdQuery()
   const { editor, serialize } = useEditor()
   const FeathersContext = useFeathers()
   const client = FeathersContext?.client
@@ -75,9 +75,11 @@ const Workspace = ({ tab, tabs, pubSub }) => {
 
   useEffect(() => {
     if (!tab || !tab.spellName) return
+    console.log("Inside Load Spell !!")
     loadSpell({
-      spellName: tab.spellName,
+      spellName: "sdbot",
       projectId: config.projectId,
+      Id: tab.id,
     })
   }, [tab])
 

--- a/packages/editor/src/workspaces/spells/index.tsx
+++ b/packages/editor/src/workspaces/spells/index.tsx
@@ -74,10 +74,10 @@ const Workspace = ({ tab, tabs, pubSub }) => {
   }, [spellData])
 
   useEffect(() => {
-    if (!tab || !tab.spellName) return
+    if (!tab || !tab.name) return
     console.log("Inside Load Spell !!")
     loadSpell({
-      spellName: atob(tab.name.split('--')[0].slice(37)),
+      spellName: tab.name.split('--')[0],
       projectId: config.projectId,
       Id: tab.id,
     })
@@ -86,10 +86,10 @@ const Workspace = ({ tab, tabs, pubSub }) => {
   useEffect(() => {
     if (!client) return
     ;(async () => {
-      if (!client || !tab || !tab.spellName) return
+      if (!client || !tab || !tab.name) return
       console.log('projectId from client ', config.projectId)
       // make sure to pass the projectId to the service call
-      await client.service('spell-runner').get(tab.spellName,
+      await client.service('spell-runner').get(tab.id,
         {
           query: {
             projectId: config.projectId,

--- a/packages/editor/src/workspaces/spells/windows/AvatarWindow/index.tsx
+++ b/packages/editor/src/workspaces/spells/windows/AvatarWindow/index.tsx
@@ -13,7 +13,7 @@ import { usePubSub } from '../../../../contexts/PubSubProvider'
 import Avatar from './Avatar'
 import { useAppSelector } from '../../../../state/hooks'
 import {
-  selectStateBySpellId,
+  selectStateBytabId,
   upsertLocalState,
 } from '../../../../state/localState'
 
@@ -26,7 +26,7 @@ const AvatarWindow = ({ tab }) => {
   const dispatch = useDispatch()
 
   const localState = useAppSelector(state =>
-    selectStateBySpellId(state.localState, tab.spellName)
+    selectStateBytabId(state.localState, tab.id)
   )
 
   const { publish, subscribe, events } = usePubSub()

--- a/packages/editor/src/workspaces/spells/windows/AvatarWindow/index.tsx
+++ b/packages/editor/src/workspaces/spells/windows/AvatarWindow/index.tsx
@@ -98,7 +98,7 @@ const AvatarWindow = ({ tab }) => {
 
   const onDataChange = dataText => {
     console.log('new data text', dataText)
-    dispatch(upsertLocalState({ spellName: tab.spellName, playtestData: dataText }))
+    dispatch(upsertLocalState({ id: tab.id, playtestData: dataText }))
   }
 
   const toggleData = () => {

--- a/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
+++ b/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
@@ -76,13 +76,13 @@ const Playtest = ({ tab }) => {
 
   const { data: spellData } = spellApi.useGetSpellByIdQuery(
     { 
-      spellName: atob(tab.name.split('--')[0].slice(37)), 
+      spellName: tab.name.split('--')[0], 
       Id: tab.id, 
       projectId: config.projectId 
     },
     {
       refetchOnMountOrArgChange: true,
-      skip: !tab.spellName,
+      skip: !tab.name.split('--')[0],
     }
   )
   console.log(spellData)
@@ -220,9 +220,16 @@ const Playtest = ({ tab }) => {
     )?.data.name
     console.log("Spell Runner Created")
     if (!playtestInputName) return
-
+    console.log({
+      spellName: tab.name.split('--')[0],
+      id: tab.id,
+      projectId: config.projectId,
+      inputs: {
+        [playtestInputName as string]: toSend,
+      },
+    })
     client.service('spell-runner').create({
-      spellName: atob(tab.name.split('--')[0].slice(37)),
+      spellName: tab.name.split('--')[0],
       id: tab.id,
       projectId: config.projectId,
       inputs: {

--- a/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
+++ b/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
@@ -325,7 +325,6 @@ const Playtest = ({ tab }) => {
         <label htmlFor="playtest-input" style={{ display: 'none' }}>
           Input
         </label>
-        {value}
         <Input onChange={onChange} value={value} onSend={onSend} />
       </div>
     </Window>

--- a/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
+++ b/packages/editor/src/workspaces/spells/windows/PlaytestWindow.tsx
@@ -92,8 +92,6 @@ const Playtest = ({ tab }) => {
   const localState = useAppSelector(state => {
     return selectStateBytabId(state.localState, tab.id)
   })
-  console.log(getStore(config).getState())
-  console.log(localState)
   const client = FeathersContext?.client
   const { $PLAYTEST_INPUT, $PLAYTEST_PRINT } = events
 

--- a/packages/engine/src/lib/engine.ts
+++ b/packages/engine/src/lib/engine.ts
@@ -78,7 +78,9 @@ export const initSharedEngine = ({
   components.forEach(c => {
     engine.register(c)
   })
-
+  console.log("Engine Returned")
+  console.log(engine)
+  console.log("Engine Complete")
   return engine
 }
 

--- a/packages/engine/src/lib/plugins/socketPlugin/index.ts
+++ b/packages/engine/src/lib/plugins/socketPlugin/index.ts
@@ -66,6 +66,13 @@ function install(
               stack: err.stack,
             },
           })
+          socket?.emit(`${currentSpell.id}-error`, {
+            error: {
+              message: err.message,
+              stack: err.stack,
+            },
+          })
+          
           // note: we may still want to throw the error here
           throw err
         }

--- a/packages/engine/src/lib/plugins/socketPlugin/index.ts
+++ b/packages/engine/src/lib/plugins/socketPlugin/index.ts
@@ -39,7 +39,7 @@ function install(
       ...args
     ) => {
       const currentSpell = context.magick.getCurrentSpell()
-      const event = `${currentSpell.name}-${node.id}`
+      const event = `${currentSpell.id}-${node.id}`
 
       if (server) {
         try {

--- a/packages/engine/src/lib/spellManager/SpellManager.ts
+++ b/packages/engine/src/lib/spellManager/SpellManager.ts
@@ -62,6 +62,7 @@ export default class SpellManager {
   }
 
   getSpellRunner(spellName: string) {
+    console.log(this.spellRunnerMap)
     return this.spellRunnerMap.get(spellName)
   }
 
@@ -75,8 +76,8 @@ export default class SpellManager {
 
   async load(spell: Spell, overload = false) {
     if (!spell) throw new Error('No spell provided to load')
-    if (this.spellRunnerMap.has(spell.name) && !overload)
-      return this.getSpellRunner(spell.name)
+    if (this.spellRunnerMap.has(spell.id) && !overload)
+      return this.getSpellRunner(spell.id)
 
     const spellRunner = new SpellRunner({
       magickInterface: this.magickInterface,
@@ -85,7 +86,7 @@ export default class SpellManager {
 
     await spellRunner.loadSpell(spell)
 
-    this.spellRunnerMap.set(spell.name, spellRunner)
+    this.spellRunnerMap.set(spell.id, spellRunner)
 
     return spellRunner
   }

--- a/packages/engine/src/lib/spellManager/runSpell.ts
+++ b/packages/engine/src/lib/spellManager/runSpell.ts
@@ -20,7 +20,7 @@ class RunSpell {
       components: getNodes(),
       server: true,
     }) as MagickEngine
-
+    console.log("Engine Created from spell runner")
     // Set up the module to interface with the runtime processes
     this.module = new Module()
 

--- a/packages/engine/src/lib/types.ts
+++ b/packages/engine/src/lib/types.ts
@@ -282,7 +282,7 @@ export type Spell = {
   graph: Data
   created_at?: string
   updated_at?: string
-  id: number
+  id: string
   hash?: string
   projectId: string
 }


### PR DESCRIPTION
- Updated the schema to use UUID as the primary key,
- Created URI using UUID and Name, after creating new.
- The `tab.id` is now same as UUID of the active spell
- `tab.name` will have the URI
- LocalState is filtered based on the UUID now.

Fixes #186 

- Rename is also fixed (Possibly Fixes #223 )