### PR TITLE
quick n dirty fix for the agent page not loading

### DIFF
--- a/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/windows/agents/AgentWindow/AgentDetails.tsx
@@ -347,7 +347,7 @@ const AgentDetails = ({
                 id={value.key}
                 style={{ width: '100%' }}
                 value={
-                  Object.keys(JSON.parse(selectedAgentData.secrets)).length !==
+                  selectedAgentData.secrets && Object.keys(JSON.parse(selectedAgentData.secrets)).length !==
                   0
                     ? JSON.parse(selectedAgentData.secrets)[value.key]
                     : ''


### PR DESCRIPTION
when importing eliza

## What Changed:

checked if secrets existed before trying to pass it to Object.keys on the AgentDetails page

## How to test:

import eliza and observe that you can get to the agent details page

## Additional information:

@lalalune it's a hack. Are you proud of me?