### PR TITLE
change inspector ports so that server and agent don't clash anymore

### DIFF
--- a/apps/agent/project.json
+++ b/apps/agent/project.json
@@ -13,7 +13,7 @@
       "options": {
         "target": "node",
         "compiler": "tsc",
-        "port": 7778,
+        "port": 7779,
         "inspect": true,
         "outputPath": "dist/apps/agent",
         "main": "apps/agent/src/index.ts",
@@ -40,7 +40,7 @@
       "options": {
         "buildTarget": "@magickml/agent:build",
         "inspect": true,
-        "port": 7778
+        "port": 7779
       },
       "configurations": {
         "production": {


### PR DESCRIPTION
## What Changed:

both agent and server were running their inspectors on port 7778, now server is on 7778 and agent is on 7779

## How to test:

check that both inspector servers are running on their correct parts.

