### PR TITLE
Handle invalid discord token

### DIFF
--- a/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
@@ -80,20 +80,15 @@ const AgentDetails = ({
       body: JSON.stringify(_data),
     })
       .then(res => res.json())
-      .then(res => {
-        if (typeof res.data === 'string' && res.data === 'internal error') {
-          enqueueSnackbar('Internal error updating agent', {
-            variant: 'error',
-          })
-        } else {
+      .then(data => {
+
           enqueueSnackbar('Updated agent', {
             variant: 'success',
           })
-          setSelectedAgentData(res.data)
+          setSelectedAgentData(data)
 
           // update data instead of refetching data to avoid agent window flashes
-          updateData(res.data)
-        }
+          updateData(data)
       })
       .catch(e => {
         console.error('ERROR', e)
@@ -197,7 +192,7 @@ const AgentDetails = ({
         ) : (
           <div className={styles.agentDescription}>
             <Avatar className={styles.avatar}>
-              {selectedAgentData.name.slice(0, 1)[0]}{' '}
+              {selectedAgentData?.name?.slice(0, 1)[0]}{' '}
             </Avatar>
             <div>
               <Typography variant="h5">{selectedAgentData.name}</Typography>

--- a/plugins/discord/client/src/components/utils.tsx
+++ b/plugins/discord/client/src/components/utils.tsx
@@ -44,7 +44,7 @@ export const KeyInput: React.FC<{ value: string, setValue: React.Dispatch<React.
   return (value ? (
     <>
       {/* Conditionally display the private key, obfuscating if secret=true */}
-      <p>{secret ? obfuscateKey(value) : value}</p>
+      <span>{secret ? obfuscateKey(value) : value}</span>
       {/* Render remove button */}
       <button onClick={removeKey} style={{ cursor: 'pointer' }}>remove</button>
     </>

--- a/plugins/discord/server/src/connectors/discord.ts
+++ b/plugins/discord/server/src/connectors/discord.ts
@@ -162,13 +162,21 @@ export class DiscordConnector {
 
         this.client.ws
 
-        this.client.login(token).then(() => {
-          console.log('Discord bot logged in')
-        }, console.error)
+        ;(async () => {
+
+        try {
+        const login = await this.client.login(token)
+        console.log('Discord client logged in', login)
+        
+        } catch (e) {
+          return console.error('Error logging in discord client', e)
+        }
 
         this.client.on('error', err => {
           console.error('Discord client error', err)
         })
+      })()
+
       } catch (e) {
         console.error('Error creating discord client', e)
       }

--- a/plugins/rest/client/src/components/utils.tsx
+++ b/plugins/rest/client/src/components/utils.tsx
@@ -56,7 +56,7 @@ export const KeyInput: React.FC<KeyInputProps> = ({ value, setValue, secret }) =
     <>
       {value ? (
         <>
-          <p>{secret ? obfuscateKey(value) : value}</p>
+          <span>{secret ? obfuscateKey(value) : value}</span>
           <button
             onClick={removeKey}
             style={{ cursor: 'pointer' }}


### PR DESCRIPTION
This PR fixes the agent window (which had a small update regression) and handles cases where the discord token is wrong. The Discord agent will not start if the token is wrong, and the backend doesn't crash.