### PR TITLE
fix gpt forgetting directive

### DIFF
--- a/packages/core/shared/src/nodes/text/TextVariable.ts
+++ b/packages/core/shared/src/nodes/text/TextVariable.ts
@@ -1,8 +1,8 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * Module represents a Rete flow based on Google code standards.
  * @module
- */ 
+ */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Rete from 'rete'
@@ -70,16 +70,16 @@ export class TextVariable extends MagickComponent<InputReturn> {
 
   /**
    * Function to operate a node of the TextVariable class.
-   * @param {WorkerData} node - The current state of the node representing the operation to be 
-   * performed. 
-   * @param {MagickWorkerInputs} inputs - The inputs of the node. In this case, this object is 
+   * @param {WorkerData} node - The current state of the node representing the operation to be
+   * performed.
+   * @param {MagickWorkerInputs} _inputs - The inputs of the node. In this case, this object is
    * not used.
    * @param {MagickWorkerOutputs} outputs - The possible outputs of the node.
    * @param {Object} context - The data passed to the worker and the module.
-   * @returns {InputReturn} - The outputs of the node. In this case, an object with the output 
+   * @returns {InputReturn} - The outputs of the node. In this case, an object with the output
    * string.
    */
-  worker(node: WorkerData, inputs: MagickWorkerInputs, 
+  worker(node: WorkerData, _inputs: MagickWorkerInputs,
     outputs: MagickWorkerOutputs, context: { module: { publicVariables: string } }) {
     let text = node.data.fewshot as string
     const publicVars = JSON.parse(context.module.publicVariables)

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -528,6 +528,12 @@ export type CompletionInspectorControls = {
   defaultValue: string
 }
 
+type HandlerResponse = {
+  success: boolean
+  result: string | number[]
+  error: string
+}
+
 export type CompletionProvider = {
   [x: string]: any
   type: CompletionType
@@ -537,7 +543,7 @@ export type CompletionProvider = {
     inputs: MagickWorkerInputs
     outputs: MagickWorkerOutputs
     context: unknown
-  }) => { success: boolean; result: string | number[]; error: string } // server only
+  }) => Promise<HandlerResponse> | HandlerResponse // server only
   inspectorControls?: CompletionInspectorControls[] // client only
   inputs: CompletionSocket[]
   outputs: CompletionSocket[]

--- a/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -1,4 +1,4 @@
-// DOCUMENTED 
+// DOCUMENTED
 import {
   ChatMessage,
   CompletionHandlerInputData,
@@ -58,11 +58,11 @@ export async function makeChatCompletion(
   // Initialize messages array and add elements
   let messages: ChatMessage[] = []
 
+  messages = [...messages, ...conversationMessages, userMessage]
+
   if (system) {
     messages.push(systemMessage)
   }
-
-  messages = [...messages, ...conversationMessages, userMessage]
 
   // Update the settings messages
   settings.messages = messages
@@ -70,7 +70,7 @@ export async function makeChatCompletion(
   // Create request headers
   const headers = {
     'Content-Type': 'application/json',
-    Authorization: 'Bearer ' + context.module.secrets['openai_api_key'],
+    Authorization: 'Bearer ' + context.module.secrets!['openai_api_key'],
   }
 
   try {


### PR DESCRIPTION
Should resolve #735 

## What Changed:

The system message is now always the last message in a conversation list sent to openai. 

This seems to prevent gpt from forgetting our directive and doesn't seem to affect the output at all (other than making it more strictly following the directive)

## How to test:

In the current development branch

Create a new discord bot spell.
Have a small conversation with it about AI.
I asked it to add some numbers then asked it how to explain AI to my boss.

Observe that after a few messages it seems to forget that its supposed to be a towel.

In my branch

follow the same steps and observe that it never forgets that its a towel.
