### PR TITLE
Add a completion provider for 11labs text2Speech

### DIFF
--- a/packages/core/shared/src/engine.ts
+++ b/packages/core/shared/src/engine.ts
@@ -141,7 +141,8 @@ export type MagicComponentCategory =
   | ' Esoterica'
   | 'Ethereum'
   | 'Pinecone'
-  | 'Search';
+  | 'Search'
+  | 'Audio';
 
 // MagickComponent abstract class
 export abstract class MagickComponent<WorkerReturnType> extends MagickEngineComponent<WorkerReturnType> {

--- a/packages/core/shared/src/nodes/audio/textToSpeech.ts
+++ b/packages/core/shared/src/nodes/audio/textToSpeech.ts
@@ -162,40 +162,35 @@ export class TextToSpeech extends MagickComponent<Promise<WorkerReturn>> {
     const completionProviders = pluginManager.getCompletionProviders('audio', [
       'text2speech',
     ]) as CompletionProvider[]
-
+  
     const model = (node.data as { model: string }).model as string
     const provider = completionProviders.find(provider =>
       provider.models.includes(model)
     ) as CompletionProvider
-
+  
     const completionHandler = provider.handler
-
+  
     if (!completionHandler) {
       console.error('No completion handler found for provider', provider)
       throw new Error('ERROR: Completion handler undefined')
     }
-
+  
     const { success, result, error } = await completionHandler({
       node,
       inputs,
       outputs,
       context,
     })
-
+  
     if (!success) {
       throw new Error('ERROR: ' + error)
     }
 
-    // Convert ArrayBuffer to Blob
-    // @ts-ignore
-    const audioBuffer = result as ArrayBuffer;
-    const audioBlob = new Blob([audioBuffer], { type: 'audio/wav' });
-
-    // Create a Blob URL
-    const audioUrl = URL.createObjectURL(audioBlob);
-
+    const audio = result as string
+  
+  
     return {
-      result: audioUrl,
+      result: audio,
     }
   }
 }

--- a/packages/core/shared/src/nodes/audio/textToSpeech.ts
+++ b/packages/core/shared/src/nodes/audio/textToSpeech.ts
@@ -1,0 +1,201 @@
+// UNDOCUMENTED
+import Rete from 'rete'
+import { DropdownControl } from '../../dataControls/DropdownControl'
+import { MagickComponent } from '../../engine'
+import { pluginManager } from '../../plugin'
+import { triggerSocket } from '../../sockets'
+import {
+  CompletionInspectorControls,
+  CompletionProvider,
+  CompletionSocket,
+  EngineContext,
+  MagickNode,
+  MagickWorkerInputs,
+  MagickWorkerOutputs,
+  WorkerData,
+} from '../../types'
+
+/** Information related to the GenerateText */
+const info = 'Generate speech using any of the providers available in Magick.'
+
+/** Type definition for the worker return */
+type WorkerReturn = {
+  result?: string
+}
+
+/**
+ * TextToSpeech component responsible for generating speech from text using any providers
+ * available in Magick.
+ */
+export class TextToSpeech extends MagickComponent<Promise<WorkerReturn>> {
+  constructor() {
+    super(
+      'Text to Speech',
+      {
+        outputs: {
+          result: 'output',
+          trigger: 'option',
+        },
+      },
+      'Audio',
+      info
+    )
+  }
+
+  /**
+   * Builder for generating speech.
+   * @param node - the MagickNode instance.
+   * @returns a configured node with data generated from providers.
+   */
+  builder(node: MagickNode) {
+    const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)
+    const dataOutput = new Rete.Output('trigger', 'Trigger', triggerSocket)
+
+    // get completion providers for text and chat categories
+    const completionProviders = pluginManager.getCompletionProviders('audio', [
+      'text2speech',
+    ]) as CompletionProvider[]
+
+    // get the models from the completion providers and flatten into a single array
+    const models = completionProviders.map(provider => provider.models).flat()
+
+    const modelName = new DropdownControl({
+      name: 'Model Name',
+      dataKey: 'model',
+      values: models,
+      defaultValue: models[0],
+    })
+
+    node.inspector.add(modelName)
+
+    node.addInput(dataInput).addOutput(dataOutput)
+
+    let lastInputSockets: CompletionSocket[] | undefined = []
+    let lastOutputSockets: CompletionSocket[] | undefined = []
+    let lastInspectorControls: CompletionInspectorControls[] | undefined = []
+
+    /**
+     * Configure the provided node according to the selected model and provider.
+     */
+    const configureNode = () => {
+      const model = node.data.model as string
+      const provider = completionProviders.find(provider =>
+        provider.models.includes(model)
+      ) as CompletionProvider
+      const inspectorControls = provider.inspectorControls
+      const inputSockets = provider.inputs
+      const outputSockets = provider.outputs
+      const connections = node.getConnections()
+
+      // update inspector controls
+      if (inspectorControls !== lastInspectorControls) {
+        lastInspectorControls?.forEach(control => {
+          node.inspector.dataControls.delete(control.dataKey)
+        })
+        inspectorControls?.forEach(control => {
+          const _control = new control.type(control)
+          node.inspector.add(_control)
+        })
+        lastInspectorControls = inspectorControls
+      }
+      // update input sockets
+      if (inputSockets !== lastInputSockets) {
+        lastInputSockets?.forEach(socket => {
+          if (node.inputs.has(socket.socket)) {
+            connections.forEach(c => {
+              if (c.input.key === socket.socket)
+                this.editor?.removeConnection(c)
+            })
+
+            node.inputs.delete(socket.socket)
+          }
+        })
+        inputSockets.forEach(socket => {
+          node.addInput(new Rete.Input(socket.socket, socket.name, socket.type))
+        })
+        lastInputSockets = inputSockets
+      }
+      // update output sockets
+      if (outputSockets !== lastOutputSockets) {
+        lastOutputSockets?.forEach(socket => {
+          if (node.outputs.has(socket.socket))
+            node.outputs.delete(socket.socket)
+        })
+        outputSockets.forEach(socket => {
+          node.addOutput(
+            new Rete.Output(socket.socket, socket.name, socket.type)
+          )
+        })
+        lastOutputSockets = outputSockets
+      }
+    }
+
+    modelName.onData = (value: string) => {
+      node.data.model = value
+      configureNode()
+    }
+
+    if (!node.data.model) node.data.model = models[0]
+    configureNode()
+    return node
+  }
+
+  /**
+   * Worker for processing the generated audio.
+   * @param node - the worker data.
+   * @param inputs - worker inputs.
+   * @param outputs - worker outputs.
+   * @param context - engine context.
+   * @returns an object with the success status and result or error message.
+   */
+  async worker(
+    node: WorkerData,
+    inputs: MagickWorkerInputs,
+    outputs: MagickWorkerOutputs,
+    context: {
+      module: unknown
+      secrets: Record<string, string>
+      projectId: string
+      context: EngineContext
+    }
+  ) {
+    const completionProviders = pluginManager.getCompletionProviders('audio', [
+      'text2speech',
+    ]) as CompletionProvider[]
+
+    const model = (node.data as { model: string }).model as string
+    const provider = completionProviders.find(provider =>
+      provider.models.includes(model)
+    ) as CompletionProvider
+
+    const completionHandler = provider.handler
+
+    if (!completionHandler) {
+      console.error('No completion handler found for provider', provider)
+      throw new Error('ERROR: Completion handler undefined')
+    }
+
+    const { success, result, error } = await completionHandler({
+      node,
+      inputs,
+      outputs,
+      context,
+    })
+
+    if (!success) {
+      throw new Error('ERROR: ' + error)
+    }
+
+    // Convert ArrayBuffer to Blob
+    // @ts-ignore
+    const audioBuffer = result as ArrayBuffer;
+    const audioBlob = new Blob([audioBuffer], { type: 'audio/wav' });
+
+    // Create a Blob URL
+    const audioUrl = URL.createObjectURL(audioBlob);
+
+    return {
+      result: audioUrl,
+    }
+  }
+}

--- a/packages/core/shared/src/nodes/index.ts
+++ b/packages/core/shared/src/nodes/index.ts
@@ -6,6 +6,7 @@ import { ArrayVariable } from './array/ArrayVariable';
 import { GetValueFromArray } from './array/GetValueFromArray';
 import { JoinListComponent } from './array/JoinList';
 import { RemapArray } from './array/RemapArray';
+import { TextToSpeech } from './audio/textToSpeech';
 import { BooleanVariable } from './boolean/BooleanVariable';
 import { IsVariableTrue } from './boolean/IsVariableTrue';
 import { LogicalOperator } from './boolean/LogicalOperator';
@@ -107,6 +108,7 @@ export const components: Record<string, () => MagickComponent<unknown>> = {
   storeDocument: () => new StoreDocument(),
   getValueFromArray: () => new GetValueFromArray(),
   cosineSimilarity: () => new CosineSimilarity(),
+  textToSpeech: () => new TextToSpeech(),
 };
 
 /**

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -226,6 +226,7 @@ export type PubSubEvents = {
   $SAVE_SPELL_DIFF: (tabId: string) => string
   $CREATE_MESSAGE_REACTION_EDITOR: (tabId: string) => string
   $CREATE_PLAYTEST: (tabId: string) => string
+  $CREATE_MEDIAWINDOW: (tabId: string) => string
   $CREATE_INSPECTOR: (tabId: string) => string
   $CREATE_TEXT_EDITOR: (tabId: string) => string
   $CREATE_PROJECT_WINDOW: (tabId: string) => string
@@ -493,11 +494,13 @@ export type MessagingWebhookBody = {
   To: string
 }
 
-export type CompletionType = 'image' | 'text'
+export type CompletionType = 'image' | 'text' | 'audio'
 
 export type ImageCompletionSubtype = 'text2image' | 'image2image' | 'image2text'
 
 export type TextCompletionSubtype = 'text' | 'embedding' | 'chat'
+
+export type AudioCompletionSubtype = 'text2speech' | 'text2audio'
 
 export type CompletionSocket = {
   socket: string
@@ -521,7 +524,7 @@ export type CompletionInspectorControls = {
 export type CompletionProvider = {
   [x: string]: any
   type: CompletionType
-  subtype: ImageCompletionSubtype | TextCompletionSubtype
+  subtype: ImageCompletionSubtype | TextCompletionSubtype | AudioCompletionSubtype
   handler?: (attrs: {
     node: WorkerData
     inputs: MagickWorkerInputs

--- a/plugins/elevenlabs/client/.babelrc
+++ b/plugins/elevenlabs/client/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/js/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/plugins/elevenlabs/client/.eslintrc.json
+++ b/plugins/elevenlabs/client/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/plugins/elevenlabs/client/jest.config.ts
+++ b/plugins/elevenlabs/client/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'elevenlabs',
+  preset: '../../jest.preset.js',
+  globals: {},
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/plugins/elevenlabs/client',
+}

--- a/plugins/elevenlabs/client/package.json
+++ b/plugins/elevenlabs/client/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@magickml/plugin-elevenlabs-client",
+  "version": "0.1.0"
+}

--- a/plugins/elevenlabs/client/project.json
+++ b/plugins/elevenlabs/client/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "@magickml/plugin-elevenlabs-client",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "plugins/elevenlabs/client/src",
+  "projectType": "library",
+  "implicitDependencies": ["@magickml/core"],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["plugins/elevenlabs/client/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "plugins/elevenlabs/client/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/plugins/elevenlabs/client/src/index.ts
+++ b/plugins/elevenlabs/client/src/index.ts
@@ -1,0 +1,55 @@
+// DOCUMENTED 
+/**
+ * A plugin for interacting with elevenlabs's API.
+ * @class
+ */
+import { ClientPlugin, InputControl } from '@magickml/core'
+import shared from '@magickml/plugin-elevenlabs-shared'
+
+// Importing shared variables from plugin-elevenlabs-shared module
+const { secrets, completionProviders } = shared
+
+// Input controls for textToSpeech completion
+const textToSpeechControls = [
+  {
+    type: InputControl,
+    dataKey: 'stability',
+    name: 'Stability (0-1.0)',
+    icon: 'moon',
+    defaultValue: 0,
+  },
+  {
+    type: InputControl,
+    dataKey: 'similarity_boost',
+    name: 'Similarity Boost (0-1.0)',
+    icon: 'moon',
+    defaultValue: 0,
+  },
+  {
+    type: InputControl,
+    dataKey: 'voice_id',
+    name: 'Voice ID',
+    icon: 'moon',
+    defaultValue: '',
+  },
+];
+
+// Object containing all input controls for different completion types
+const inspectorControls = {
+  text2speech: textToSpeechControls,
+}
+
+// Creating a new elevenlabsPlugin instance
+const elevenlabsPlugin = new ClientPlugin({
+  name: 'elevenlabsPlugin',
+  secrets, // API Key and Model ID secrets
+  completionProviders: completionProviders.map(provider => {
+    // Adding custom input controls for each completion type 
+    return {
+      ...provider,
+      inspectorControls: inspectorControls[provider.subtype],
+    }
+  }),
+})
+
+export default elevenlabsPlugin

--- a/plugins/elevenlabs/client/tsconfig.json
+++ b/plugins/elevenlabs/client/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "rootDir": "../../..",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": [
+      "vite/client"
+    ]
+  },
+  "files": [],
+  "include": [
+    "src"
+  ]
+}

--- a/plugins/elevenlabs/client/tsconfig.lib.json
+++ b/plugins/elevenlabs/client/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "module": "esnext",
+    "types": ["node"],
+    "esModuleInterop": true, 
+
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/plugins/elevenlabs/client/tsconfig.spec.json
+++ b/plugins/elevenlabs/client/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/plugins/elevenlabs/server/.babelrc
+++ b/plugins/elevenlabs/server/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/js/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/plugins/elevenlabs/server/.eslintrc.json
+++ b/plugins/elevenlabs/server/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/plugins/elevenlabs/server/jest.config.ts
+++ b/plugins/elevenlabs/server/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'elevenlabs',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/plugin-elevenlabs/server'
+};

--- a/plugins/elevenlabs/server/package.json
+++ b/plugins/elevenlabs/server/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@magickml/plugin-elevenlabs-server",
+  "version": "0.1.0"
+}

--- a/plugins/elevenlabs/server/project.json
+++ b/plugins/elevenlabs/server/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "@magickml/plugin-elevenlabs-server",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "plugin-elevenlabs/server/src",
+  "projectType": "library",
+  "implicitDependencies": ["@magickml/core"],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["plugin/elevenlabs-server/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "plugin/elevenlabs-server/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/plugins/elevenlabs/server/src/functions/index.ts
+++ b/plugins/elevenlabs/server/src/functions/index.ts
@@ -1,0 +1,5 @@
+// DOCUMENTED 
+/** 
+ * Exporting necessary modules for external use.
+ */
+export * from './textToSpeech';

--- a/plugins/elevenlabs/server/src/functions/textToSpeech.ts
+++ b/plugins/elevenlabs/server/src/functions/textToSpeech.ts
@@ -21,7 +21,7 @@ async function callTextToSpeechApi(text: string, voice_id: string, stability: nu
     headers: {
       'xi-api-key': apiKey
     },
-    responseType: 'arraybuffer'
+    responseType: 'blob'
   });
 
   return response.data;
@@ -39,17 +39,19 @@ export async function textToSpeech(
   const { node, inputs, context } = data
 
   const settings = {
-    stability: parseFloat(inputs['stability']?.[0] as string ?? "0.0"),
-    similarity_boost: parseFloat(inputs['similarity_boost']?.[0] as string ?? "0.0"),
-    voice_id: inputs['voice_id']?.[0] as string
+    stability: parseFloat(node?.data?.stability as string ?? "0.5"),
+    similarity_boost: parseFloat(node?.data?.stability as string ?? "0.5"),
+    voice_id: node?.data.voice_id as string ?? 'MF3mGyEYCl7XYWbV9V6O'
   }
-
+  
   const text = inputs['input']?.[0] as string
 
   // @ts-ignore
   const key = context.module.secrets['elevenlabs_api_key'] as string
   try {
-    const audioBuffer = await callTextToSpeechApi(text, 'MF3mGyEYCl7XYWbV9V6O', settings.stability, settings.similarity_boost, key);
+    const audioBuffer = await callTextToSpeechApi(text, settings.voice_id, settings.stability, settings.similarity_boost, key);
+
+    // TODO: handle event storage
 
     if (audioBuffer) {
       return { success: true, result: audioBuffer }

--- a/plugins/elevenlabs/server/src/functions/textToSpeech.ts
+++ b/plugins/elevenlabs/server/src/functions/textToSpeech.ts
@@ -1,0 +1,61 @@
+// UNDOCUMENTED 
+import {
+  CompletionHandlerInputData,
+  Event,
+  saveRequest
+} from '@magickml/core'
+import axios from 'axios'
+
+
+async function callTextToSpeechApi(text: string, voice_id: string, stability: number, similarity_boost: number, apiKey: string) {
+  const apiUrl = `https://api.elevenlabs.io/v1/text-to-speech/${voice_id}`
+  const requestBody = {
+    text,
+    voice_settings: {
+      stability,
+      similarity_boost
+    }
+  }
+
+  const response = await axios.post(apiUrl, requestBody, {
+    headers: {
+      'xi-api-key': apiKey
+    },
+    responseType: 'arraybuffer'
+  });
+
+  return response.data;
+}
+
+
+/**
+ * Generate speech from text.
+ * @param data - CompletionHandlerInputData object.
+ * @returns An object with success status and either a result or an error message.
+ */
+export async function textToSpeech(
+  data: CompletionHandlerInputData
+): Promise<{ success: boolean, result?: ArrayBuffer | null, error?: string | null }> {
+  const { node, inputs, context } = data
+
+  const settings = {
+    stability: parseFloat(inputs['stability']?.[0] as string ?? "0.0"),
+    similarity_boost: parseFloat(inputs['similarity_boost']?.[0] as string ?? "0.0"),
+    voice_id: inputs['voice_id']?.[0] as string
+  }
+
+  const text = inputs['input']?.[0] as string
+
+  // @ts-ignore
+  const key = context.module.secrets['elevenlabs_api_key'] as string
+  try {
+    const audioBuffer = await callTextToSpeechApi(text, 'MF3mGyEYCl7XYWbV9V6O', settings.stability, settings.similarity_boost, key);
+
+    if (audioBuffer) {
+      return { success: true, result: audioBuffer }
+    }
+    return { success: false, error: 'No result' }
+  } catch (err: any) {
+    return { success: false, error: err.message }
+  }
+}

--- a/plugins/elevenlabs/server/src/index.ts
+++ b/plugins/elevenlabs/server/src/index.ts
@@ -1,0 +1,46 @@
+// DOCUMENTED
+/**
+ * A plugin for the @magickml/core that adds elevenlabs completion functionality
+ *
+ * @remarks
+ * The plugin uses handlers for text, chat and text embedding which are defined in the 'makeTextCompletion',
+ * 'makeChatCompletion' and 'makeTextEmbedding' functions respectively.
+ *
+ * @packageDocumentation
+ */
+
+import { ServerPlugin } from '@magickml/core'
+import shared from '@magickml/plugin-elevenlabs-shared'
+import {
+  textToSpeech,
+} from './functions'
+
+/**
+ * The secrets used by the elevenlabs API
+ */
+const { secrets } = shared
+
+/**
+ * The handlers for each type of elevenlabs completion
+ */
+const completionHandlers = {
+  audio: {
+    'text2speech': textToSpeech,
+  },
+}
+
+/**
+ * A server plugin for the @magickml/core that adds elevenlabs completion functionality
+ */
+const elevenlabsPlugin = new ServerPlugin({
+  name: 'elevenlabsPlugin',
+  secrets,
+  completionProviders: shared.completionProviders.map(provider => {
+    return {
+      ...provider,
+      handler: completionHandlers[provider.type][provider.subtype],
+    }
+  }),
+})
+
+export default elevenlabsPlugin

--- a/plugins/elevenlabs/server/tsconfig.json
+++ b/plugins/elevenlabs/server/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "rootDir": "../../..",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": [
+      "vite/client"
+    ]
+  },
+  "files": [],
+  "include": [
+    "src"
+, "../../server-core/src/services/Upload.class.ts"  ]
+}

--- a/plugins/elevenlabs/server/tsconfig.lib.json
+++ b/plugins/elevenlabs/server/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "module": "esnext",
+    "types": ["node"],
+    "esModuleInterop": true, 
+
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/plugins/elevenlabs/server/tsconfig.spec.json
+++ b/plugins/elevenlabs/server/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/plugins/elevenlabs/shared/.babelrc
+++ b/plugins/elevenlabs/shared/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/js/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/plugins/elevenlabs/shared/.eslintrc.json
+++ b/plugins/elevenlabs/shared/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/plugins/elevenlabs/shared/jest.config.ts
+++ b/plugins/elevenlabs/shared/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'elevenlabs',
+  preset: '../../jest.preset.js',
+  globals: {},
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/plugins/elevenlabs/shared',
+}

--- a/plugins/elevenlabs/shared/package.json
+++ b/plugins/elevenlabs/shared/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@magickml/plugin-elevenlabs-shared",
+  "version": "0.1.0"
+}

--- a/plugins/elevenlabs/shared/project.json
+++ b/plugins/elevenlabs/shared/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "@magickml/plugin-elevenlabs-shared",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "plugins/elevenlabs/shared/src",
+  "projectType": "library",
+  "implicitDependencies": ["@magickml/core"],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["plugins/elevenlabs/shared/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "plugins/elevenlabs/shared/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/plugins/elevenlabs/shared/src/index.ts
+++ b/plugins/elevenlabs/shared/src/index.ts
@@ -1,0 +1,51 @@
+// DOCUMENTED 
+import {
+  arraySocket,
+  CompletionProvider,
+  PluginSecret,
+  stringSocket,
+} from "@magickml/core";
+
+/**
+ * An array of PluginSecret objects containing information about API key secrets.
+ */
+const secrets: PluginSecret[] = [
+  {
+    name: "ElevenLabs API Key",
+    key: "elevenlabs_api_key",
+    global: true,
+    getUrl: "https://beta.elevenlabs.io/",
+  },
+];
+
+/**
+ * An array of CompletionProvider objects containing information about supported completion providers.
+ */
+const completionProviders: CompletionProvider[] = [
+  {
+    type: "audio",
+    subtype: "text2speech",
+    inputs: [
+      {
+        socket: "input",
+        name: "Input",
+        type: stringSocket,
+      },
+    ],
+    outputs: [
+      {
+        socket: "result",
+        name: "Result",
+        type: stringSocket,
+      }
+    ],
+    models: [
+      "elevenlabs",
+    ],
+  },
+];
+
+export default {
+  secrets,
+  completionProviders,
+};

--- a/plugins/elevenlabs/shared/tsconfig.json
+++ b/plugins/elevenlabs/shared/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "rootDir": "../../..",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": [
+      "vite/client"
+    ]
+  },
+  "files": [],
+  "include": [
+    "src"
+  ]
+}

--- a/plugins/elevenlabs/shared/tsconfig.lib.json
+++ b/plugins/elevenlabs/shared/tsconfig.lib.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "module": "esnext",
+    "types": ["node"],
+    "esModuleInterop": true, 
+
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/plugins/elevenlabs/shared/tsconfig.spec.json
+++ b/plugins/elevenlabs/shared/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,51 +11,27 @@
     "jsx": "react",
     "target": "esnext",
     "module": "esnext",
-    "lib": [
-      "es2021",
-      "dom"
-    ],
+    "lib": ["es2021", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "esModuleInterop": true,
-    "typeRoots": [
-      "./packages/@types",
-      "./node_modules/@types"
-    ],
+    "typeRoots": ["./packages/@types", "./node_modules/@types"],
     "paths": {
-      "@magickml/agent": [
-        "apps/agent/src/index.ts"
+      "@magickml/agent": ["apps/agent/src/index.ts"],
+      "@magickml/client": ["apps/client/src/index.ts"],
+      "@magickml/client-core": ["packages/core/client/src/index.ts"],
+      "@magickml/core": ["packages/core/shared/src/index.ts"],
+      "@magickml/docs": ["apps/docs/src/index.ts"],
+      "@magickml/editor": ["packages/editor/src/index.ts"],
+      "@magickml/plugin-avatar-client": ["plugins/avatar/client/src/index.ts"],
+      "@magickml/plugin-banana-client": ["plugins/banana/client/src/index.ts"],
+      "@magickml/plugin-banana-server": ["plugins/banana/server/src/index.ts"],
+      "@magickml/plugin-bluesky-client": [
+        "plugins/bluesky/client/src/index.ts"
       ],
-      "@magickml/client": [
-        "apps/client/src/index.ts"
-      ],
-      "@magickml/client-core": [
-        "packages/core/client/src/index.ts"
-      ],
-      "@magickml/docs": [
-        "apps/docs/src/index.ts"
-      ],
-      "@magickml/editor": [
-        "packages/editor/src/index.ts"
-      ],
-      "@magickml/core": [
-        "packages/core/shared/src/index.ts"
-      ],
-      "@magickml/server": [
-        "apps/server/src/index.ts"
-      ],
-      "@magickml/server-core": [
-        "packages/core/server/src/index.ts"
-      ],
-      "@magickml/types": [
-        "packages/@types/src/index.ts"
-      ],
-      "@magickml/plugin-banana-client": [
-        "plugins/banana/client/src/index.ts"
-      ],
-      "@magickml/plugin-banana-server": [
-        "plugins/banana/server/src/index.ts"
+      "@magickml/plugin-bluesky-server": [
+        "plugins/bluesky/server/src/index.ts"
       ],
       "@magickml/plugin-discord-client": [
         "plugins/discord/client/src/index.ts"
@@ -90,21 +66,8 @@
       "@magickml/plugin-finetune-server": [
         "plugins/finetune/server/src/index.ts"
       ],
-      "@magickml/plugin-loop-client": [
-        "plugins/loop/client/src/index.ts"
-      ],
-      "@magickml/plugin-loop-server": [
-        "plugins/loop/server/src/index.ts"
-      ],
-      "@magickml/plugin-openai-client": [
-        "plugins/openai/client/src/index.ts"
-      ],
-      "@magickml/plugin-openai-server": [
-        "plugins/openai/server/src/index.ts"
-      ],
-      "@magickml/plugin-openai-shared": [
-        "plugins/openai/shared/src/index.ts"
-      ],
+      "@magickml/plugin-gmail-client": ["plugins/gmail/client/src/index.ts"],
+      "@magickml/plugin-gmail-server": ["plugins/gmail/server/src/index.ts"],
       "@magickml/plugin-googleai-client": [
         "plugins/googleai/client/src/index.ts"
       ],
@@ -113,15 +76,6 @@
       ],
       "@magickml/plugin-googleai-shared": [
         "plugins/googleai/shared/src/index.ts"
-      ],
-      "@magickml/plugin-pinecone-client": [
-        "plugins/pinecone/client/src/index.ts"
-      ],
-      "@magickml/plugin-pinecone-server": [
-        "plugins/pinecone/server/src/index.ts"
-      ],
-      "@magickml/plugin-pinecone-shared": [
-        "plugins/pinecone/shared/src/index.ts"
       ],
       "@magickml/plugin-langchain-client": [
         "plugins/langchain/client/src/index.ts"
@@ -132,49 +86,39 @@
       "@magickml/plugin-langchain-shared": [
         "plugins/langchain/shared/src/index.ts"
       ],
-      "@magickml/plugin-rest-client": [
-        "plugins/rest/client/src/index.ts"
+      "@magickml/plugin-loop-client": ["plugins/loop/client/src/index.ts"],
+      "@magickml/plugin-loop-server": ["plugins/loop/server/src/index.ts"],
+      "@magickml/plugin-openai-client": ["plugins/openai/client/src/index.ts"],
+      "@magickml/plugin-openai-server": ["plugins/openai/server/src/index.ts"],
+      "@magickml/plugin-openai-shared": ["plugins/openai/shared/src/index.ts"],
+      "@magickml/plugin-elevenlabs-client": ["plugins/elevenlabs/client/src/index.ts"],
+      "@magickml/plugin-elevenlabs-server": ["plugins/elevenlabs/server/src/index.ts"],
+      "@magickml/plugin-elevenlabs-shared": ["plugins/elevenlabs/shared/src/index.ts"],
+      "@magickml/plugin-pinecone-client": [
+        "plugins/pinecone/client/src/index.ts"
       ],
-      "@magickml/plugin-rest-server": [
-        "plugins/rest/server/src/index.ts"
+      "@magickml/plugin-pinecone-server": [
+        "plugins/pinecone/server/src/index.ts"
       ],
-      "@magickml/plugin-search-client": [
-        "plugins/search/client/src/index.ts"
+      "@magickml/plugin-pinecone-shared": [
+        "plugins/pinecone/shared/src/index.ts"
       ],
-      "@magickml/plugin-search-server": [
-        "plugins/search/server/src/index.ts"
-      ],
-      "@magickml/plugin-search-shared": [
-        "plugins/search/shared/src/index.ts"
-      ],
+      "@magickml/plugin-qa-server": ["plugins/qa/server/src/index.ts"],
+      "@magickml/plugin-rest-client": ["plugins/rest/client/src/index.ts"],
+      "@magickml/plugin-rest-server": ["plugins/rest/server/src/index.ts"],
+      "@magickml/plugin-search-client": ["plugins/search/client/src/index.ts"],
+      "@magickml/plugin-search-server": ["plugins/search/server/src/index.ts"],
+      "@magickml/plugin-search-shared": ["plugins/search/shared/src/index.ts"],
       "@magickml/plugin-twitter-client": [
         "plugins/twitter/client/src/index.ts"
       ],
       "@magickml/plugin-twitter-server": [
         "plugins/twitter/server/src/index.ts"
       ],
-      "@magickml/plugin-qa-server": [
-        "plugins/qa/server/src/index.ts"
-      ],
-      "@magickml/plugin-avatar-client": [
-        "plugins/avatar/client/src/index.ts"
-      ],
-      "@magickml/plugin-bluesky-client": [
-        "plugins/bluesky/client/src/index.ts"
-      ],
-      "@magickml/plugin-bluesky-server": [
-        "plugins/bluesky/server/src/index.ts"
-      ],
-      "@magickml/plugin-gmail-client": [
-        "plugins/gmail/client/src/index.ts"
-      ],
-      "@magickml/plugin-gmail-server": [
-        "plugins/gmail/server/src/index.ts"
-      ]
+      "@magickml/server": ["apps/server/src/index.ts"],
+      "@magickml/server-core": ["packages/core/server/src/index.ts"],
+      "@magickml/types": ["packages/@types/src/index.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## What Changed:

A plugin for eleven labs has been added which adds a completion provider for text2Speech.

## How to test:

Setup your .env.local to include the plugin 'elevenlabs'
Use the new text to speech node under the Audio category.

## Additional information:

It is currently returning a blob array, and until we have a storage direction, will not play well with connectors such as discord.
