### PR TITLE
Remove old build instructions.

### DIFF
--- a/build_notes.md
+++ b/build_notes.md
@@ -1,6 +1,0 @@
-# Commands
-
-`lerna bootstrap --use-workspaces`
-Installs all dependencies in the workspace and links them together
-
-``


### PR DESCRIPTION
The current build instructions are:

```
npm install --global nx
npm install --global knex
git clone https://github.com/Oneirocom/Magick magick -b development
cd magick
npm install
npm run dev
```

Remove the old build instructions.