### PR TITLE
Hide avatar, documents, chat and clean up for cloud

### DIFF
--- a/.env
+++ b/.env
@@ -9,10 +9,8 @@ DATABASE_TYPE=sqlite
 ## for postgres, this should be your full connection string, starting with postgres://
 DATABASE_URL=./mydb.sqlite
 
-SKIP_DB_EXTENSIONS=false
-
 # Copy these to .env.local and fill in your own values to customize
-CLIENT_PLUGINS=discord,twitter,rest,loop,openai,avatar
+CLIENT_PLUGINS=discord,twitter,rest,loop,openai
 SERVER_PLUGINS=discord,twitter,rest,loop,openai,qa
 
 # Memory to use for build cache

--- a/packages/core/client/src/components/Drawer/index.tsx
+++ b/packages/core/client/src/components/Drawer/index.tsx
@@ -258,7 +258,8 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
           <DrawerItem
             active={
               location.pathname.includes('/magick') ||
-              location.pathname.includes('/home')
+              location.pathname.includes('/home') ||
+              location.pathname === '/'
             }
             Icon={AutoFixHighIcon}
             open={open}
@@ -272,15 +273,15 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             onClick={onClick('/agents')}
             text="Agents"
           />
-          <DrawerItem
+          {/* <DrawerItem
             active={location.pathname === '/documents'}
             Icon={DocumentIcon}
             open={open}
             onClick={onClick('/documents')}
             text="Documents"
-          />
+          /> */}
           <DrawerItem
-            active={location.pathname === '/requests'}
+            active={location.pathname === '/events'}
             Icon={BoltIcon}
             open={open}
             onClick={onClick('/events')}
@@ -293,14 +294,14 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             onClick={onClick('/requests')}
             text="Requests"
           />
-          <Divider />
+          {/* <Divider />
           <DrawerItem
             active={location.pathname.includes('/chat')}
             Icon={ChatIcon}
             open={open}
             onClick={onClick('/chat')}
             text="Chat"
-          />
+          /> */}
           <Divider />
           <PluginDrawerItems onClick={onClick} open={open} />
           <Divider />

--- a/packages/core/server/src/services/documents/documents.ts
+++ b/packages/core/server/src/services/documents/documents.ts
@@ -1,6 +1,5 @@
 // DOCUMENTED 
 import { hooks as schemaHooks } from '@feathersjs/schema';
-import { SKIP_DB_EXTENSIONS } from '@magickml/core';
 import pgvector from 'pgvector/pg';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -51,7 +50,6 @@ export const document = (app: Application) => {
       find: [],
       get: [
         (context: HookContext) => {
-          if (SKIP_DB_EXTENSIONS) return context;
           const { getEmbedding } = context.params.query;
           if (getEmbedding) {
             context.params.query.$limit = 1;
@@ -64,7 +62,6 @@ export const document = (app: Application) => {
       create: [
         // feathers hook to get the 'embedding' field from the request and make sure it is a valid pgvector (cast all to floats)
         async (context: HookContext) => {
-          if (SKIP_DB_EXTENSIONS) return context
           const { embedding } = context.data
           const { data, service } = context
           const id = uuidv4()
@@ -121,7 +118,6 @@ export const document = (app: Application) => {
       create: [
         // Commented out because it is not being used currently
         // async (context: HookContext) => {
-        //   if (SKIP_DB_EXTENSIONS) return context;
         //   if (!context.data.embedding || context.data.embedding.length === 0)
         //     return context;
         //   const { id } = context.result;

--- a/packages/core/server/src/services/events/events.ts
+++ b/packages/core/server/src/services/events/events.ts
@@ -1,6 +1,5 @@
 // DOCUMENTED 
 import { hooks as schemaHooks } from '@feathersjs/schema';
-import { SKIP_DB_EXTENSIONS } from '@magickml/core';
 import os from 'os';
 import pgvector from 'pgvector/pg';
 import { v4 as uuidv4 } from 'uuid';
@@ -61,7 +60,6 @@ export const event = (app: Application) => {
       find: [],
       get: [
         (context: HookContext) => {
-          if (SKIP_DB_EXTENSIONS) return context;
           const { getEmbedding } = context.params.query;
           if (getEmbedding) {
             context.params.query.$limit = 1;
@@ -73,7 +71,6 @@ export const event = (app: Application) => {
       create: [
         // feathers hook to get the 'embedding' field from the request and make sure it is a valid pgvector (cast all to floats)
         async (context: HookContext) => {
-          if (SKIP_DB_EXTENSIONS) return context
           const { embedding } = context.data
           const { data, service } = context
           const id = uuidv4()

--- a/packages/core/shared/src/config.ts
+++ b/packages/core/shared/src/config.ts
@@ -27,8 +27,6 @@ function getVarForEnvironment(env: string): string | undefined {
 
 // Define and export constants from environment variables
 export const IGNORE_AUTH = getVarForEnvironment('IGNORE_AUTH') === 'true'
-export const SKIP_DB_EXTENSIONS =
-  getVarForEnvironment('SKIP_DB_EXTENSIONS') === 'true'
 export const DEFAULT_PROJECT_ID =
   getVarForEnvironment('PROJECT_ID') || 'bb1b3d24-84e0-424e-b4f1-57603f307a89'
 export const DEFAULT_USER_ID = getVarForEnvironment('USER_ID') || '1234567890'


### PR DESCRIPTION
Currently we have some pre-alpha in-development parts of the app which we should hide in the cloud for now. These can be re-enabled by uncommenting the drawer link (in the case of documents and chat) or adding the avatar back as a client plugin