### PR TITLE
Fix/lint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,16 @@
 {
   "root": true,
-  "ignorePatterns": [
-    "**/*"
-  ],
-  "plugins": [
-    "@nrwl/nx"
-  ],
+  "ignorePatterns": ["**/*"],
+  "plugins": ["@nrwl/nx"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off"
   },
   "overrides": [
     {
-      "files": [
-        "*.ts",
-        "*.tsx",
-        "*.js",
-        "*.jsx"
-      ],
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "no-extra-semi": "off",
+        "@typescript-eslint/no-extra-semi": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@nrwl/nx/enforce-module-boundaries": [
           "error",
@@ -27,9 +20,7 @@
             "depConstraints": [
               {
                 "sourceTag": "*",
-                "onlyDependOnLibsWithTags": [
-                  "*"
-                ]
+                "onlyDependOnLibsWithTags": ["*"]
               }
             ]
           }
@@ -37,34 +28,21 @@
       }
     },
     {
-      "files": [
-        "*.ts",
-        "*.tsx"
-      ],
-      "extends": [
-        "plugin:@nrwl/nx/typescript"
-      ],
+      "files": ["*.ts", "*.tsx"],
+      "extends": ["plugin:@nrwl/nx/typescript"],
       "rules": {
+        "no-extra-semi": "off",
+        "@typescript-eslint/no-extra-semi": "off",
         "@typescript-eslint/no-explicit-any": "off"
       }
     },
     {
-      "files": [
-        "*.js",
-        "*.jsx"
-      ],
-      "extends": [
-        "plugin:@nrwl/nx/javascript"
-      ],
+      "files": ["*.js", "*.jsx"],
+      "extends": ["plugin:@nrwl/nx/javascript"],
       "rules": {}
     },
     {
-      "files": [
-        "*.spec.ts",
-        "*.spec.tsx",
-        "*.spec.js",
-        "*.spec.jsx"
-      ],
+      "files": ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
       "env": {
         "jest": true
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start-docs": "npx nx serve @magickml/docs",
     "migrate:make": "nx run @magickml/server:migrate:make",
     "migrate": "nx run @magickml/server:migrate",
-    "lint": "npx nx run-many --target=lint --all",
+    "lint": "npx nx lint @magickml/engine",
     "build": "npx nx lint @magickml/engine && npx nx run-many --target=build --projects=@magickml/server,@magickml/agent",
     "build-client": "npx nx build @magickml/client",
     "heroku-prebuild": "npm i -g @nrwl/cli",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start-docs": "npx nx serve @magickml/docs",
     "migrate:make": "nx run @magickml/server:migrate:make",
     "migrate": "nx run @magickml/server:migrate",
+    "lint": "npx nx run-many --target=lint --all",
     "build": "npx nx lint @magickml/engine && npx nx run-many --target=build --projects=@magickml/server,@magickml/agent",
     "build-client": "npx nx build @magickml/client",
     "heroku-prebuild": "npm i -g @nrwl/cli",

--- a/packages/client-core/src/components/TabLayout/index.tsx
+++ b/packages/client-core/src/components/TabLayout/index.tsx
@@ -3,10 +3,8 @@ import css from './TabLayout.module.css'
 
 export const TabLayout = ({ children }) => {
   return (
-    <>
-      <div className={css['view-container']}>
+    <div className={css['view-container']}>
         <div style={{ position: 'relative', height: '100%' }}>{children}</div>
       </div>
-    </>
   )
 }

--- a/packages/engine/src/lib/functions/saveRequest.ts
+++ b/packages/engine/src/lib/functions/saveRequest.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { calculateCompletionCost } from '@magickml/cost-calculator'
 import { v4 } from 'uuid'
 import { globalsManager } from '../globals'
@@ -47,6 +48,6 @@ export function saveRequest({
     cost,
     // if spell is json, stringify it
     spell: typeof spell === 'string' ? spell : JSON.stringify(spell),
-    nodeId
+    nodeId,
   })
 }

--- a/packages/engine/src/lib/nodes/array/ArrayToJSON.ts
+++ b/packages/engine/src/lib/nodes/array/ArrayToJSON.ts
@@ -1,14 +1,10 @@
 import Rete from 'rete'
 
 import { MagickComponent } from '../../engine'
-import { arraySocket, objectSocket, stringSocket, triggerSocket } from '../../sockets'
-import {
-  MagickNode,
-  MagickWorkerInputs, WorkerData
-} from '../../types'
+import { arraySocket, stringSocket, triggerSocket } from '../../sockets'
+import { MagickNode, MagickWorkerInputs, WorkerData } from '../../types'
 
-const info =
-  'Convert an object into a JSON string.'
+const info = 'Convert an object into a JSON string.'
 
 type WorkerReturn = {
   output: string
@@ -16,12 +12,17 @@ type WorkerReturn = {
 
 export class ArrayToJSON extends MagickComponent<Promise<WorkerReturn>> {
   constructor() {
-    super('Array To JSON', {
-      outputs: {
-        output: 'output',
-        trigger: 'option',
+    super(
+      'Array To JSON',
+      {
+        outputs: {
+          output: 'output',
+          trigger: 'option',
+        },
       },
-    }, 'Array', info)
+      'Array',
+      info
+    )
   }
 
   builder(node: MagickNode) {

--- a/packages/engine/src/lib/nodes/array/JoinList.ts
+++ b/packages/engine/src/lib/nodes/array/JoinList.ts
@@ -1,7 +1,5 @@
 import Rete from 'rete'
 import { InputControl } from '../../dataControls/InputControl'
-
-import { TextInputControl } from '../../dataControls/TextInputControl'
 import { MagickComponent } from '../../engine'
 import { arraySocket, stringSocket } from '../../sockets'
 import { MagickNode, MagickWorkerInputs, WorkerData } from '../../types'
@@ -15,12 +13,17 @@ type WorkerReturn = {
 export class JoinListComponent extends MagickComponent<WorkerReturn> {
   constructor() {
     // Name of the component
-    super('Join List', {
-      outputs: {
-        text: 'output',
-        trigger: 'option',
+    super(
+      'Join List',
+      {
+        outputs: {
+          text: 'output',
+          trigger: 'option',
+        },
       },
-    }, 'Array', info)
+      'Array',
+      info
+    )
   }
 
   // the builder is used to "assemble" the node component.

--- a/packages/engine/src/lib/nodes/embedding/CreateTextEmbedding.ts
+++ b/packages/engine/src/lib/nodes/embedding/CreateTextEmbedding.ts
@@ -20,18 +20,23 @@ const info = 'Event Store is used to store events for an event and user'
 type InputReturn = {
   success: boolean
   error?: string
-  result?: any
+  result?: string
 }
 
 export class CreateTextEmbedding extends MagickComponent<Promise<InputReturn>> {
   constructor() {
-    super('Create Text Embedding', {
-      outputs: {
-        trigger: 'option',
-        result: 'output',
-        success: 'output',
+    super(
+      'Create Text Embedding',
+      {
+        outputs: {
+          trigger: 'option',
+          result: 'output',
+          success: 'output',
+        },
       },
-    }, 'Embedding', info)
+      'Embedding',
+      info
+    )
   }
 
   builder(node: MagickNode) {
@@ -133,7 +138,7 @@ export class CreateTextEmbedding extends MagickComponent<Promise<InputReturn>> {
     const completionProviders = pluginManager.getCompletionProviders('text', [
       'embedding',
     ]) as CompletionProvider[]
-    const model = (node.data as {model: string}).model as string
+    const model = (node.data as { model: string }).model as string
 
     // get the provider for the selected model
     const provider = completionProviders.find(provider =>

--- a/packages/engine/src/lib/nodes/io/Input.ts
+++ b/packages/engine/src/lib/nodes/io/Input.ts
@@ -50,10 +50,10 @@ export class InputComponent extends MagickComponent<InputReturn> {
   }
 
   builder(node: MagickNode) {
-    if(node.data.useTrigger === undefined) {
+    if (node.data.useTrigger === undefined) {
       node.data.useTrigger = true
     }
-    if(node.data.useData === undefined) {
+    if (node.data.useData === undefined) {
       node.data.useData = true
     }
     // Setup dynamic controls
@@ -76,7 +76,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
       defaultValue: node.data.useTrigger,
       onData: data => {
         console.log('trigger switch')
-        configureNode();
+        configureNode()
       },
     }
 
@@ -88,7 +88,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
       defaultValue: node.data.useData,
       onData: data => {
         console.log('data switch', data)
-        configureNode();
+        configureNode()
       },
     }
 
@@ -97,7 +97,6 @@ export class InputComponent extends MagickComponent<InputReturn> {
       name: 'output',
       type: anySocket,
     }
-
 
     const triggerOutput = {
       socket: 'trigger',
@@ -116,20 +115,19 @@ export class InputComponent extends MagickComponent<InputReturn> {
     // Combine default input types with plugin input types
     const inputTypes = [...defaultInputTypes, ...pluginManager.getInputTypes()]
 
-     // Set isInput to true so we can identify this node as an input node
-     node.data.isInput = true
+    // Set isInput to true so we can identify this node as an input node
+    node.data.isInput = true
 
-     // Each node should have a unique socket key
-     node.data.socketKey = node?.data?.socketKey || uuidv4()
- 
+    // Each node should have a unique socket key
+    node.data.socketKey = node?.data?.socketKey || uuidv4()
+
     console.log('inputTypes[0].name', inputTypes[0].name)
 
-     // Set the default name if there is none
-     if(!node.data.name) {
-      
-       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-       node.data.name ?? `Input - ${inputTypes[0].name}`
-     }
+    // Set the default name if there is none
+    if (!node.data.name) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      node.data.name ?? `Input - ${inputTypes[0].name}`
+    }
 
     // Setup default controls
     const inputType = new DropdownControl({
@@ -142,19 +140,18 @@ export class InputComponent extends MagickComponent<InputReturn> {
     node.inspector.add(inputType)
 
     //
-    let lastInspectorControls: any[] | undefined = []
+    let lastInspectorControls: DataControl[] | undefined = []
     let lastSockets: CompletionSocket[] | undefined = []
 
-
-    const handleSockets = (sockets) => {
+    const handleSockets = sockets => {
       const connections = node.getConnections()
       if (sockets !== lastSockets) {
         lastSockets?.forEach(socket => {
           console.log('deleting socket', socket)
-          if (node.outputs.has(socket.socket)){
+          if (node.outputs.has(socket.socket)) {
             connections.forEach(c => {
               console.log('checking connection', c)
-              if (c.output.key === socket.socket){
+              if (c.output.key === socket.socket) {
                 console.log('removing connection', c)
                 this.editor?.removeConnection(c)
               } else {
@@ -165,13 +162,14 @@ export class InputComponent extends MagickComponent<InputReturn> {
           }
         })
         sockets.forEach(socket => {
-          if(node.outputs.has(socket.socket)) return;
+          if (node.outputs.has(socket.socket)) return
           console.log('adding socket', socket)
-          if(node.data.inputType === 'Default') {
+          if (node.data.inputType === 'Default') {
             // if socket is trigger and useTrigger is false, don't add
-            if(socket.socket === 'trigger' && node.data.useTrigger !== true) return;
+            if (socket.socket === 'trigger' && node.data.useTrigger !== true)
+              return
             // if socket is output and useData is false, don't add
-            if(socket.socket === 'output' && node.data.useData !== true) return;
+            if (socket.socket === 'output' && node.data.useData !== true) return
           }
           console.log('adding socket', socket)
           node.addOutput(
@@ -182,14 +180,13 @@ export class InputComponent extends MagickComponent<InputReturn> {
         lastSockets = sockets
       }
     }
-    
+
     const configureNode = () => {
       console.log('configuring node', node.data.inputType ?? 'Default')
-      const inputType = node.data.inputType ?? 'Default' as string
+      const inputType = node.data.inputType ?? ('Default' as string)
       console.log('node.outputs', node.outputs)
 
       const connections = node.getConnections()
-
 
       console.log('reading input type', inputType)
 
@@ -203,19 +200,13 @@ export class InputComponent extends MagickComponent<InputReturn> {
       const sockets = inputTypeData.sockets ?? []
 
       // configure default
-      if (
-        inputType === 'Default' &&
-        node.data.useTrigger === true
-      ) {
+      if (inputType === 'Default' && node.data.useTrigger === true) {
         sockets.push(triggerOutput)
       }
 
       console.log('node.data.useData', node.data.useData)
 
-      if (
-        inputType === 'Default' &&
-        node.data.useData === true
-      ) {
+      if (inputType === 'Default' && node.data.useData === true) {
         sockets.push(dataOutput)
       }
 
@@ -227,12 +218,15 @@ export class InputComponent extends MagickComponent<InputReturn> {
         node.data.name = `Input - ${node.data.inputName}`
         if (node.data.useTrigger !== true && node.outputs.has('trigger')) {
           connections.forEach(c => {
-            if (c.output.key === 'trigger'){
+            if (c.output.key === 'trigger') {
               this.editor?.removeConnection(c)
             }
           })
           node.outputs.delete('trigger')
-        } else if (node.data.useTrigger === true && !node.outputs.has('trigger')) {
+        } else if (
+          node.data.useTrigger === true &&
+          !node.outputs.has('trigger')
+        ) {
           console.log('adding socket trigger')
 
           node.addOutput(new Rete.Output('trigger', 'trigger', triggerSocket))
@@ -241,7 +235,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
         if (!node.data.useData && node.outputs.has('output')) {
           connections.forEach(c => {
             console.log('checking connection', c)
-            if (c.output.key === 'output'){
+            if (c.output.key === 'output') {
               this.editor?.removeConnection(c)
             }
           })
@@ -257,21 +251,24 @@ export class InputComponent extends MagickComponent<InputReturn> {
           node.inspector.dataControls.delete(control.dataKey)
         })
         inspectorControls.forEach(control => {
-          const _control = new control.type({...control, defaultValue: node.data[control.dataKey] || control.defaultValue})
+          const _control = new control.type({
+            ...control,
+            defaultValue: node.data[control.dataKey] || control.defaultValue,
+          })
           _control.onData = control.onData
           node.inspector.add(_control)
         })
         lastInspectorControls = inspectorControls
       }
 
-        handleSockets(sockets)
+      handleSockets(sockets)
 
-        const context = this.editor && this.editor.magick
-        if (!context) return
-        const { sendToInspector } = context
-        if (sendToInspector) {
-          sendToInspector(node.inspector.data())
-        }
+      const context = this.editor && this.editor.magick
+      if (!context) return
+      const { sendToInspector } = context
+      if (sendToInspector) {
+        sendToInspector(node.inspector.data())
+      }
     }
 
     inputType.onData = data => {
@@ -294,10 +291,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
   ) {
     node.data.isInput = true
     // handle data subscription.  If there is data, this is from playtest
-    if (
-      data &&
-      !isEmpty(data)
-    ) {
+    if (data && !isEmpty(data)) {
       this._task.closed = []
 
       const output = Object.values(data)[0] as string

--- a/packages/engine/src/lib/plugin.ts
+++ b/packages/engine/src/lib/plugin.ts
@@ -1,6 +1,5 @@
 import { Application } from '@feathersjs/koa'
 import { FC, LazyExoticComponent } from 'react'
-import { Socket } from 'rete'
 import { MagickComponentArray } from './engine'
 import { CompletionProvider, Route, SpellInterface } from './types'
 

--- a/packages/engine/src/lib/plugins/modulePlugin/module.ts
+++ b/packages/engine/src/lib/plugins/modulePlugin/module.ts
@@ -1,4 +1,5 @@
-import { Agent } from "@magickml/server-core"
+// eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
+import type { Agent } from '@magickml/server-core'
 
 export class Module {
   secrets?: Record<string, string>
@@ -13,15 +14,10 @@ export class Module {
     this.publicVariables = {}
   }
 
-  read({
-    inputs,
-    secrets,
-    publicVariables,
-    agent
-  }) {
+  read({ inputs, secrets, publicVariables, agent }) {
     this.inputs = inputs
-    this.secrets = secrets || {} as Record<string, string>
-    this.publicVariables = publicVariables || {} as Record<string, string>
+    this.secrets = secrets || ({} as Record<string, string>)
+    this.publicVariables = publicVariables || ({} as Record<string, string>)
     this.agent = agent
   }
 

--- a/packages/server-core/src/services/Upload.class.ts
+++ b/packages/server-core/src/services/Upload.class.ts
@@ -5,11 +5,11 @@ export class UploadService {
         this.image_store = new Array<any>();
     }
     async create(body, params){
-        let img_body = {
+        const img_body = {
             "id": body["id"],
             "uri":body["uri"]
         }
-        let idx = this.image_store.map(e => e.id).indexOf(body["id"]);
+        const idx = this.image_store.map(e => e.id).indexOf(body["id"]);
         console.log(body["id"])
         idx === -1 ? this.image_store.push(img_body) : this.image_store[idx] = img_body;
         this.image_store.push(img_body)

--- a/packages/server-core/src/services/events/events.ts
+++ b/packages/server-core/src/services/events/events.ts
@@ -76,7 +76,7 @@ export const event = (app: Application) => {
           if (SKIP_DB_EXTENSIONS) return context
           const { embedding } = context.data
           const { data, service } = context
-          let id = uuidv4()
+          const id = uuidv4()
           //Add UUID for events.
           context.data = {
             [service.id]: id,

--- a/packages/server-core/src/vectordb.ts
+++ b/packages/server-core/src/vectordb.ts
@@ -88,7 +88,7 @@ class HNSW<T> {
     let neighborId = node.neighbors[level - 1];
     while (neighborId !== null) {
       neighbors.push(neighborId);
-      let neighbor = this.nodes.get(neighborId);
+      const neighbor = this.nodes.get(neighborId);
       neighborId = neighbor ? neighbor.neighbors[level - 1] : null;
     }
     return neighbors;
@@ -179,7 +179,7 @@ class HNSWVectorDatabase<T> implements VectorDatabase<T> {
       .map((item) => item.data);
   }
   public delete(id: string) {
-    let k = this.index.nodes.get(id)
+    const k = this.index.nodes.get(id)
     this.index.nodes.delete(id)
     this.saveIndex()
     return {events: k.data}


### PR DESCRIPTION
This PR resolves lint errors in the `@magickml/engine package`. This is the only package currently being checked during the build process, so it should pass.

Some notes about decisions made (and to have on record for historic reference):

- Warnings about the usage of `any` have not been fully been resolved. I fixed what I could quickly make sense of, but more work needs to be done here
- The estranged semicolon is being added automatically by Prettier, but throwing an error with ESLint. I've updated the ESLint configuration to ignore this
  - Details about why can be found here: https://prettier.io/docs/en/rationale.html#semicolons
- A few ESLint ignores have been applied for [enforce-module-boundaries](https://nx.dev/core-features/enforce-project-boundaries)
  - In `packages/engine/src/lib/functions/saveRequest.ts` the `@magickml/cost-calculator` violates the `enforceBuildableLibDependency` rule.
  - In `packages/engine/src/lib/plugins/modulePlugin/module.ts` there is a perceived circular dependency
    - `@magickml/engine -> @magickml/server-core -> @magickml/engine`
  - This is because of the imported `Agent` class, though it is only being used as a Type 
