### PR TITLE
make selectionPlugin compatible with multiCopyPlugin

### DIFF
--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -180,7 +180,7 @@ export const initEditor = function ({
     editor.use(TaskPlugin)
   }
 
-  // editor.use(SelectionPlugin, { enabled: true })
+  editor.use(SelectionPlugin, { enabled: true })
 
   // WARNING all the plugins from the editor get installed onto the component and modify it.  This effects the components registered in the engine, which already have plugins installed.
   components.forEach((c: any) => {
@@ -197,10 +197,6 @@ export const initEditor = function ({
     'multiselectnode',
     args => (args.accumulate = args.e.ctrlKey || args.e.metaKey)
   )
-
-  editor.on(['click'], () => {
-    editor.selected.list = []
-  })
 
   editor.bind('run')
   editor.bind('save')

--- a/packages/engine/src/lib/plugins/multiCopyPlugin/index.ts
+++ b/packages/engine/src/lib/plugins/multiCopyPlugin/index.ts
@@ -9,8 +9,6 @@ function install(editor: IRunContextEditor) {
   // Define variables and constants
   const storedNodesKey = 'selectedNodes'
   const connectedPairKey = 'connectedNodePairs'
-  let accumulate = false;
-  let copiedNodes: MagickNode[] = [];
   let mouse = { x: 0, y: 0 }
 
   // Store the current mouse position on click event
@@ -18,16 +16,11 @@ function install(editor: IRunContextEditor) {
     mouse = { x: editor.view.area.mouse.x, y: editor.view.area.mouse.y }
   })
 
-  // Handle multiple node selection with Ctrl/Cmd key
-  editor.on('multiselectnode', (args) => {
-    accumulate = args.e.ctrlKey || args.e.metaKey
-  })
-
   // Copy the selected nodes and their connections
   editor.on('multiselectcopy', () => {
-    if (!accumulate) return
+    if (!editor.selected.list.length) return
 
-    copiedNodes = []
+    const copiedNodes: MagickNode[] = []
     editor.selected.each((node) => {
       copiedNodes.push(node as MagickNode)
     })

--- a/packages/engine/src/lib/plugins/selectionPlugin/index.ts
+++ b/packages/engine/src/lib/plugins/selectionPlugin/index.ts
@@ -203,8 +203,12 @@ function install(editor: NodeEditor, params: Cfg) {
       return
     }
 
+    editor.selected.list = []
+
     selectedNodes.forEach(node => {
-      editor.selectNode(node, accumulate)
+      const payload = { node, accumulate };
+
+      editor.trigger('selectnode', payload);
     })
   }
 
@@ -216,9 +220,6 @@ function install(editor: NodeEditor, params: Cfg) {
       return
     }
     if (!pressing) {
-      return
-    }
-    if (editor.selected.list.length > 0) {
       return
     }
 


### PR DESCRIPTION
I add some changes to:
- SelectionPlugin (the dragging blue box)
- MultiCopyPlugin (now you can select any nodes without accumulation check)