### PR TITLE
posthog env fix

### DIFF
--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -76,7 +76,7 @@ if (window === window.parent) {
         // TODO: store configuration in localstorage
         const { config } = payload
         const Root = () => {
-          if (POSTHOG_ENABLED === 'true') {
+          if (POSTHOG_ENABLED) {
             return (
               <PostHogProvider
                 apiKey={POSTHOG_API_KEY}

--- a/packages/core/shared/src/config.ts
+++ b/packages/core/shared/src/config.ts
@@ -58,7 +58,7 @@ export const PAGINATE_MAX = getVarForEnvironment('PAGINATE_MAX') || '100'
 export const JWT_SECRET = getVarForEnvironment('JWT_SECRET') || 'secret'
 
 export const POSTHOG_ENABLED =
-  getVarForEnvironment('POSTHOG_ENABLED') === 'true'
+  getVarForEnvironment('POSTHOG_ENABLED') === 'true' || false
 export const POSTHOG_API_KEY = getVarForEnvironment('POSTHOG_API_KEY') || ''
 export const REDISCLOUD_URL = getVarForEnvironment('REDISCLOUD_URL') || ''
 


### PR DESCRIPTION
## What Changed:
Posthog enabled env has been changed to return only a boolean from config.ts

## How to test:
set your envs to
```
VITE_APP_POSTHOG_ENABLED=true
VITE_APP_POSTHOG_API_KEY=posthog_key_here
```
and make sure events are being recorded.

## Additional information:
N/A