### PR TITLE
fix: update procfile to include agent worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: npm run start
+worker: npm run start-agent


### PR DESCRIPTION
This small PR allows the Agent server to be created as a background worker. The update to the Procfile doesn't immediately start the worker, but should unlock some new UI in Heroku.