### PR TITLE
fix: agent worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start-docs": "npx nx serve @magickml/docs",
     "migrate:make": "nx run @magickml/server:migrate:make",
     "migrate": "nx run @magickml/server:migrate",
-    "build": "node scripts/build-server.js",
+    "build": "npx nx run-many --target=build --projects=@magickml/server,@magickml/agent",
     "build-client": "npx nx build @magickml/client",
     "heroku-prebuild": "npm i -g @nrwl/cli",
     "build-templates": "npx nx build @magickml/templates",


### PR DESCRIPTION
Heroku isn't building both the Agent and the Server because of the logic in the `build-server.js` script. This PR is a test to see if bypassing this script will achieve our desired results.