### PR TITLE
Switch away from getCurrentSpell for socket events

### DIFF
--- a/packages/editor/src/contexts/EditorProvider.tsx
+++ b/packages/editor/src/contexts/EditorProvider.tsx
@@ -1,7 +1,16 @@
 import { LoadingScreen } from '@magickml/client-core'
-import { EditorContext, GraphData, MagickEditor, SpellInterface } from '@magickml/engine'
+import {
+  EditorContext,
+  GraphData,
+  MagickEditor,
+  SpellInterface,
+} from '@magickml/engine'
 import React, {
-  createContext, useContext, useEffect, useRef, useState
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
 } from 'react'
 import { Component } from 'rete/types/engine'
 
@@ -40,7 +49,6 @@ type EditorContextType = {
   setEditor: (editor: any) => void
   getNodeMap: () => Map<string, Component>
   getNodes: () => any
-  loadGraph: (graph: any) => void
   setContainer: (container: HTMLDivElement) => void
   undo: () => void
   redo: () => void
@@ -90,8 +98,8 @@ const EditorProvider = ({ children }) => {
     setEditor(newEditor)
     // copy spell in case it is read onl
     const spell = JSON.parse(JSON.stringify(_spell ?? '{}'))
-    const graph = spell.graph
-    newEditor?.loadGraph(graph)
+    // newEditor?.loadGraph(graph)
+    newEditor.loadSpell(spell)
   }
 
   const run = () => {
@@ -144,12 +152,6 @@ const EditorProvider = ({ children }) => {
     return editor && Object.fromEntries(editor.components)
   }
 
-  const loadGraph = graph => {
-    if (!editorRef.current) return
-
-    editorRef.current.loadGraph(graph)
-  }
-
   const setContainer = () => {
     //
   }
@@ -162,7 +164,6 @@ const EditorProvider = ({ children }) => {
     buildEditor,
     getNodeMap,
     getNodes,
-    loadGraph,
     setEditor,
     getEditor,
     undo,

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -4,9 +4,14 @@ import { Plugin } from 'rete/types/core/plugin'
 import gridimg from './grid.png'
 import CommentPlugin from './plugins/commentPlugin'
 import ContextMenuPlugin from './plugins/contextMenu'
-import { OnSubspellUpdated, PubSubCallback, PubSubContext, SelectionPlugin } from '@magickml/engine'
+import {
+  OnSubspellUpdated,
+  PubSubCallback,
+  PubSubContext,
+  SelectionPlugin,
+} from '@magickml/engine'
 import ReactRenderPlugin, {
-  ReactRenderPluginOptions
+  ReactRenderPluginOptions,
 } from './plugins/reactRenderPlugin'
 
 import {
@@ -28,7 +33,7 @@ import {
   SocketOverridePlugin,
   SocketPlugin,
   SocketPluginArgs,
-  TaskPlugin
+  TaskPlugin,
 } from '@magickml/engine'
 
 import AreaPlugin from './plugins/areaPlugin'
@@ -143,7 +148,7 @@ export const initEditor = function ({
   editor.use(AreaPlugin, {
     scaleExtent: { min: 0.1, max: 1.5 },
     background,
-    tab
+    tab,
     // snap: true - TODO: add ability to enable and disable snapping to UI
   })
 
@@ -209,18 +214,23 @@ export const initEditor = function ({
 
   editor.runProcess = async callback => {
     await engine.abort()
-    await engine.process(editor.toJSON(), null, { magick: magick })
+    await engine.process(editor.toJSON(), null, {
+      magick: magick,
+      currentSpell: editor.currentSpell,
+    })
     if (callback) callback()
   }
 
-  editor.loadGraph = async (_graph: Data) => {
-    if(!_graph) return console.error('No graph to load')
+  editor.loadSpell = async (spell: any) => {
+    if (!spell) return console.error('No spell to load')
+    const _graph = spell.graph
     const graph = JSON.parse(JSON.stringify(_graph))
     await engine.abort()
     editor.fromJSON(graph)
 
     editor.view.resize()
     editor.runProcess()
+    editor.currentSpell = spell
   }
 
   // Start the engine off on first load

--- a/packages/engine/src/lib/plugins/socketPlugin/index.ts
+++ b/packages/engine/src/lib/plugins/socketPlugin/index.ts
@@ -12,7 +12,6 @@ export type SocketPluginArgs = {
   client?: any
 }
 
-
 export type SocketData = {
   output?: unknown
   error?: {
@@ -23,6 +22,9 @@ export type SocketData = {
 
 type Context = {
   magick: EngineContext
+  currentSpell: {
+    id: string
+  }
 }
 
 function install(
@@ -32,102 +34,110 @@ function install(
 ) {
   const subscriptionMap = new Map()
 
-  editor.on('componentregister', (component: MagickComponent<Promise<{ output: unknown } | void>>) => {
-    const worker = component.worker
+  editor.on(
+    'componentregister',
+    (component: MagickComponent<Promise<{ output: unknown } | void>>) => {
+      const worker = component.worker
 
-    component.worker = async (
-      node,
-      inputs,
-      outputs,
-      context: Context,
-      ...args
-    ) => {
-      const currentSpell = context.magick.getCurrentSpell()
-      const event = `${currentSpell.id}-${node.id}`
+      component.worker = async (
+        node,
+        inputs,
+        outputs,
+        context: Context,
+        ...args
+      ) => {
+        console.log('Running worker for node', node.id, node.name)
+        console.log('currentSpell', context.currentSpell.id)
+        const currentSpell = context.currentSpell
+        const event = `${currentSpell.id}-${node.id}`
 
-      if (server) {
-        try {
-          const result = await worker.apply(component, [
-            node,
-            inputs,
-            outputs,
-            context,
-            ...args,
-          ])
-
-          socket?.emit(event, {
-            output: result?.output,
-          })
-          return result
-        } catch (err: unknown) {
-          console.log('CAUGHT ERROR')
-          console.log(err)
-          if (err instanceof Error) {
-            // handle errors here so they dont crash the process, and are communicated to the client
-            socket?.emit(`${currentSpell.id}-${node.id}-error`, {
-              error: {
-                message: err.message,
-                stack: err.stack,
-              },
-            })
-            socket?.emit(`${currentSpell.id}-error`, {
-              error: {
-                message: err.message,
-                stack: err.stack,
-              },
-            })
-          }
-          else {
-            throw err
-          }
-          socket?.emit(event, {
-            output: { error: true },
-          })
-          // note: we may still want to throw the error here
-          return console.error(err)
-        }
-      }
-
-      if (client) {
-        node.console = new MagickConsole({
-          node: node as unknown as MagickNode,
-          component,
-          editor,
-          server,
-        })
-
-        if (subscriptionMap.has(node.id)) return
-        //  We may need to namespace this by spell as well
-        const unsubscribe = client.io.on(
-          event,
-          async (socketData: SocketData) => {
-            const newContext = {
-              ...context,
-              socketOutput: socketData,
-            }
-
-            // make sure errors are handled in the flow.
-            if (socketData?.error) {
-              const error = new Error(socketData.error.message)
-              error.stack = socketData.error.stack
-              node.console?.error(error)
-              return
-            }
-
-            await worker.apply(component, [
+        if (server) {
+          try {
+            const result = await worker.apply(component, [
               node,
               inputs,
               outputs,
-              newContext,
+              context,
               ...args,
             ])
-          }
-        )
 
-        subscriptionMap.set(node.id, unsubscribe)
+            console.log('*******************Emitting event', event)
+
+            socket?.emit(event, {
+              output: result?.output,
+            })
+            return result
+          } catch (err: unknown) {
+            console.log('CAUGHT ERROR')
+            console.log(err)
+            if (err instanceof Error) {
+              // handle errors here so they dont crash the process, and are communicated to the client
+              socket?.emit(`${currentSpell.id}-${node.id}-error`, {
+                error: {
+                  message: err.message,
+                  stack: err.stack,
+                },
+              })
+              socket?.emit(`${currentSpell.id}-error`, {
+                error: {
+                  message: err.message,
+                  stack: err.stack,
+                },
+              })
+            } else {
+              throw err
+            }
+
+            console.log('*******************Emitting event', event)
+            socket?.emit(event, {
+              output: { error: true },
+            })
+            // note: we may still want to throw the error here
+            return console.error(err)
+          }
+        }
+
+        if (client) {
+          node.console = new MagickConsole({
+            node: node as unknown as MagickNode,
+            component,
+            editor,
+            server,
+          })
+
+          if (subscriptionMap.has(node.id)) return
+          //  We may need to namespace this by spell as well
+          const unsubscribe = client.io.on(
+            event,
+            async (socketData: SocketData) => {
+              const newContext = {
+                ...context,
+                socketOutput: socketData,
+              }
+
+              // make sure errors are handled in the flow.
+              if (socketData?.error) {
+                const error = new Error(socketData.error.message)
+                error.stack = socketData.error.stack
+                node.console?.error(error)
+                return
+              }
+
+              await worker.apply(component, [
+                node,
+                inputs,
+                outputs,
+                newContext,
+                ...args,
+              ])
+            }
+          )
+
+          subscriptionMap.set(node.id, unsubscribe)
+        }
       }
     }
-  })
+  )
 }
 
 const defaultExport = {

--- a/packages/engine/src/lib/types.ts
+++ b/packages/engine/src/lib/types.ts
@@ -5,7 +5,7 @@ import {
   InputsData,
   NodeData,
   OutputsData,
-  WorkerOutputs
+  WorkerOutputs,
 } from 'rete/types/core/data'
 import { MagickComponent } from './engine'
 import { MagickConsole } from './plugins/consolePlugin/MagickConsole'
@@ -25,7 +25,6 @@ import io from 'socket.io'
 export type { InspectorData } from './plugins/inspectorPlugin/Inspector'
 
 export * from './schemas'
-
 
 export type ImageType = {
   id: string
@@ -135,11 +134,13 @@ export type OnSubspellUpdated = (spell: SpellInterface) => void
 
 export class MagickEditor extends NodeEditor<EventsTypes> {
   declare tasks: Task[]
+  declare currentSpell: { id: string }
   declare pubSub: PubSubContext
   declare magick: EditorContext
   declare tab: { type: string }
   declare abort: unknown
   declare loadGraph: (graph: Data, relaoding?: boolean) => Promise<void>
+  declare loadSpell: (graph: Data, relaoding?: boolean) => Promise<void>
   declare moduleManager: ModuleManager
   declare runProcess: (callback?: () => void | undefined) => Promise<void>
   declare onSpellUpdated: (
@@ -271,7 +272,7 @@ export interface EditorContext extends EngineContext {
   ) => () => void
   sendToPlaytest: (data: string) => void
   sendToInspector: PublishEditorEvent
-  sendToDebug: (message: unknown)=>void
+  sendToDebug: (message: unknown) => void
   onInspector: OnInspector
   onPlaytest: OnEditor
   onDebug: OnDebug
@@ -501,7 +502,7 @@ export type CompletionSocket = {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface DataControlImplementation extends DataControl {
-  new(control:CompletionInspectorControls): DataControl
+  new (control: CompletionInspectorControls): DataControl
 }
 
 export type CompletionInspectorControls = {
@@ -515,10 +516,12 @@ export type CompletionInspectorControls = {
 export type CompletionProvider = {
   type: CompletionType
   subtype: ImageCompletionSubtype | TextCompletionSubtype
-  handler?: (attrs:{node:WorkerData,
-    inputs:MagickWorkerInputs,
-    outputs:MagickWorkerOutputs,
-    context:unknown}) => {success:boolean, result: string, error:string} // server only
+  handler?: (attrs: {
+    node: WorkerData
+    inputs: MagickWorkerInputs
+    outputs: MagickWorkerOutputs
+    context: unknown
+  }) => { success: boolean; result: string; error: string } // server only
   inspectorControls?: CompletionInspectorControls[] // client only
   inputs: CompletionSocket[]
   outputs: CompletionSocket[]


### PR DESCRIPTION
Should work now.  Brought up issue though that "getCurrentSpell" may not be a super reliable way to fetch the current spell. We may want to look into swapping it out in other places.  

The current spell is not injected on every run directly onto the whole context, rather than going through a helper function of the magick interface,