### PR TITLE
feat: convert root spell to JSON

### DIFF
--- a/packages/editor/src/windows/agents/AgentManagerWindow.tsx
+++ b/packages/editor/src/windows/agents/AgentManagerWindow.tsx
@@ -27,12 +27,11 @@ const AgentManagerWindow = () => {
     const json = await res.json()
     setData(json.data)
     setIsLoading(false)
-    console.log('res is', json)
-    if(!json.data || !json.data[0]) return;
-    const spellAgent = JSON.parse(json.data[0].rootSpell)
+    if (!json.data || !json.data[0]) return
+    const spellAgent = json.data[0]?.rootSpell ?? {}
     const inputs = pluginManager.getInputByName()
     const plugin_list = pluginManager.getPlugins()
-    for (const key of Object.keys(plugin_list)){
+    for (const key of Object.keys(plugin_list)) {
       plugin_list[key] = validateSpellData(spellAgent, inputs[key])
     }
     setEnable(plugin_list)
@@ -84,7 +83,7 @@ const AgentManagerWindow = () => {
       data.projectId = config.projectId
       data.enabled = data?.enabled ? true : false
       data.updatedAt = new Date().toISOString()
-      data.rootSpell = data?.rootSpell || '{}'
+      data.rootSpell = data?.rootSpell || {}
       data.spells = Array.isArray(data?.spells) ? data.spells : []
       data.secrets = JSON.stringify(
         Array.isArray(data?.secrets) ? data.secrets : []
@@ -177,15 +176,15 @@ const AgentManagerWindow = () => {
   }, [config.apiUrl])
 
   useEffect(() => {
-    (async () => {
+    ;(async () => {
       const res = await fetch(`${config.apiUrl}/agents`)
       const json = await res.json()
       console.log('res data', json.data)
-      if(!json.data || !json.data[0]) return;
-      const spellAgent = JSON.parse(json.data[0].rootSpell)
+      if (!json.data || !json.data[0]) return
+      const spellAgent = json.data[0]?.rootSpell ?? {}
       const inputs = pluginManager.getInputByName()
       const plugin_list = pluginManager.getPlugins()
-      for (const key of Object.keys(plugin_list)){
+      for (const key of Object.keys(plugin_list)) {
         plugin_list[key] = validateSpellData(spellAgent, inputs[key])
       }
       console.log(plugin_list)

--- a/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
@@ -26,6 +26,7 @@ const AgentDetails = ({
   const [oldName, setOldName] = useState<string>('')
   const [enable, setEnable] = useState(onLoadEnables)
   console.log('selectedAgentData', selectedAgentData)
+
   const update = (id, data = undefined) => {
     const _data = data || { ...selectedAgentData }
     id = id || _data.id
@@ -99,6 +100,7 @@ const AgentDetails = ({
   }
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
     ;(async () => {
       const res = await fetch(
         `${config.apiUrl}/spells?projectId=${config.projectId}`
@@ -208,18 +210,17 @@ const AgentDetails = ({
           }}
           name="rootSpell"
           id="rootSpell"
-          value={JSON.parse(selectedAgentData.rootSpell)?.name || 'default'}
+          value={selectedAgentData.rootSpell?.name || 'default'}
           onChange={event => {
             const newRootSpell = spellList.find(
               spell => spell.name === event.target.value
             )
             const inputs = pluginManager.getInputByName()
             const plugin_list = pluginManager.getPlugins()
-            for (const key of Object.keys(plugin_list)){
-              if(!newRootSpell) continue
+            for (const key of Object.keys(plugin_list)) {
+              if (!newRootSpell) continue
               plugin_list[key] = validateSpellData(newRootSpell, inputs[key])
             }
-            console.log(plugin_list)
             setEnable(plugin_list)
             enqueueSnackbar(
               'Greyed out components are not available because of the selected spell.',
@@ -244,7 +245,7 @@ const AgentDetails = ({
             //setEnable("DiscordPlugin")
             setSelectedAgentData({
               ...selectedAgentData,
-              rootSpell: JSON.stringify(newRootSpell),
+              rootSpell: newRootSpell,
               publicVariables: JSON.stringify(
                 Object.values(newRootSpell.graph.nodes as any)
                   // get the public nodes
@@ -267,7 +268,7 @@ const AgentDetails = ({
             })
           }}
         >
-          <option disabled value={'default'} key={0}>
+          <option disabled value={'default'}>
             Select Spell
           </option>
           {spellList?.length > 0 &&
@@ -312,7 +313,6 @@ const AgentDetails = ({
       {selectedAgentData.publicVariables !== '{}' && (
         <AgentPubVariables
           setPublicVars={data => {
-            console.log('new daa', data)
             setSelectedAgentData({
               ...selectedAgentData,
               publicVariables: JSON.stringify(data),

--- a/packages/editor/src/windows/agents/AgentWindow/index.tsx
+++ b/packages/editor/src/windows/agents/AgentWindow/index.tsx
@@ -9,8 +9,8 @@ import { useConfig } from '../../../contexts/ConfigProvider'
 interface Props {
   data: Array<object>
   selectedAgentData: object
-  rootSpell: string
-  onLoadEnables: Object
+  rootSpell: object
+  onLoadEnables: object
   setRootSpell: (spell: string) => void
   setSelectedAgentData: (data: object) => void
   onCreateAgent: (data: any) => void
@@ -61,7 +61,7 @@ const AgentWindow = ({
               projectId: config.projectId,
               enabled: false,
               spells: '[]',
-              rootSpell: '{}',
+              rootSpell: {},
               publicVariables: '{}',
               secrets: '{}',
             })

--- a/packages/plugin-rest/server/src/services/api/api.class.ts
+++ b/packages/plugin-rest/server/src/services/api/api.class.ts
@@ -54,7 +54,7 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
     }
 
     // get the selectedAgentData's spells
-    const rootSpell = JSON.parse(agent.rootSpell ?? '{}')
+    const rootSpell = agent.rootSpell ?? {}
     // run the spell
     const result = await runSpell({
       spellId: rootSpell.id,
@@ -118,7 +118,7 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
       }
     }
 
-    const rootSpell = JSON.parse(agent.rootSpell ?? '{}')
+    const rootSpell = agent.rootSpell ?? {}
 
     const result = await runSpell({
       spellId: rootSpell.id,
@@ -180,7 +180,7 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
       }
     }
 
-    const rootSpell = JSON.parse(agent.rootSpell ?? '{}')
+    const rootSpell = agent.rootSpell ?? {}
 
     const result = await runSpell({
       spellId: rootSpell.id,
@@ -232,7 +232,7 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
       }
     }
 
-    const rootSpell = JSON.parse(agent.rootSpell ?? '{}')
+    const rootSpell = agent.rootSpell ?? {}
     // run the spell
     const result = await runSpell({
       spellId: rootSpell.id,

--- a/packages/server-core/src/agents/Agent.ts
+++ b/packages/server-core/src/agents/Agent.ts
@@ -9,7 +9,7 @@ type AgentData = {
   data: any
   name: string
   secrets: string
-  rootSpell: string
+  rootSpell: any
   publicVariables: any[]
   projectId: string
   spellManager: SpellManager
@@ -44,7 +44,7 @@ export class Agent {
     this.publicVariables = agentData.publicVariables
     this.id = agentData.id
     this.data = agentData
-    this.rootSpell = JSON.parse(agentData.rootSpell ?? '{}')
+    this.rootSpell = agentData.rootSpell ?? {}
     this.agentManager = agentManager
     this.name = agentData.name ?? 'agent'
     this.projectId = agentData.projectId
@@ -68,7 +68,7 @@ export class Agent {
 
       this.spellRunner = await this.spellManager.load(spell, override)
       const agentStartMethods = pluginManager.getAgentStartMethods()
-      
+
       for (const method of Object.keys(agentStartMethods)) {
         await agentStartMethods[method]({
           agentManager,

--- a/packages/server-core/src/services/agents/agents.schema.ts
+++ b/packages/server-core/src/services/agents/agents.schema.ts
@@ -16,7 +16,7 @@ export const agentSchema = Type.Object(
   {
     id: Type.String(),
     projectId: Type.String(),
-    rootSpell: Type.Optional(Type.String()),
+    rootSpell: Type.Optional(Type.Any()),
     name: Type.String(),
     enabled: Type.Optional(Type.Boolean()),
     updatedAt: Type.String(),
@@ -106,9 +106,7 @@ export const agentQueryProperties = Type.Pick(agentSchema, [
   'secrets',
 ])
 export const agentQuerySchema = Type.Intersect(
-  [
-    querySyntax(agentQueryProperties),
-  ],
+  [querySyntax(agentQueryProperties)],
   { additionalProperties: false }
 )
 export type AgentQuery = Static<typeof agentQuerySchema>
@@ -117,4 +115,4 @@ export const agentQueryValidator = getValidator(
   queryValidator
 )
 export const agentQueryResolver = resolve<AgentQuery, HookContext>({})
-export const agentJsonFields = ['spells', 'data']
+export const agentJsonFields = ['rootSpell', 'spells', 'data']


### PR DESCRIPTION
This PR makes the necessary updates to convert the `rootSpell` property of an `agent` to be handled as a JSON object instead of a string.

Tested locally both with SQLite and Postgres.