### PR TITLE
Fix windows build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,7 +233,6 @@
         "@nrwl/linter": "15.9.2",
         "@nrwl/node": "15.9.2",
         "@nrwl/nx-cloud": "15.3.5",
-        "@nrwl/nx-win32-x64-msvc": "^15.9.3",
         "@nrwl/react": "15.9.2",
         "@nrwl/vite": "15.9.2",
         "@nrwl/web": "15.9.2",
@@ -312,7 +311,8 @@
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "^0.17.11",
         "@esbuild/linux-x64": "^0.17.11",
-        "@nrwl/nx-linux-x64-gnu": "15.9.2"
+        "@nrwl/nx-linux-x64-gnu": "15.9.2",
+        "@nrwl/nx-win32-x64-msvc": "^15.9.3"
       },
       "peerDependencies": {
         "@discordjs/opus": "^0.9.0",
@@ -13866,7 +13866,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "optional": true,
       "os": [
         "win32"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,7 @@
         "@nrwl/linter": "15.9.2",
         "@nrwl/node": "15.9.2",
         "@nrwl/nx-cloud": "15.3.5",
+        "@nrwl/nx-win32-x64-msvc": "^15.9.3",
         "@nrwl/react": "15.9.2",
         "@nrwl/vite": "15.9.2",
         "@nrwl/web": "15.9.2",
@@ -13725,10 +13726,85 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.2.tgz",
+      "integrity": "sha512-qHfdluHlPzV0UHOwj1ZJ+qNEhzfLGiBuy1cOth4BSzDlvMnkuqBWoprfaXoztzYcus2NSILY1/7b3Jw4DAWmMw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.2.tgz",
+      "integrity": "sha512-0GzwbablosnYnnJDCJvAeZv8LlelSrNwUnGhe43saeoZdAew35Ay1E34zBrg/GCGTASuz+knEEYFM+gDD9Mc6A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.2.tgz",
+      "integrity": "sha512-3mFIY7iUTPG45hSIRaM2DmraCy8W6hNoArAGRrTgYw40BIJHtLrW+Rt7DLyvVXaYCvrKugWOKtxC+jG7kpIZVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.2.tgz",
+      "integrity": "sha512-FNBnXEtockwxZa4I3NqggrJp0YIbNokJvt/clrICP+ijOacdUDkv8mJedavobkFsRsNq9gzCbRbUScKymrOLrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.2",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.2.tgz",
       "integrity": "sha512-gHWsP5lbe4FNQCa1Q/VLxIuik+BqAOcSzyPjdUa4gCDcbxPa8xiE57PgXB5E1XUzOWNnDTlXa/Ll07/TIuKuog==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-x64-musl": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.2.tgz",
+      "integrity": "sha512-EaFUukCbmoHsYECX2AS4pxXH933yesBFVvBgD38DkoFDxDoJMVt6JqYwm+d5R7S4R2P9U3l++aurljQTRq567Q==",
       "cpu": [
         "x64"
       ],
@@ -13766,6 +13842,36 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.2.tgz",
+      "integrity": "sha512-PGAe7QMr51ivx1X3avvs8daNlvv1wGo3OFrobjlu5rSyjC1Y3qHwT9+wdlwzNZ93FIqWOq09s+rE5gfZRfpdAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.3.tgz",
+      "integrity": "sha512-gdnvqURKnu0EQGOFJ6NUKq6wSB+viNb7Z8qtKhzSmFwVjT8akOnLWn7ZhL9v28TAjLM7/s1Mwvmz/IMj1PGlcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nrwl/react": {
@@ -47894,6 +48000,21 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nx/node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.2",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.2.tgz",
+      "integrity": "sha512-Q8onNzhuAZ0l9DNkm8D4Z1AEIzJr8JiT4L2fVBLYrV/R75C2HS3q7lzvfo6oqMY6mXge1cFPcrTtg3YXBQaSWA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"

--- a/package.json
+++ b/package.json
@@ -269,7 +269,6 @@
     "@nrwl/linter": "15.9.2",
     "@nrwl/node": "15.9.2",
     "@nrwl/nx-cloud": "15.3.5",
-    "@nrwl/nx-win32-x64-msvc": "^15.9.3",
     "@nrwl/react": "15.9.2",
     "@nrwl/vite": "15.9.2",
     "@nrwl/web": "15.9.2",
@@ -348,7 +347,8 @@
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "^0.17.11",
     "@esbuild/linux-x64": "^0.17.11",
-    "@nrwl/nx-linux-x64-gnu": "15.9.2"
+    "@nrwl/nx-linux-x64-gnu": "15.9.2",
+    "@nrwl/nx-win32-x64-msvc": "^15.9.3"
   },
   "overrides": {
     "vite-plugin-markdown": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "Apache 2.0",
   "scripts": {
-    "dev": "NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent,@magickml/docs --parallel --maxParallel=100",
+    "dev": "cross-env NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent,@magickml/docs --parallel --maxParallel=100",
     "start": "node scripts/start-server.js",
     "start-server": "node dist/apps/server/main.js",
     "start-agent": "node dist/apps/agent/main.js",
@@ -269,6 +269,7 @@
     "@nrwl/linter": "15.9.2",
     "@nrwl/node": "15.9.2",
     "@nrwl/nx-cloud": "15.3.5",
+    "@nrwl/nx-win32-x64-msvc": "^15.9.3",
     "@nrwl/react": "15.9.2",
     "@nrwl/vite": "15.9.2",
     "@nrwl/web": "15.9.2",


### PR DESCRIPTION
## What Changed:

Building on Windows was not working because the dev script was only setting NX_NON_NATIVE_HASHER=true for mac/linux. I fixed this by using cross-env. Also added a nx-win32 as a optional dependency to fix another error.

## How to test:

Build and run Magick.

## Additional information:

n/a
