### PR TITLE
fix: snap enabled by default

### DIFF
--- a/packages/editor/src/plugins/areaPlugin/index.js
+++ b/packages/editor/src/plugins/areaPlugin/index.js
@@ -8,14 +8,14 @@ import { zoomAt } from './zoom-at'
 function install(editor, params) {
   console.log('installing', params)
   const background = params.background || false
-  const snap = params.snap || false
+  const snap = params.snap || true
   const scaleExtent = params.scaleExtent || false
   const translateExtent = params.translateExtent || false
 
   if (background) {
     this._background = new Background(editor, background)
   }
-  
+
   if (scaleExtent || translateExtent) {
     this._restrictor = new Restrictor(editor, scaleExtent, translateExtent)
   }


### PR DESCRIPTION
Per #334 This is a small PR that enables `snap` by default. Quick and easy win!