### PR TITLE
fix: invalid json parse on rootSpell

### DIFF
--- a/packages/editor/src/workspaces/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/workspaces/agents/AgentWindow/AgentDetails.tsx
@@ -25,6 +25,8 @@ const AgentDetails = ({
   const [editMode, setEditMode] = useState<boolean>(false)
   const [oldName, setOldName] = useState<string>('')
 
+  console.log('selectedAgentData', selectedAgentData)
+
   const update = (id, data = undefined) => {
     const _data = data || { ...selectedAgentData }
     id = id || _data.id
@@ -205,7 +207,7 @@ const AgentDetails = ({
           }}
           name="rootSpell"
           id="rootSpell"
-          value={JSON.parse(selectedAgentData.rootSpell).name || 'default'}
+          value={selectedAgentData.rootSpell?.name || 'default'}
           onChange={event => {
             const newRootSpell = spellList.find(
               spell => spell.name === event.target.value


### PR DESCRIPTION
Small bug fix that removes a `JSON.parse` operator on an existing Object. The `selectedAgentData` being passed to `AgentDetails` contains a `rootSpell` property that is already an object, not a string like the `blicVariables` or `secrets` properties. This was causing an `Uncaught SyntaxError: "[object Object]" is not valid JSON` error and preventing the `AgentDetails` component from loading.