### PR TITLE
allows spellIds to be preserved on project import

### DIFF
--- a/packages/core/server/src/services/projects/projects.class.ts
+++ b/packages/core/server/src/services/projects/projects.class.ts
@@ -91,7 +91,6 @@ export class ProjectsService {
     })
 
     const mappedSpells = spells.map(spell => {
-      delete spell.id
       delete spell.updatedAt
       delete spell.creatorId
       spell.projectId = projectId

--- a/packages/core/server/src/services/spells/spells.schema.ts
+++ b/packages/core/server/src/services/spells/spells.schema.ts
@@ -18,7 +18,7 @@ export const spellExternalResolver = resolve<SpellInterface, HookContext>({})
 // Schema for creating new entries, removing additional fields
 export const spellDataSchema = Type.Pick(
   spellSchema,
-  ['name', 'projectId', 'graph', 'createdAt', 'updatedAt', 'hash'],
+  ['name', 'id', 'projectId', 'graph', 'createdAt', 'updatedAt', 'hash'],
   {
     $id: 'SpellData',
   }


### PR DESCRIPTION
## What Changed:

added 'id' to the create spell schema and removed the spell id delete line
