### PR TITLE
fix: alter tables to remove string and use text

### DIFF
--- a/apps/server/migrations/20230329030820_agent_string_to_text.ts
+++ b/apps/server/migrations/20230329030820_agent_string_to_text.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('agents', (table) => {
+    table.text('publicVariables').alter()
+    table.text('secrets').alter()
+    table.text('name').alter()
+    table.text('updatedAt').alter()
+    table.text('pingedAt').alter()
+    table.text('projectId').alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('agents', (table) => {
+    table.string('publicVariables').alter()
+    table.string('secrets').alter()
+    table.string('name').alter()
+    table.string('updatedAt').alter()
+    table.string('pingedAt').alter()
+    table.string('projectId').alter()
+  })
+}

--- a/apps/server/migrations/20230329031531_documents_string_to_text.ts
+++ b/apps/server/migrations/20230329031531_documents_string_to_text.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('documents', (table) => {
+    table.text('type').alter()
+    table.text('owner').alter()
+    table.text('projectId').alter()
+    table.text('date').alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('documents', (table) => {
+    table.string('type').alter()
+    table.string('owner').alter()
+    table.string('projectId').alter()
+    table.string('date').alter()
+  })
+}

--- a/apps/server/migrations/20230329031659_events_string_to_text.ts
+++ b/apps/server/migrations/20230329031659_events_string_to_text.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('events', (table) => {
+    table.text('type').alter()
+    table.text('observer').alter()
+    table.text('sender').alter()
+    table.text('client').alter()
+    table.text('channel').alter()
+    table.text('channelType').alter()
+    table.text('projectId').alter()
+    table.text('agentId').alter()
+    table.text('date').alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('events', (table) => {
+    table.string('type').alter()
+    table.string('observer').alter()
+    table.string('sender').alter()
+    table.string('client').alter()
+    table.string('channel').alter()
+    table.string('channelType').alter()
+    table.string('projectId').alter()
+    table.string('agentId').alter()
+    table.string('date').alter()
+  })
+}

--- a/apps/server/migrations/20230329031824_request_string_to_text.ts
+++ b/apps/server/migrations/20230329031824_request_string_to_text.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('request', (table) => {
+    table.text('projectId').notNullable().alter()
+    table.text('status').alter()
+    table.text('model').alter()
+    table.text('provider').notNullable().alter()
+    table.text('type').notNullable().alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('request', (table) => {
+    table.string('projectId').notNullable().alter()
+    table.string('status').alter()
+    table.string('model').alter()
+    table.string('provider').notNullable().alter()
+    table.string('type').notNullable().alter()
+  })
+}

--- a/apps/server/migrations/20230329032028_spells_string_to_text.ts
+++ b/apps/server/migrations/20230329032028_spells_string_to_text.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('spells', (table) => {
+    table.text('name').alter()
+    table.text('projectId').alter()
+    table.text('hash').alter()
+    table.text('createdAt').alter()
+    table.text('updatedAt').alter()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('spells', (table) => {
+    table.string('name').alter()
+    table.string('projectId').alter()
+    table.string('hash').alter()
+    table.string('createdAt').alter()
+    table.string('updatedAt').alter()
+  })
+}


### PR DESCRIPTION
This issue resolves the "character too long for varchar" issue seen when either the request or response to an Agent is too long. Additionally, it also standardizes the use of `text` as opposed to `varchar` column types across all tables.