### PR TITLE
fix: type errors

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ DATABASE_TYPE=sqlite
 DATABASE_URL=./mydb.sqlite
 
 # Copy these to .env.local and fill in your own values to customize
-CLIENT_PLUGINS=discord,twitter,rest,loop,openai
-SERVER_PLUGINS=discord,twitter,rest,loop,openai,qa
+CLIENT_PLUGINS=discord,twitter,rest,loop,openai,search
+SERVER_PLUGINS=discord,twitter,rest,loop,openai,search,qa
 
 # Memory to use for build cache
 NODE_OPTIONS="--max-old-space-size=8192"

--- a/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
@@ -274,11 +274,12 @@ const AgentDetails = ({
               enabled: true,
               ...selectedAgentData,
             })
+            console.log('newRootSpell', newRootSpell)
             setSelectedAgentData({
               ...selectedAgentData,
               rootSpell: newRootSpell,
               publicVariables: JSON.stringify(
-                newRootSpell.graph.nodes
+                Object.values(newRootSpell.graph.nodes)
                   // get the public nodes
                   .filter((node: { data }) => node?.data?.isPublic)
                   // map to an array of objects

--- a/plugins/search/client/src/index.ts
+++ b/plugins/search/client/src/index.ts
@@ -9,14 +9,14 @@ import { ClientPlugin } from '@magickml/core';
  * This is the `Nodes` object from the search shared plugin.
  * @typedef {object} Nodes
  */
-import Nodes from '@magickml/plugin-search-shared';
+import { getNodes } from '@magickml/plugin-search-shared';
 
 /**
  * Represents a search plugin usable by clients.
  */
 const SearchPlugin = new ClientPlugin({
   name: 'SearchPlugin',
-  nodes: Nodes
+  nodes: getNodes()
 });
 
 export default SearchPlugin;

--- a/plugins/search/server/src/index.ts
+++ b/plugins/search/server/src/index.ts
@@ -1,8 +1,8 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * Class representing a server plugin for search functionality
  */
-import { ServerPlugin } from "@magickml/core"
+import { ServerPlugin } from '@magickml/core'
 
 /**
  * Nodes that are shared between search plugins
@@ -19,8 +19,8 @@ import { googleSearch } from './services/google-search/google-search'
  */
 const SearchPlugin = new ServerPlugin({
   name: 'SearchPlugin',
-  nodes: Nodes,
-  services: [googleSearch]
+  nodes: Nodes(),
+  services: [googleSearch],
 })
 
-export default SearchPlugin;
+export default SearchPlugin

--- a/plugins/search/server/src/index.ts
+++ b/plugins/search/server/src/index.ts
@@ -7,7 +7,7 @@ import { ServerPlugin } from '@magickml/core'
 /**
  * Nodes that are shared between search plugins
  */
-import Nodes from '@magickml/plugin-search-shared'
+import { getNodes } from '@magickml/plugin-search-shared'
 
 /**
  * Service for Google search functionality
@@ -19,7 +19,7 @@ import { googleSearch } from './services/google-search/google-search'
  */
 const SearchPlugin = new ServerPlugin({
   name: 'SearchPlugin',
-  nodes: Nodes(),
+  nodes: getNodes(),
   services: [googleSearch],
 })
 

--- a/plugins/search/server/src/services/google-search/google-search.ts
+++ b/plugins/search/server/src/services/google-search/google-search.ts
@@ -1,4 +1,4 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * Initializes the GoogleSearchService and its hooks via `app.configured`.
  * Registers the GoogleSearchService on the Feathers application.
@@ -6,16 +6,23 @@
  * @returns void
  */
 
-import type { Application } from '@magickml/server-core';
-import { GoogleSearchService } from './google-search.class';
+import type { Application } from '@magickml/server-core'
+import { GoogleSearchService } from './google-search.class'
 
-export * from './google-search.class';
+// Add this service to the service type index
+declare module '@magickml/server-core' {
+  interface ServiceTypes {
+    'google-search': GoogleSearchService
+  }
+}
+
+export * from './google-search.class'
 
 export const googleSearch = (app: Application): void => {
   app.use('google-search', new GoogleSearchService(), {
     methods: ['find'], // Exposes the 'find' method of the GoogleSearchService externally.
     events: [], // Can add custom events to be sent to clients.
-  });
+  })
 
   app.service('google-search').hooks({
     around: {
@@ -23,9 +30,6 @@ export const googleSearch = (app: Application): void => {
     },
     before: {
       all: [],
-      get: [],
-      create: [],
-      update: [],
     },
     after: {
       all: [],
@@ -33,5 +37,5 @@ export const googleSearch = (app: Application): void => {
     error: {
       all: [],
     },
-  });
-};
+  })
+}

--- a/plugins/search/shared/src/index.ts
+++ b/plugins/search/shared/src/index.ts
@@ -1,17 +1,15 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * This is the main file exporting the nodes used in the app
  */
 
- import { MagickComponent } from '@magickml/core';
- import { SearchGoogle } from './nodes/SearchGoogle';
+import { MagickComponent } from '@magickml/core'
+import { SearchGoogle } from './nodes/SearchGoogle'
 
- /**
-  * Export an array of all nodes used in the app.
-  * @returns MagickComponent[]
-  */
- export default function getNodes(): MagickComponent[] {
-   return [
-     SearchGoogle
-   ];
- }
+/**
+ * Export an array of all nodes used in the app.
+ * @returns MagickComponent[]
+ */
+export default function getNodes(): MagickComponent<any>[] {
+  return [new SearchGoogle()]
+}

--- a/plugins/search/shared/src/index.ts
+++ b/plugins/search/shared/src/index.ts
@@ -10,6 +10,6 @@ import { SearchGoogle } from './nodes/SearchGoogle'
  * Export an array of all nodes used in the app.
  * @returns MagickComponent[]
  */
-export default function getNodes(): MagickComponent<any>[] {
-  return [new SearchGoogle()]
+export function getNodes(): MagickComponent<any>[] {
+  return [SearchGoogle]
 }


### PR DESCRIPTION
This PR fixes some errors I was facing when trying to build the Editor from scratch. They are all centered around the Google Search plugin.

Not going to lie though; I have no idea how to test these to make sure I didn't just break the plugin. The build errors are gone, but I'm not sure if I actually fixed things or made it worse.

My main concern are with:

```
// plugins/search/server/src/index.ts
...
nodes: Nodes()
...
```

and

```
//plugins/search/shared/src/index.ts
...
return [new SearchGoogle()]
...
```