### PR TITLE
Increase feathers limits to 1000

### DIFF
--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -95,7 +95,10 @@ export class DocumentService<
  */
 export const getOptions = (app: Application): KnexAdapterOptions => {
   return {
-    paginate: app.get('paginate'),
+    paginate: {
+      default: 1000,
+      max: 1000,
+    },
     Model: app.get('dbClient'),
     name: 'documents',
   }

--- a/packages/core/server/src/services/events/events.class.ts
+++ b/packages/core/server/src/services/events/events.class.ts
@@ -112,7 +112,10 @@ export class EventService<
  */
 export const getOptions = (app: Application): KnexAdapterOptions => {
   return {
-    paginate: app.get('paginate'),
+    paginate: {
+      default: 1000,
+      max: 1000,
+    },
     Model: app.get('dbClient'),
     name: 'events',
   }

--- a/packages/core/server/src/services/projects/projects.class.ts
+++ b/packages/core/server/src/services/projects/projects.class.ts
@@ -41,12 +41,12 @@ export class ProjectsService {
       app.service('agents').find({
         query: {
           projectId,
-          $limit: 1000,
         },
       }),
       app.service('spells').find({
         query: {
           projectId,
+          $limit: 1000,
         },
       }),
       app.service('documents').find({

--- a/packages/core/server/src/services/projects/projects.class.ts
+++ b/packages/core/server/src/services/projects/projects.class.ts
@@ -41,6 +41,7 @@ export class ProjectsService {
       app.service('agents').find({
         query: {
           projectId,
+          $limit: 1000,
         },
       }),
       app.service('spells').find({
@@ -51,6 +52,7 @@ export class ProjectsService {
       app.service('documents').find({
         query: {
           projectId,
+          $limit: 1000,
         },
       }),
     ])

--- a/packages/core/server/src/services/projects/projects.class.ts
+++ b/packages/core/server/src/services/projects/projects.class.ts
@@ -46,13 +46,11 @@ export class ProjectsService {
       app.service('spells').find({
         query: {
           projectId,
-          $limit: 1000,
         },
       }),
       app.service('documents').find({
         query: {
           projectId,
-          $limit: 1000,
         },
       }),
     ])

--- a/packages/core/server/src/services/requests/requests.class.ts
+++ b/packages/core/server/src/services/requests/requests.class.ts
@@ -1,28 +1,30 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * For more information about this file see
  * https://dove.feathersjs.com/guides/cli/service.class.html#database-services
  */
-import type { Params } from '@feathersjs/feathers';
-import { KnexService } from '@feathersjs/knex';
-import type { KnexAdapterParams, KnexAdapterOptions } from '@feathersjs/knex';
+import type { Params } from '@feathersjs/feathers'
+import { KnexService } from '@feathersjs/knex'
+import type { KnexAdapterParams, KnexAdapterOptions } from '@feathersjs/knex'
 
-import type { Application } from '../../declarations';
-import type { Request, RequestData, RequestPatch, RequestQuery } from './requests.schema';
+import type { Application } from '../../declarations'
+import type {
+  Request,
+  RequestData,
+  RequestPatch,
+  RequestQuery,
+} from './requests.schema'
 
-export type RequestParams = KnexAdapterParams<RequestQuery>;
+export type RequestParams = KnexAdapterParams<RequestQuery>
 
 /**
  * By default calls the standard Knex adapter service methods but can be
  * customized with your own functionality.
  * @template ServiceParams - Extends the Params for better typing
  */
-export class RequestService<ServiceParams extends Params = RequestParams> extends KnexService<
-  Request,
-  RequestData,
-  ServiceParams,
-  RequestPatch
-> {}
+export class RequestService<
+  ServiceParams extends Params = RequestParams
+> extends KnexService<Request, RequestData, ServiceParams, RequestPatch> {}
 
 /**
  * Get options for the RequestService
@@ -31,8 +33,11 @@ export class RequestService<ServiceParams extends Params = RequestParams> extend
  */
 export const getOptions = (app: Application): KnexAdapterOptions => {
   return {
-    paginate: app.get('paginate'),
+    paginate: {
+      default: 1000,
+      max: 1000,
+    },
     Model: app.get('dbClient'),
-    name: 'request'
-  };
-};
+    name: 'request',
+  }
+}

--- a/packages/core/server/src/services/spells/spells.class.ts
+++ b/packages/core/server/src/services/spells/spells.class.ts
@@ -1,63 +1,74 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * Imports
  */
-import otJson0 from 'ot-json0';
-import md5 from 'md5';
-import { KnexService } from '@feathersjs/knex';
-import { BadRequest } from '@feathersjs/errors/lib';
-import type { Application } from '../../declarations';
-import type { Params } from '@feathersjs/feathers';
-import type { KnexAdapterParams, KnexAdapterOptions } from '@feathersjs/knex';
-import type { SpellData, SpellPatch, SpellQuery } from './spells.schema';
-import { SpellInterface } from '@magickml/core';
-import { app } from '../../app';
+import otJson0 from 'ot-json0'
+import md5 from 'md5'
+import { KnexService } from '@feathersjs/knex'
+import { BadRequest } from '@feathersjs/errors/lib'
+import type { Application } from '../../declarations'
+import type { Params } from '@feathersjs/feathers'
+import type { KnexAdapterParams, KnexAdapterOptions } from '@feathersjs/knex'
+import type { SpellData, SpellPatch, SpellQuery } from './spells.schema'
+import { SpellInterface } from '@magickml/core'
+import { app } from '../../app'
 
 /**
  * Interface and Types
  */
-export type SpellParams = KnexAdapterParams<SpellQuery>;
+export type SpellParams = KnexAdapterParams<SpellQuery>
 export type SaveDiffData = {
-  name: string;
-  diff: Record<string, any>;
-  projectId: string;
+  name: string
+  diff: Record<string, any>
+  projectId: string
 }
 
 /**
  * Spell Service
  * By default calls the standard Knex adapter service methods but can be customized with your own functionality.
  */
-export class SpellService<ServiceParams extends Params = SpellParams> extends KnexService<SpellInterface, SpellData, ServiceParams, SpellPatch> {
-  
+export class SpellService<
+  ServiceParams extends Params = SpellParams
+> extends KnexService<SpellInterface, SpellData, ServiceParams, SpellPatch> {
   /**
    * Saves the diff of a spell
    */
   async saveDiff(data: SaveDiffData) {
-    const { name, diff, projectId } = data;
+    const { name, diff, projectId } = data
 
     // Find spell data
-    const spellData = await app.service('spells').find({ query: { projectId, name } });
-    const spell = spellData.data[0];
+    const spellData = await app
+      .service('spells')
+      .find({ query: { projectId, name } })
+    const spell = spellData.data[0]
 
     // Check if spell exists and that diff is available
-    if (!spell) throw new BadRequest(`No spell with ${name} name found.`);
-    if (!diff) throw new BadRequest('No diff provided in request body');
+    if (!spell) throw new BadRequest(`No spell with ${name} name found.`)
+    if (!diff) throw new BadRequest('No diff provided in request body')
 
     // Apply diff to spell data
-    const spellUpdate = otJson0.type.apply(spell, diff);
+    const spellUpdate = otJson0.type.apply(spell, diff)
 
     // Check if the graph would be cleared
     if (Object.keys(spellUpdate.graph.nodes).length === 0) {
-      throw new BadRequest('Graph would be cleared. Aborting.');
+      throw new BadRequest('Graph would be cleared. Aborting.')
     }
 
     // Calculate checksum of graph
-    const hash = md5(JSON.stringify(spellUpdate.graph.nodes));
+    const hash = md5(JSON.stringify(spellUpdate.graph.nodes))
 
     // Update spell data
-    const updatedSpell = await app.service('spells').update(spell.id, { ...spellUpdate, hash });
+    const updatedSpell = await app
+      .service('spells')
+      .update(spell.id, { ...spellUpdate, hash })
 
-    return updatedSpell;
+    return updatedSpell
+  }
+
+  async find(params?: SpellParams) {
+    const { query = {} } = params || {}
+    query.$limit = Math.min(query.$limit || 1000, 1000)
+    return super.find({ ...params, query })
   }
 }
 
@@ -68,6 +79,6 @@ export const getOptions = (app: Application): KnexAdapterOptions => {
   return {
     paginate: app.get('paginate'),
     Model: app.get('dbClient'),
-    name: 'spells'
+    name: 'spells',
   }
 }

--- a/packages/core/server/src/services/spells/spells.class.ts
+++ b/packages/core/server/src/services/spells/spells.class.ts
@@ -64,12 +64,6 @@ export class SpellService<
 
     return updatedSpell
   }
-
-  async find(params?: SpellParams) {
-    const { query = {} } = params || {}
-    query.$limit = Math.min(query.$limit || 1000, 1000)
-    return super.find({ ...params, query })
-  }
 }
 
 /**
@@ -77,7 +71,10 @@ export class SpellService<
  */
 export const getOptions = (app: Application): KnexAdapterOptions => {
   return {
-    paginate: app.get('paginate'),
+    paginate: {
+      default: 1000,
+      max: 1000,
+    },
     Model: app.get('dbClient'),
     name: 'spells',
   }

--- a/packages/core/server/src/services/spells/spells.schema.ts
+++ b/packages/core/server/src/services/spells/spells.schema.ts
@@ -7,6 +7,7 @@ import {
   querySyntax,
   Type,
 } from '@feathersjs/typebox'
+import { SpellInterface, spellSchema } from '@magickml/core'
 import { dataValidator, queryValidator } from '../../config/validators'
 import type { HookContext } from '../../declarations'
 
@@ -14,26 +15,14 @@ import type { HookContext } from '../../declarations'
 export const spellResolver = resolve<SpellInterface, HookContext>({})
 export const spellExternalResolver = resolve<SpellInterface, HookContext>({})
 
-import { SpellInterface, spellSchema } from '@magickml/core'
 // Schema for creating new entries, removing additional fields
-// Define the properties for the new schema
-const spellDataSchemaProperties = {
-  name: spellSchema.properties.name,
-  projectId: spellSchema.properties.projectId,
-  graph: spellSchema.properties.graph,
-  createdAt: spellSchema.properties.createdAt,
-  updatedAt: spellSchema.properties.updatedAt,
-  hash: spellSchema.properties.hash,
-  id: Type.Optional(spellSchema.properties.id),
-};
-
-export const spellDataSchema = Type.Object(
-  spellDataSchemaProperties,
+export const spellDataSchema = Type.Pick(
+  spellSchema,
+  ['name', 'projectId', 'graph', 'createdAt', 'updatedAt', 'hash'],
   {
     $id: 'SpellData',
   }
 )
-
 export type SpellData = Static<typeof spellDataSchema>
 export const spellDataValidator = getDataValidator(
   spellDataSchema,

--- a/packages/core/server/src/services/spells/spells.ts
+++ b/packages/core/server/src/services/spells/spells.ts
@@ -35,6 +35,12 @@ export * from './spells.schema'
  * @param app - Application
  */
 export const spell = (app: Application) => {
+  // Configure pagination
+  app.set('paginate', {
+    default: 1000,
+    max: 1000,
+  })
+
   // Register our service on the Feathers application
   app.use('spells', new SpellService(getOptions(app)), {
     methods: ['find', 'get', 'create', 'patch', 'remove', 'saveDiff'],


### PR DESCRIPTION
## What Changed:

Spells, documents, requests and events fetching has been increased to a limit of 1000.

## How to test:

Make sure all four of those still work, and try to see if the limit goes beyond 100 now.

## Additional information:

Pagination soon to follow in another issue.
