### PR TITLE
Switch to the React PostHogProvider

### DIFF
--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -8,7 +8,7 @@ import {
   POSTHOG_API_KEY,
   POSTHOG_ENABLED,
 } from '@magickml/core'
-import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
 
 import plugins from './plugins'
 
@@ -37,20 +37,13 @@ if (window === window.parent) {
     token: '',
   }
 
-  // Initialize posthog
-  if (POSTHOG_ENABLED === 'true') {
-    console.log('Posthog enabled')
-    posthog.init(POSTHOG_API_KEY, {
-      api_host: 'https://app.posthog.com',
-    })
-  }
-
   const Root = () => <MagickIDE config={config} />
+
   root.render(<Root />)
 } else {
-/**
- * If the editor is loaded in an iframe, listen for messages from the parent to initialize and render the MagickIDE component
- */
+  /**
+   * If the editor is loaded in an iframe, listen for messages from the parent to initialize and render the MagickIDE component
+   */
   window.addEventListener(
     'message',
     event => {
@@ -82,16 +75,23 @@ if (window === window.parent) {
       if (type === 'INIT') {
         // TODO: store configuration in localstorage
         const { config } = payload
-
-        // Initialize posthog
-        if (POSTHOG_ENABLED) {
-          console.log('Posthog enabled')
-          posthog.init(POSTHOG_API_KEY, {
-            api_host: 'https://app.posthog.com',
-          })
+        const Root = () => {
+          if (POSTHOG_ENABLED === 'true') {
+            console.log('Posthog enabled')
+            return (
+              <PostHogProvider
+                apiKey={POSTHOG_API_KEY}
+                options={{
+                  api_host: 'https://app.posthog.com',
+                }}
+              >
+                <MagickIDE config={config} />
+              </PostHogProvider>
+            )
+          } else {
+            return <MagickIDE config={config} />
+          }
         }
-
-        const Root = () => <MagickIDE config={config} />
         const container = document.getElementById('root')
         const root = createRoot(container) // createRoot(container!) if you use TypeScript
         ;(window as any).root = root


### PR DESCRIPTION
## What Changed:

I was troubleshooting posthog as I thought it was not working. Turns out I has adblock on! lol
This is a quick improvement i made while troubleshooting that, it switches to using the PosthogProvider component so that we can integrate things missed as metioned by @Knar33 here https://github.com/Oneirocom/Magick/pull/704#pullrequestreview-1400354771 easier.

## How to test:
setup your envs
```
VITE_APP_POSTHOG_ENABLED=false
VITE_APP_POSTHOG_API_KEY=key
```
and then login to posthog to check for events/recordings.
