### PR TITLE
Adds overflow property to dropdown text

### DIFF
--- a/packages/core/client/src/components/Select/index.tsx
+++ b/packages/core/client/src/components/Select/index.tsx
@@ -1,4 +1,4 @@
-// DOCUMENTED 
+// DOCUMENTED
 import React, { useEffect, useRef } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import Creatable from 'react-select/creatable';
@@ -129,6 +129,7 @@ export const Select = ({
       flex: '1',
       alignItems: 'center',
       fontFamily: 'IBM Plex Mono',
+      overflow: 'clip',
     }),
     singleValue: () => ({
       color: 'rgba(255,255,255)',


### PR DESCRIPTION
## What Changed:

Added `overflow: clip` to dropdowns. See attached screenshots

Before
![before_pr](https://user-images.githubusercontent.com/1340967/235992838-e65dfecf-5222-4c62-950c-967b3a781cb7.png)


After
![after_pr](https://user-images.githubusercontent.com/1340967/235992957-4564e3f6-55fa-4889-9bd0-cb458f9871e8.png)
