### PR TITLE
Fix authentication error on API and update API to new spell manager and run handler

### DIFF
--- a/packages/core/server/src/app.ts
+++ b/packages/core/server/src/app.ts
@@ -134,6 +134,11 @@ app.hooks({
     all: [
       logError,
       async (context: HookContext, next) => {
+        // if the route is to the api service, skip auth
+        if (context.path === 'api') {
+          return next()
+        }
+
         if (context.path !== 'authentication') {
           return authenticate('jwt')(context, next)
         }

--- a/plugins/rest/server/src/services/api/api.class.ts
+++ b/plugins/rest/server/src/services/api/api.class.ts
@@ -4,7 +4,7 @@
  * https://dove.feathersjs.com/guides/cli/service.class.html#custom-services
  */
 import type { Id, Params, ServiceInterface } from '@feathersjs/feathers'
-import { runSpell } from '@magickml/core'
+import { Agent, AgentManager, runSpell } from '@magickml/core'
 import { Application, app } from '@magickml/server-core'
 import type { Api, ApiData, ApiPatch, ApiQuery } from './api.schema'
 
@@ -47,8 +47,10 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
     id: Id,
     _params?: ServiceParams
   ): Promise<ApiGetResponse | any /* TODO: remove */> {
+    console.log('***** GET', id, _params)
     const { apiKey, content } = _params?.query as any // TODO: why is this error
-
+    const app = this.options.app
+    console.log('app', app)
     // Return error if apiKey is not specified.
     if (!apiKey) {
       return {
@@ -70,6 +72,8 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
     // Get the agent by id.
     const agent = await agentService.get(id)
 
+    console.log('***** agent', agent)
+
     const agentRestApiKey = agent?.data?.rest_api_key
 
     // Return error if the provided apiKey doesn't match the expected apiKey.
@@ -84,10 +88,27 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
       id: `no rootspell present for agent ${agent.name}`,
     }
 
+    const agentManager = new AgentManager(app)
+
+    // create a new Agent
+    const newAgent = new Agent(
+      {
+        id: agent.id,
+        name: agent.name,
+        projectId: agent.projectId,
+        secrets: agent.secrets,
+        publicVariables: agent.publicVariables,
+      },
+      agentManager,
+      app
+    )
+
+    const spell = await newAgent.spellManager.loadById(rootSpell.id)
+    console.log('spell loaded', spell)
+
     // Run the root spell.
-    const result = await runSpell({
+    const result = await newAgent.spellManager.run({
       spellId: rootSpell.id,
-      projectId: agent.projectId,
       inputs: {
         'Input - REST API (GET)': {
           connector: 'REST API (GET)',
@@ -99,14 +120,15 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
           agentId: agent.id,
           entities: ['api', agent.name],
           channel: id,
-          rawData: JSON.stringify({ id: id, params: _params }),
+          rawData: JSON.stringify({ id: id }),
         },
       },
       secrets: JSON.parse(agent.secrets ?? '{}'),
       publicVariables: agent.publicVariables,
       app,
-      agent,
     })
+
+    console.log('***** result', result)
 
     return {
       result,

--- a/plugins/rest/server/src/services/api/api.ts
+++ b/plugins/rest/server/src/services/api/api.ts
@@ -1,10 +1,10 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * For more information about this file see https://dove.feathersjs.com/guides/cli/service.html
  */
 
 // Import hooks from '@feathersjs/schema'
-import { hooks as schemaHooks } from '@feathersjs/schema';
+import { hooks as schemaHooks } from '@feathersjs/schema'
 
 // Import API resolvers and validators
 import {
@@ -14,26 +14,26 @@ import {
   apiQueryResolver,
   apiQueryValidator,
   apiResolver,
-} from './api.schema';
+} from './api.schema'
 
 // Import types and classes
-import type { Application } from '@magickml/server-core';
-import { ApiService, getOptions } from './api.class';
+import type { Application } from '@magickml/server-core'
+import { ApiService, getOptions } from './api.class'
 
 // Add this service to the service type index
 declare module '@magickml/server-core' {
   interface ServiceTypes {
-    [apiPath]: ApiService;
+    [apiPath]: ApiService
   }
 }
 
 // Constants for API path and methods
-export const apiPath = 'api';
-export const apiMethods = ['get', 'create', 'update', 'remove'] as const;
+export const apiPath = 'api'
+export const apiMethods = ['get', 'create', 'update', 'remove'] as const
 
 // Export class and schema files
-export * from './api.class';
-export * from './api.schema';
+export * from './api.class'
+export * from './api.schema'
 
 /**
  * A configure function that registers the service and its hooks via `app.configure`
@@ -46,7 +46,7 @@ export const api = (app: Application) => {
     methods: apiMethods,
     // You can add additional custom events to be sent to clients here
     events: [],
-  });
+  })
 
   // Initialize hooks
   app.service(apiPath).hooks({
@@ -78,5 +78,5 @@ export const api = (app: Application) => {
     error: {
       all: [],
     },
-  } as any); // TODO: fix me
-};
+  } as any) // TODO: fix me
+}


### PR DESCRIPTION
## What Changed:
This PR fixes the API connector.

NOTE: In progress, I need to make sure POST works as well

To get GET

```
async function test() {
    const output = await fetch('http://localhost:3030/api/e552337d-3a88-4ac9-af2d-fec929bec4e4?apiKey=88bac817bd7a004d4a0f1a26b0fcf0a7&content=Hello+World')
    const json = await output.json()
    console.log(json)
}

test();
```