### PR TITLE
make logging enabling/disabling clearer

### DIFF
--- a/.env
+++ b/.env
@@ -27,3 +27,6 @@ VITE_APP_POSTHOG_API_KEY=key
 # Settings for authentication
 PRODUCTION=false
 VITE_APP_PRODUCTION=false
+
+# Logging flag
+VITE_APP_LOGGING_ENABLED=false

--- a/packages/core/shared/src/config.ts
+++ b/packages/core/shared/src/config.ts
@@ -55,7 +55,6 @@ export const FILE_SERVER_PORT =
 export const FILE_SERVER_URL =
   getVarForEnvironment('FILE_SERVER_URL') || 'https://localhost:65530'
 export const USESSL = getVarForEnvironment('USESSL') || false
-export const NODE_ENV = getVarForEnvironment('NODE_ENV') || 'development'
 
 export const PAGINATE_DEFAULT = getVarForEnvironment('PAGINATE_DEFAULT') || '10'
 export const PAGINATE_MAX = getVarForEnvironment('PAGINATE_MAX') || '100'
@@ -71,3 +70,6 @@ export const ELEVENLABS_API_KEY =
   'ce69df07b50e7179cbbfc5c2bef9d752'
 export const VITE_APP_TRUSTED_PARENT_URL =
   getVarForEnvironment('VITE_APP_TRUSTED_PARENT_URL') || ''
+
+export const LOGGING_ENABLED =
+  getVarForEnvironment('LOGGING_ENABLED') === 'true'

--- a/packages/core/shared/src/logger/index.ts
+++ b/packages/core/shared/src/logger/index.ts
@@ -1,33 +1,33 @@
 import pino from 'pino'
-import { NODE_ENV } from '@magickml/core'
+import { LOGGING_ENABLED } from '../config'
 
 let logger: pino.Logger | null = null
 
 const defaultLoggerOpts = {}
 
 export const initLogger = (opts: object = defaultLoggerOpts) => {
-    if (NODE_ENV === 'development') {
-        logger = pino({
-            transport: {
-                target: 'pino-pretty',
-                options: {
-                    colorize: true,
-                }
-            },
-            ...opts,
-            level: 'debug',
-        })
+  if (LOGGING_ENABLED === true) {
+    logger = pino({
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+        },
+      },
+      ...opts,
+      level: 'debug',
+    })
 
-        return
-    }
+    return
+  }
 
-    logger = pino(opts)
+  logger = pino(opts)
 }
 
 export const getLogger: () => pino.Logger = () => {
-    if (logger !== null) {
-        return logger
-    }
+  if (logger !== null) {
+    return logger
+  }
 
-    throw new Error("Logger not initialized. Please call initLogger() first.")
+  throw new Error('Logger not initialized. Please call initLogger() first.')
 }

--- a/packages/editor/src/wdyr.ts
+++ b/packages/editor/src/wdyr.ts
@@ -1,6 +1,5 @@
-// DOCUMENTED 
-
-import { NODE_ENV } from "@magickml/core";
+// DOCUMENTED
+import { LOGGING_ENABLED } from '@magickml/core'
 import whyDidYouRender from '@welldone-software/why-did-you-render'
 
 /**
@@ -14,7 +13,7 @@ import whyDidYouRender from '@welldone-software/why-did-you-render'
  */
 function enableWhyDidYouRender(React: any): void {
   // If in development
-  if (NODE_ENV === 'development') {
+  if (LOGGING_ENABLED) {
     console.log('running WDYR!')
     whyDidYouRender(React, {
       trackAllPureComponents: false,
@@ -22,4 +21,4 @@ function enableWhyDidYouRender(React: any): void {
   }
 }
 
-export default enableWhyDidYouRender;  // Export the function for usage in other files.
+export default enableWhyDidYouRender // Export the function for usage in other files.


### PR DESCRIPTION
## What Changed:

It wasn't very clear to local users how to disable logging, and its reliance on production made testing production reliant things harder.
This adds a flag specifically for logging.
## How to test:

Set the LOGGING_ENABLED .env to true or false depending on what you are testing.

## Additional information:

N/A
