### PR TITLE
Fixed deleting spell

### DIFF
--- a/packages/core/client/src/components/Drawer/index.tsx
+++ b/packages/core/client/src/components/Drawer/index.tsx
@@ -8,22 +8,25 @@ import StorageIcon from '@mui/icons-material/Storage'
 import Divider from '@mui/material/Divider'
 import MuiDrawer from '@mui/material/Drawer'
 import List from '@mui/material/List'
+import { IGNORE_AUTH, VITE_APP_TRUSTED_PARENT_URL } from '@magickml/core'
 import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import { CSSObject, styled, Theme } from '@mui/material/styles'
 import { useEffect, useState } from 'react'
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
   ProjectWindowProvider,
-  useProjectWindow
+  useProjectWindow,
 } from '../../contexts/ProjectWindowContext'
 import ProjectWindow from './ProjectWindow'
 import MagickLogo from './purple-logo-full.png'
 import MagickLogoSmall from './purple-logo-small.png'
 import { SetAPIKeys } from './SetAPIKeys'
-import ArticleIcon from '@mui/icons-material/Article';
+import ArticleIcon from '@mui/icons-material/Article'
+import DvrIcon from '@mui/icons-material/Dvr'
 
 // Constants
 const drawerWidth = 150
@@ -230,6 +233,13 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
     }
   }, [])
 
+  const handleClick = () => {
+    const URL = IGNORE_AUTH
+      ? 'http://localhost:3000/projects'
+      : `${VITE_APP_TRUSTED_PARENT_URL}/projects`
+    if (URL) window.open(URL)
+  }
+
   return (
     <div style={{ display: 'flex', height: '100%' }}>
       <StyledDrawer variant="permanent" open={openDrawer}>
@@ -251,6 +261,12 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
               alt=""
             />
           }
+          {openDrawer && (
+            <ArrowBackIosIcon
+              fontSize="small"
+              style={{ marginLeft: '1rem', color: '#ccc', cursor: 'pointer' }}
+            />
+          )}
         </DrawerHeader>
         <List
           sx={{
@@ -274,6 +290,13 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/agents')}
             text="Agents"
+          />
+          <DrawerItem
+            active={location.pathname.includes('/settings')}
+            Icon={DvrIcon}
+            open={openDrawer}
+            onClick={handleClick}
+            text="Projects"
           />
           <DrawerItem
             active={location.pathname === '/documents'}

--- a/packages/core/shared/src/config.ts
+++ b/packages/core/shared/src/config.ts
@@ -32,7 +32,7 @@ export const DATABASE_URL = getVarForEnvironment('DATABASE_URL')
 export const DEFAULT_PROJECT_ID =
   getVarForEnvironment('PROJECT_ID') || 'bb1b3d24-84e0-424e-b4f1-57603f307a89'
 export const DEFAULT_USER_ID = getVarForEnvironment('USER_ID') || '1234567890'
-export const SERVER_PORT = getVarForEnvironment('PORT') || "3030"
+export const SERVER_PORT = getVarForEnvironment('PORT') || '3030'
 export const SERVER_HOST = getVarForEnvironment('HOST') || 'localhost'
 export const SPEECH_SERVER_URL =
   getVarForEnvironment('SPEECH_SERVER_URL') || 'http://localhost:65532'
@@ -54,9 +54,11 @@ export const FILE_SERVER_URL =
 export const USESSL = getVarForEnvironment('USESSL') || false
 export const NODE_ENV = getVarForEnvironment('NODE_ENV') || 'development'
 
-export const PAGINATE_DEFAULT = getVarForEnvironment('PAGINATE_DEFAULT') || "10"
-export const PAGINATE_MAX = getVarForEnvironment('PAGINATE_MAX') || "100"
+export const PAGINATE_DEFAULT = getVarForEnvironment('PAGINATE_DEFAULT') || '10'
+export const PAGINATE_MAX = getVarForEnvironment('PAGINATE_MAX') || '100'
 export const JWT_SECRET = getVarForEnvironment('JWT_SECRET') || 'secret'
 
 export const POSTHOG_ENABLED = getVarForEnvironment('POSTHOG_ENABLED') || false
 export const POSTHOG_API_KEY = getVarForEnvironment('POSTHOG_API_KEY') || ''
+export const VITE_APP_TRUSTED_PARENT_URL =
+  getVarForEnvironment('VITE_APP_TRUSTED_PARENT_URL') || ''

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -83,9 +83,10 @@ const StartScreen = (): JSX.Element => {
   const onDelete = async (spellName): Promise<void> => {
     try {
       await deleteSpell({ spellName, projectId: config.projectId })
-      const [tab] = tabs.filter(tab => tab.URI === spellName)
+      const [tab] = tabs.filter(tab => tab.id === spellName)
       if (tab) {
         dispatch(closeTab(tab.id))
+        window.localStorage.removeItem(`zoomValues-${tab.id}`)
       }
     } catch (err) {
       console.error('Error deleting spell', err)


### PR DESCRIPTION
## What Changed:

- Added a chevron to indicate side drawer minimization
- Added link to the side drawer to open cloud projects in a new tab when clicked
- Delete spell remove it from the tab

## How to test:

- Open the side drawer and close it by clicking the arrow icon
- click on the projects menu in the side drawer
- Delete spell

## Additional information:

Refer to the attached video
