### PR TITLE
Added initLoggers to the server and client, and lowered the log level on noisy logs

### DIFF
--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -11,10 +11,15 @@ import {
   PRODUCTION,
 } from '@magickml/core'
 import { PostHogProvider } from 'posthog-js/react'
+import { initLogger, getLogger } from '@magickml/core'
 
 import plugins from './plugins'
 
-console.log('plugins', plugins)
+initLogger({ name: "AIDE" })
+
+const logger = getLogger()
+
+logger.info('loaded with plugins %o', plugins)
 /**
  * Initialize and render the MagickIDE component when running as a standalone editor (not inside an iframe)
  */
@@ -62,13 +67,15 @@ if (window === window.parent) {
         event.origin !== window.location.origin &&
         event.origin !== cloudUrl
       ) {
-        console.error('untrusted origin', event.origin)
-        console.error(
-          'cloudUrl is ',
-          cloudUrl,
-          'TRUSTED_PARENT_URL',
+        logger.error('untrusted origin %s', event.origin)
+        logger.error(
+          'cloudUrl is %s',
+          cloudUrl)
+        logger.error(
+          'TRUSTED_PARENT_URL is %s',
           TRUSTED_PARENT_URL
         )
+
         return
       }
 

--- a/apps/docs/docs/api/index.md
+++ b/apps/docs/docs/api/index.md
@@ -1,7 +1,7 @@
 ---
-id: 'index'
-title: '@magickml/core'
-sidebar_label: 'Exports'
+id: "index"
+title: "@magickml/core"
+sidebar_label: "Exports"
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -59,9 +59,9 @@ The interface for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L75)
+[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L75)
 
----
+___
 
 ### AgentSchema
 
@@ -71,9 +71,9 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L73)
+[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L73)
 
----
+___
 
 ### AgentTask
 
@@ -81,22 +81,22 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name        | Type              |
-| :---------- | :---------------- |
-| `agentId?`  | `string`          |
+| Name | Type |
+| :------ | :------ |
+| `agentId?` | `string` |
 | `eventData` | [`Event`](#event) |
-| `id`        | `number`          |
-| `objective` | `string`          |
-| `projectId` | `string`          |
-| `status`    | `AgentTaskStatus` |
-| `steps`     | `string`          |
-| `type`      | `string`          |
+| `id` | `number` |
+| `objective` | `string` |
+| `projectId` | `string` |
+| `status` | `AgentTaskStatus` |
+| `steps` | `string` |
+| `type` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L73)
+[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L73)
 
----
+___
 
 ### AgentTaskData
 
@@ -104,19 +104,19 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name        | Type     |
-| :---------- | :------- |
-| `action`    | `string` |
-| `result`    | `string` |
-| `skill`     | `string` |
-| `thought`   | `string` |
+| Name | Type |
+| :------ | :------ |
+| `action` | `string` |
+| `result` | `string` |
+| `skill` | `string` |
+| `thought` | `string` |
 | `timestamp` | `number` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L84)
+[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L84)
 
----
+___
 
 ### AppService
 
@@ -128,8 +128,8 @@ The type for an agent object that's based on the `agentSchema`.
 
 ##### Parameters
 
-| Name  | Type                  |
-| :---- | :-------------------- |
+| Name | Type |
+| :------ | :------ |
 | `app` | `FeathersApplication` |
 
 ##### Returns
@@ -138,19 +138,19 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L633)
+[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L633)
 
----
+___
 
 ### AudioCompletionSubtype
 
-Ƭ **AudioCompletionSubtype**: `"text2speech"` \| `"text2audio"`
+Ƭ **AudioCompletionSubtype**: ``"text2speech"`` \| ``"text2audio"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L480)
+[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L480)
 
----
+___
 
 ### ChatCompletionData
 
@@ -158,25 +158,25 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name                   | Type                            |
-| :--------------------- | :------------------------------ |
-| `apiKey?`              | `string`                        |
+| Name | Type |
+| :------ | :------ |
+| `apiKey?` | `string` |
 | `conversationMessages` | [`ChatMessage`](#chatmessage)[] |
-| `frequency_penalty`    | `number`                        |
-| `max_tokens`           | `number`                        |
-| `model`                | `string`                        |
-| `presence_penalty`     | `number`                        |
-| `stop`                 | `string`[]                      |
-| `systemMessage`        | `string`                        |
-| `temperature`          | `number`                        |
-| `top_p`                | `number`                        |
-| `userMessage`          | `string`                        |
+| `frequency_penalty` | `number` |
+| `max_tokens` | `number` |
+| `model` | `string` |
+| `presence_penalty` | `number` |
+| `stop` | `string`[] |
+| `systemMessage` | `string` |
+| `temperature` | `number` |
+| `top_p` | `number` |
+| `userMessage` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L543)
+[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L543)
 
----
+___
 
 ### ChatMessage
 
@@ -184,16 +184,16 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name      | Type                                                |
-| :-------- | :-------------------------------------------------- |
-| `content` | `string`                                            |
-| `role`    | `"system"` \| `"user"` \| `"assistant"` \| `string` |
+| Name | Type |
+| :------ | :------ |
+| `content` | `string` |
+| `role` | ``"system"`` \| ``"user"`` \| ``"assistant"`` \| `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L538)
+[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L538)
 
----
+___
 
 ### ClassifierSchema
 
@@ -201,16 +201,16 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name       | Type                   |
-| :--------- | :--------------------- |
+| Name | Type |
+| :------ | :------ |
 | `examples` | `string`[] \| `string` |
-| `type`     | `string`               |
+| `type` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L462)
+[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L462)
 
----
+___
 
 ### CompletionHandlerInputData
 
@@ -218,18 +218,18 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name      | Type                                          |
-| :-------- | :-------------------------------------------- |
-| `context` | [`ModuleContext`](#modulecontext)             |
-| `inputs`  | [`MagickWorkerInputs`](#magickworkerinputs)   |
-| `node`    | `NodeData`                                    |
+| Name | Type |
+| :------ | :------ |
+| `context` | [`ModuleContext`](#modulecontext) |
+| `inputs` | [`MagickWorkerInputs`](#magickworkerinputs) |
+| `node` | `NodeData` |
 | `outputs` | [`MagickWorkerOutputs`](#magickworkeroutputs) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L600)
+[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L600)
 
----
+___
 
 ### CompletionInspectorControls
 
@@ -237,19 +237,19 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name           | Type                        |
-| :------------- | :-------------------------- |
-| `dataKey`      | `string`                    |
-| `defaultValue` | `string`                    |
-| `icon`         | `string`                    |
-| `name`         | `string`                    |
-| `type`         | `DataControlImplementation` |
+| Name | Type |
+| :------ | :------ |
+| `dataKey` | `string` |
+| `defaultValue` | `string` |
+| `icon` | `string` |
+| `name` | `string` |
+| `type` | `DataControlImplementation` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L493)
+[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L493)
 
----
+___
 
 ### CompletionProvider
 
@@ -261,21 +261,21 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name                 | Type                                                                                                                                                                                                                                               |
-| :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `handler?`           | (`attrs`: { `context`: `unknown` ; `inputs`: [`MagickWorkerInputs`](#magickworkerinputs) ; `node`: [`WorkerData`](#workerdata) ; `outputs`: [`MagickWorkerOutputs`](#magickworkeroutputs) }) => `Promise`<`HandlerResponse`\> \| `HandlerResponse` |
-| `inputs`             | [`CompletionSocket`](#completionsocket)[]                                                                                                                                                                                                          |
-| `inspectorControls?` | [`CompletionInspectorControls`](#completioninspectorcontrols)[]                                                                                                                                                                                    |
-| `models`             | `string`[]                                                                                                                                                                                                                                         |
-| `outputs`            | [`CompletionSocket`](#completionsocket)[]                                                                                                                                                                                                          |
-| `subtype`            | [`ImageCompletionSubtype`](#imagecompletionsubtype) \| [`TextCompletionSubtype`](#textcompletionsubtype) \| [`AudioCompletionSubtype`](#audiocompletionsubtype)                                                                                    |
-| `type`               | [`CompletionType`](#completiontype)                                                                                                                                                                                                                |
+| Name | Type |
+| :------ | :------ |
+| `handler?` | (`attrs`: { `context`: `unknown` ; `inputs`: [`MagickWorkerInputs`](#magickworkerinputs) ; `node`: [`WorkerData`](#workerdata) ; `outputs`: [`MagickWorkerOutputs`](#magickworkeroutputs)  }) => `Promise`<`HandlerResponse`\> \| `HandlerResponse` |
+| `inputs` | [`CompletionSocket`](#completionsocket)[] |
+| `inspectorControls?` | [`CompletionInspectorControls`](#completioninspectorcontrols)[] |
+| `models` | `string`[] |
+| `outputs` | [`CompletionSocket`](#completionsocket)[] |
+| `subtype` | [`ImageCompletionSubtype`](#imagecompletionsubtype) \| [`TextCompletionSubtype`](#textcompletionsubtype) \| [`AudioCompletionSubtype`](#audiocompletionsubtype) |
+| `type` | [`CompletionType`](#completiontype) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L507)
+[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L507)
 
----
+___
 
 ### CompletionSocket
 
@@ -283,53 +283,53 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Type declaration
 
-| Name     | Type     |
-| :------- | :------- |
-| `name`   | `string` |
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
 | `socket` | `string` |
-| `type`   | `Socket` |
+| `type` | `Socket` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L482)
+[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L482)
 
----
+___
 
 ### CompletionType
 
-Ƭ **CompletionType**: `"image"` \| `"text"` \| `"audio"`
+Ƭ **CompletionType**: ``"image"`` \| ``"text"`` \| ``"audio"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L474)
+[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L474)
 
----
+___
 
 ### ComponentData
 
-Ƭ **ComponentData**<`T`\>: `Record`<`string`, `unknown`\> & { `icon?`: `string` ; `ignored?`: [`IgnoredList`](#ignoredlist) ; `socketType?`: [`SocketType`](#sockettype) ; `taskType?`: `T` }
+Ƭ **ComponentData**<`T`\>: `Record`<`string`, `unknown`\> & { `icon?`: `string` ; `ignored?`: [`IgnoredList`](#ignoredlist) ; `socketType?`: [`SocketType`](#sockettype) ; `taskType?`: `T`  }
 
 #### Type parameters
 
-| Name | Type                    |
-| :--- | :---------------------- |
-| `T`  | [`TaskType`](#tasktype) |
+| Name | Type |
+| :------ | :------ |
+| `T` | [`TaskType`](#tasktype) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L352)
+[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L352)
 
----
+___
 
 ### ConnectionType
 
-Ƭ **ConnectionType**: `"input"` \| `"output"`
+Ƭ **ConnectionType**: ``"input"`` \| ``"output"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L305)
+[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L305)
 
----
+___
 
 ### CostPerToken
 
@@ -339,15 +339,15 @@ Represents the cost per token for a given model
 
 #### Type parameters
 
-| Name | Type                                                                                                                          |
-| :--- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `T`  | extends [`TextModel`](enums/TextModel.md) \| [`EmbeddingModel`](enums/EmbeddingModel.md) \| [`ChatModel`](enums/ChatModel.md) |
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`TextModel`](enums/TextModel.md) \| [`EmbeddingModel`](enums/EmbeddingModel.md) \| [`ChatModel`](enums/ChatModel.md) |
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/cost-calculator.ts#L33)
+[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L33)
 
----
+___
 
 ### CreateAgentTaskArgs
 
@@ -355,21 +355,21 @@ Represents the cost per token for a given model
 
 #### Type declaration
 
-| Name        | Type              |
-| :---------- | :---------------- |
-| `agentId?`  | `string`          |
+| Name | Type |
+| :------ | :------ |
+| `agentId?` | `string` |
 | `eventData` | [`Event`](#event) |
-| `objective` | `string`          |
-| `projectId` | `string`          |
-| `status`    | `AgentTaskStatus` |
-| `steps`     | `string`          |
-| `type`      | `string`          |
+| `objective` | `string` |
+| `projectId` | `string` |
+| `status` | `AgentTaskStatus` |
+| `steps` | `string` |
+| `type` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L63)
+[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L63)
 
----
+___
 
 ### CreateDocumentArgs
 
@@ -377,9 +377,9 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L55)
+[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L55)
 
----
+___
 
 ### CreateEventArgs
 
@@ -387,21 +387,21 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L110)
+[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L110)
 
----
+___
 
 ### CustomErrorCodes
 
-Ƭ **CustomErrorCodes**: `"input-failed"` \| `"server-error"` \| `"not-found"` \| `"already-exists"` \| `"authentication-error"`
+Ƭ **CustomErrorCodes**: ``"input-failed"`` \| ``"server-error"`` \| ``"not-found"`` \| ``"already-exists"`` \| ``"authentication-error"``
 
 The possible custom error codes to be used in the application.
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/utils/SpellError.ts#L5)
+[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/SpellError.ts#L5)
 
----
+___
 
 ### DataSocketType
 
@@ -409,20 +409,20 @@ The possible custom error codes to be used in the application.
 
 #### Type declaration
 
-| Name             | Type                                |
-| :--------------- | :---------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `connectionType` | [`ConnectionType`](#connectiontype) |
-| `name`           | [`SocketNameType`](#socketnametype) |
-| `socketKey`      | `string`                            |
-| `socketType`     | [`SocketType`](#sockettype)         |
-| `taskType`       | [`TaskType`](#tasktype)             |
-| `useSocketName`  | `boolean`                           |
+| `name` | [`SocketNameType`](#socketnametype) |
+| `socketKey` | `string` |
+| `socketType` | [`SocketType`](#sockettype) |
+| `taskType` | [`TaskType`](#tasktype) |
+| `useSocketName` | `boolean` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L307)
+[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L307)
 
----
+___
 
 ### DebuggerArgs
 
@@ -432,16 +432,16 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name          | Type                             |
-| :------------ | :------------------------------- |
-| `server?`     | `boolean`                        |
+| Name | Type |
+| :------ | :------ |
+| `server?` | `boolean` |
 | `throwError?` | (`message`: `unknown`) => `void` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
 
----
+___
 
 ### Document
 
@@ -449,20 +449,20 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name         | Type       |
-| :----------- | :--------- |
-| `content?`   | `string`   |
-| `date?`      | `string`   |
+| Name | Type |
+| :------ | :------ |
+| `content?` | `string` |
+| `date?` | `string` |
 | `embedding?` | `number`[] |
-| `id?`        | `number`   |
-| `projectId?` | `string`   |
-| `type?`      | `string`   |
+| `id?` | `number` |
+| `projectId?` | `string` |
+| `type?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L46)
+[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L46)
 
----
+___
 
 ### EmbeddingData
 
@@ -470,17 +470,17 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name     | Type     |
-| :------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `apiKey` | `string` |
-| `input`  | `string` |
+| `input` | `string` |
 | `model?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L557)
+[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L557)
 
----
+___
 
 ### EngineContext
 
@@ -488,23 +488,23 @@ Arguments passed to the `install` function
 
 #### Type parameters
 
-| Name       | Type                           |
-| :--------- | :----------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `DataType` | `Record`<`string`, `unknown`\> |
 
 #### Type declaration
 
-| Name           | Type                                 |
-| :------------- | :----------------------------------- |
-| `getSpell`     | [`GetSpell`](#getspell)              |
-| `processCode?` | [`ProcessCode`](#processcode)        |
-| `runSpell`     | [`RunSpell`](#runspell)<`DataType`\> |
+| Name | Type |
+| :------ | :------ |
+| `getSpell` | [`GetSpell`](#getspell) |
+| `processCode?` | [`ProcessCode`](#processcode) |
+| `runSpell` | [`RunSpell`](#runspell)<`DataType`\> |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L197)
+[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L197)
 
----
+___
 
 ### Env
 
@@ -512,15 +512,15 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name           | Type     |
-| :------------- | :------- |
+| Name | Type |
+| :------ | :------ |
 | `API_ROOT_URL` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L158)
+[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L158)
 
----
+___
 
 ### Event
 
@@ -528,29 +528,29 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name           | Type                 |
-| :------------- | :------------------- |
-| `agentId?`     | `number` \| `string` |
-| `channel?`     | `string`             |
-| `channelType?` | `string`             |
-| `client?`      | `string`             |
-| `connector?`   | `string`             |
-| `content?`     | `string`             |
-| `date?`        | `string`             |
-| `embedding?`   | `number`[]           |
-| `entities?`    | `string`[]           |
-| `id?`          | `number`             |
-| `observer?`    | `string`             |
-| `projectId?`   | `string`             |
-| `rawData?`     | `string`             |
-| `sender?`      | `string`             |
-| `type?`        | `string`             |
+| Name | Type |
+| :------ | :------ |
+| `agentId?` | `number` \| `string` |
+| `channel?` | `string` |
+| `channelType?` | `string` |
+| `client?` | `string` |
+| `connector?` | `string` |
+| `content?` | `string` |
+| `date?` | `string` |
+| `embedding?` | `number`[] |
+| `entities?` | `string`[] |
+| `id?` | `number` |
+| `observer?` | `string` |
+| `projectId?` | `string` |
+| `rawData?` | `string` |
+| `sender?` | `string` |
+| `type?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L92)
+[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L92)
 
----
+___
 
 ### EventResponse
 
@@ -558,9 +558,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L133)
+[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L133)
 
----
+___
 
 ### EventsTypes
 
@@ -572,23 +572,23 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name                        | Type                                                                  |
-| :-------------------------- | :-------------------------------------------------------------------- |
-| `connectiondrop`            | `Input` \| `Output`                                                   |
-| `connectionpath`            | { `connection`: `Connection` ; `d`: `string` ; `points`: `number`[] } |
-| `connectionpath.connection` | `Connection`                                                          |
-| `connectionpath.d`          | `string`                                                              |
-| `connectionpath.points`     | `number`[]                                                            |
-| `connectionpick`            | `Input` \| `Output`                                                   |
-| `resetconnection`           | `void`                                                                |
-| `run`                       | `void`                                                                |
-| `save`                      | `void`                                                                |
+| Name | Type |
+| :------ | :------ |
+| `connectiondrop` | `Input` \| `Output` |
+| `connectionpath` | { `connection`: `Connection` ; `d`: `string` ; `points`: `number`[]  } |
+| `connectionpath.connection` | `Connection` |
+| `connectionpath.d` | `string` |
+| `connectionpath.points` | `number`[] |
+| `connectionpick` | `Input` \| `Output` |
+| `resetconnection` | `void` |
+| `run` | `void` |
+| `save` | `void` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L284)
+[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L284)
 
----
+___
 
 ### ExFn
 
@@ -596,19 +596,19 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L455)
+[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L455)
 
----
+___
 
 ### GetDocumentArgs
 
-Ƭ **GetDocumentArgs**: [`Document`](#document) & { `maxCount?`: `number` }
+Ƭ **GetDocumentArgs**: [`Document`](#document) & { `maxCount?`: `number`  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L57)
+[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L57)
 
----
+___
 
 ### GetEventArgs
 
@@ -616,31 +616,31 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name           | Type     |
-| :------------- | :------- |
-| `channel?`     | `string` |
+| Name | Type |
+| :------ | :------ |
+| `channel?` | `string` |
 | `channelType?` | `string` |
-| `client?`      | `string` |
-| `connector?`   | `string` |
-| `embedding?`   | `string` |
-| `maxCount?`    | `number` |
-| `observer?`    | `string` |
-| `projectId?`   | `string` |
-| `rawData?`     | `string` |
-| `type?`        | `string` |
+| `client?` | `string` |
+| `connector?` | `string` |
+| `embedding?` | `string` |
+| `maxCount?` | `number` |
+| `observer?` | `string` |
+| `projectId?` | `string` |
+| `rawData?` | `string` |
+| `type?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L112)
+[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L112)
 
----
+___
 
 ### GetSpell
 
 Ƭ **GetSpell**: (`{
   spellName,
   projectId,
-}`: { `projectId`: `string` ; `spellName`: `string` }) => `Promise`<[`SpellInterface`](#spellinterface)\>
+}`: { `projectId`: `string` ; `spellName`: `string`  }) => `Promise`<[`SpellInterface`](#spellinterface)\>
 
 #### Type declaration
 
@@ -652,8 +652,7 @@ Arguments passed to the `install` function
 ##### Parameters
 
 | Name | Type |
-| :--- | :--- |
-
+| :------ | :------ |
 | `{
   spellName,
   projectId,
@@ -673,9 +672,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L174)
+[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L174)
 
----
+___
 
 ### GetVectorEventArgs
 
@@ -683,17 +682,17 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name        | Type       |
-| :---------- | :--------- |
-| `entities`  | `string`[] |
-| `maxCount?` | `number`   |
-| `type`      | `string`   |
+| Name | Type |
+| :------ | :------ |
+| `entities` | `string`[] |
+| `maxCount?` | `number` |
+| `type` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L127)
+[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L127)
 
----
+___
 
 ### GoFn
 
@@ -701,9 +700,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L448)
+[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L448)
 
----
+___
 
 ### GraphData
 
@@ -711,9 +710,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L344)
+[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L344)
 
----
+___
 
 ### Handler
 
@@ -725,8 +724,8 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name  | Type          |
-| :---- | :------------ |
+| Name | Type |
+| :------ | :------ |
 | `ctx` | `Koa.Context` |
 
 ##### Returns
@@ -735,19 +734,19 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L667)
+[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L667)
 
----
+___
 
 ### IgnoredList
 
-Ƭ **IgnoredList**: { `name`: `string` }[] \| `string`[]
+Ƭ **IgnoredList**: { `name`: `string`  }[] \| `string`[]
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L346)
+[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L346)
 
----
+___
 
 ### ImageCacheResponse
 
@@ -755,25 +754,25 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name     | Type                        |
-| :------- | :-------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `images` | [`ImageType`](#imagetype)[] |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L42)
+[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L42)
 
----
+___
 
 ### ImageCompletionSubtype
 
-Ƭ **ImageCompletionSubtype**: `"text2image"` \| `"image2image"` \| `"image2text"`
+Ƭ **ImageCompletionSubtype**: ``"text2image"`` \| ``"image2image"`` \| ``"image2text"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L476)
+[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L476)
 
----
+___
 
 ### ImageType
 
@@ -781,20 +780,20 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name           | Type                 |
-| :------------- | :------------------- |
-| `captionId`    | `string`             |
-| `id`           | `string`             |
-| `imageCaption` | `string`             |
-| `imageUrl`     | `string`             |
-| `score`        | `number` \| `string` |
-| `tag`          | `string`             |
+| Name | Type |
+| :------ | :------ |
+| `captionId` | `string` |
+| `id` | `string` |
+| `imageCaption` | `string` |
+| `imageUrl` | `string` |
+| `score` | `number` \| `string` |
+| `tag` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L33)
+[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L33)
 
----
+___
 
 ### InitEngineArguments
 
@@ -802,19 +801,19 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name          | Type                                                          |
-| :------------ | :------------------------------------------------------------ |
-| `components`  | [`MagickComponent`](classes/MagickComponent.md)<`unknown`\>[] |
-| `name`        | `string`                                                      |
-| `server`      | `boolean`                                                     |
-| `socket?`     | `io.Socket`                                                   |
-| `throwError?` | (`message`: `unknown`) => `void`                              |
+| Name | Type |
+| :------ | :------ |
+| `components` | [`MagickComponent`](classes/MagickComponent.md)<`unknown`\>[] |
+| `name` | `string` |
+| `server` | `boolean` |
+| `socket?` | `io.Socket` |
+| `throwError?` | (`message`: `unknown`) => `void` |
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:55](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L55)
+[packages/core/shared/src/engine.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L55)
 
----
+___
 
 ### InputComponentData
 
@@ -822,9 +821,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L359)
+[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L359)
 
----
+___
 
 ### InspectorData
 
@@ -832,50 +831,50 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name           | Type                        |
-| :------------- | :-------------------------- |
-| `category?`    | `string`                    |
-| `data`         | [`WorkerData`](#workerdata) |
+| Name | Type |
+| :------ | :------ |
+| `category?` | `string` |
+| `data` | [`WorkerData`](#workerdata) |
 | `dataControls` | [`PubSubData`](#pubsubdata) |
-| `info`         | `string`                    |
-| `name`         | `string`                    |
-| `nodeId`       | `number`                    |
+| `info` | `string` |
+| `name` | `string` |
+| `nodeId` | `number` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
+[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
 
----
+___
 
 ### MagicComponentCategory
 
-Ƭ **MagicComponentCategory**: `"Esoterica"` \| `"Object"` \| `"Number"` \| `"I/O"` \| `"Flow"` \| `"Experimental"` \| `"Discord"` \| `"Embedding"` \| `"Document"` \| `"Code"` \| `"Boolean"` \| `"Array"` \| `"Image"` \| `"Generation"` \| `"Event"` \| `"Text"` \| `"Utility"` \| `"Esoterica"` \| `"Ethereum"` \| `"Pinecone"` \| `"Search"` \| `"Magick"` \| `"Audio"` \| `"Task"`
+Ƭ **MagicComponentCategory**: ``"Esoterica"`` \| ``"Object"`` \| ``"Number"`` \| ``"I/O"`` \| ``"Flow"`` \| ``"Experimental"`` \| ``"Discord"`` \| ``"Embedding"`` \| ``"Document"`` \| ``"Code"`` \| ``"Boolean"`` \| ``"Array"`` \| ``"Image"`` \| ``"Generation"`` \| ``"Event"`` \| ``"Text"`` \| ``"Utility"`` \| ``"Esoterica"`` \| ``"Ethereum"`` \| ``"Pinecone"`` \| ``"Search"`` \| ``"Magick"`` \| ``"Audio"`` \| ``"Task"``
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L123)
+[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L123)
 
----
+___
 
 ### MagicNodeInput
 
-Ƭ **MagicNodeInput**: `Input` & { `socketType`: [`DataSocketType`](#datasockettype) }
+Ƭ **MagicNodeInput**: `Input` & { `socketType`: [`DataSocketType`](#datasockettype)  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L316)
+[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L316)
 
----
+___
 
 ### MagicNodeOutput
 
-Ƭ **MagicNodeOutput**: `Output` & { `socketType`: [`DataSocketType`](#datasockettype) ; `taskType?`: [`TaskType`](#tasktype) }
+Ƭ **MagicNodeOutput**: `Output` & { `socketType`: [`DataSocketType`](#datasockettype) ; `taskType?`: [`TaskType`](#tasktype)  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L317)
+[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L317)
 
----
+___
 
 ### MagickComponentArray
 
@@ -883,25 +882,25 @@ Arguments passed to the `install` function
 
 #### Type parameters
 
-| Name | Type                                                                        |
-| :--- | :-------------------------------------------------------------------------- |
-| `T`  | extends [`MagickComponent`](classes/MagickComponent.md)<`unknown`\> = `any` |
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`MagickComponent`](classes/MagickComponent.md)<`unknown`\> = `any` |
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:221](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L221)
+[packages/core/shared/src/engine.ts:221](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L221)
 
----
+___
 
 ### MagickNode
 
-Ƭ **MagickNode**: `Node` & { `category?`: `string` ; `console`: `MagickConsole` ; `data`: [`WorkerData`](#workerdata) ; `display`: (`content`: `string`) => `void` ; `displayName?`: `string` ; `info`: `string` ; `inspector`: `Inspector` ; `outputs`: [`MagicNodeOutput`](#magicnodeoutput)[] ; `subscription`: [`PubSubCallback`](#pubsubcallback) }
+Ƭ **MagickNode**: `Node` & { `category?`: `string` ; `console`: `MagickConsole` ; `data`: [`WorkerData`](#workerdata) ; `display`: (`content`: `string`) => `void` ; `displayName?`: `string` ; `info`: `string` ; `inspector`: `Inspector` ; `outputs`: [`MagicNodeOutput`](#magicnodeoutput)[] ; `subscription`: [`PubSubCallback`](#pubsubcallback)  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L322)
+[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L322)
 
----
+___
 
 ### MagickNodeData
 
@@ -913,20 +912,20 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name            | Type      |
-| :-------------- | :-------- |
-| `defaultValue?` | `string`  |
-| `element?`      | `number`  |
-| `isInput?`      | `boolean` |
-| `name?`         | `string`  |
-| `socketKey?`    | `string`  |
-| `useDefault?`   | `boolean` |
+| Name | Type |
+| :------ | :------ |
+| `defaultValue?` | `string` |
+| `element?` | `number` |
+| `isInput?` | `boolean` |
+| `name?` | `string` |
+| `socketKey?` | `string` |
+| `useDefault?` | `boolean` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L379)
+[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L379)
 
----
+___
 
 ### MagickReteInput
 
@@ -934,18 +933,18 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name         | Type                                     |
-| :----------- | :--------------------------------------- |
-| `key`        | `string`                                 |
-| `outputData` | `unknown`                                |
-| `task`       | [`MagickTask`](interfaces/MagickTask.md) |
-| `type`       | [`TaskOutputTypes`](#taskoutputtypes)    |
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `outputData` | `unknown` |
+| `task` | [`MagickTask`](interfaces/MagickTask.md) |
+| `type` | [`TaskOutputTypes`](#taskoutputtypes) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L426)
+[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L426)
 
----
+___
 
 ### MagickSpellInput
 
@@ -953,9 +952,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L418)
+[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L418)
 
----
+___
 
 ### MagickSpellOutput
 
@@ -963,9 +962,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L419)
+[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L419)
 
----
+___
 
 ### MagickWorkerInput
 
@@ -973,9 +972,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L441)
+[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L441)
 
----
+___
 
 ### MagickWorkerInputs
 
@@ -987,19 +986,19 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L442)
+[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L442)
 
----
+___
 
 ### MagickWorkerOutputs
 
-Ƭ **MagickWorkerOutputs**: `WorkerOutputs` & { `[key: string]`: [`TaskOutput`](#taskoutput); }
+Ƭ **MagickWorkerOutputs**: `WorkerOutputs` & { `[key: string]`: [`TaskOutput`](#taskoutput);  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L443)
+[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L443)
 
----
+___
 
 ### MessagingRequest
 
@@ -1007,9 +1006,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L607)
+[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L607)
 
----
+___
 
 ### MessagingWebhookBody
 
@@ -1017,28 +1016,28 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name         | Type     |
-| :----------- | :------- |
-| `Body`       | `string` |
-| `From`       | `string` |
+| Name | Type |
+| :------ | :------ |
+| `Body` | `string` |
+| `From` | `string` |
 | `MessageSid` | `string` |
-| `To`         | `string` |
+| `To` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L467)
+[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L467)
 
----
+___
 
 ### Method
 
-Ƭ **Method**: `"get"` \| `"head"` \| `"post"` \| `"put"` \| `"delete"` \| `"connect"` \| `"options"` \| `"trace"` \| `"patch"`
+Ƭ **Method**: ``"get"`` \| ``"head"`` \| ``"post"`` \| ``"put"`` \| ``"delete"`` \| ``"connect"`` \| ``"options"`` \| ``"trace"`` \| ``"patch"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L655)
+[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L655)
 
----
+___
 
 ### Middleware
 
@@ -1050,10 +1049,10 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name   | Type          |
-| :----- | :------------ |
-| `ctx`  | `Koa.Context` |
-| `next` | `any`         |
+| Name | Type |
+| :------ | :------ |
+| `ctx` | `Koa.Context` |
+| `next` | `any` |
 
 ##### Returns
 
@@ -1061,9 +1060,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L653)
+[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L653)
 
----
+___
 
 ### Module
 
@@ -1071,27 +1070,27 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name   | Type     |
-| :----- | :------- |
-| `data` | `Data`   |
-| `id`   | `string` |
+| Name | Type |
+| :------ | :------ |
+| `data` | `Data` |
+| `id` | `string` |
 | `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L416)
+[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L416)
 
----
+___
 
 ### ModuleComponent
 
-Ƭ **ModuleComponent**: [`MagickComponent`](classes/MagickComponent.md)<`unknown`\> & { `run`: (`node`: [`MagickNode`](#magicknode), `data?`: `unknown`) => `Promise`<`void`\> }
+Ƭ **ModuleComponent**: [`MagickComponent`](classes/MagickComponent.md)<`unknown`\> & { `run`: (`node`: [`MagickNode`](#magicknode), `data?`: `unknown`) => `Promise`<`void`\>  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L362)
+[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L362)
 
----
+___
 
 ### ModuleContext
 
@@ -1099,30 +1098,30 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name                      | Type                                                                                                                                                                                                             |
-| :------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent`                   | [`Agent`](classes/Agent.md)                                                                                                                                                                                      |
-| `app`                     | `Application`                                                                                                                                                                                                    |
-| `context`                 | [`EngineContext`](#enginecontext)                                                                                                                                                                                |
-| `currentSpell`            | `Spell`                                                                                                                                                                                                          |
-| `data`                    | { `[key: string]`: `unknown`; }                                                                                                                                                                                  |
-| `module`                  | { `app?`: `Application` ; `inputs`: `Record`<`string`, `unknown`\> ; `outputs`: `Record`<`string`, `unknown`\> ; `publicVariables?`: `Record`<`string`, `string`\> ; `secrets?`: `Record`<`string`, `string`\> } |
-| `module.app?`             | `Application`                                                                                                                                                                                                    |
-| `module.inputs`           | `Record`<`string`, `unknown`\>                                                                                                                                                                                   |
-| `module.outputs`          | `Record`<`string`, `unknown`\>                                                                                                                                                                                   |
-| `module.publicVariables?` | `Record`<`string`, `string`\>                                                                                                                                                                                    |
-| `module.secrets?`         | `Record`<`string`, `string`\>                                                                                                                                                                                    |
-| `projectId`               | `string`                                                                                                                                                                                                         |
-| `socketInfo`              | { `targetNode`: [`MagickNode`](#magicknode) ; `targetSocket`: `string` }                                                                                                                                         |
-| `socketInfo.targetNode`   | [`MagickNode`](#magicknode)                                                                                                                                                                                      |
-| `socketInfo.targetSocket` | `string`                                                                                                                                                                                                         |
-| `spellManager`            | [`SpellManager`](classes/SpellManager.md)                                                                                                                                                                        |
+| Name | Type |
+| :------ | :------ |
+| `agent` | [`Agent`](classes/Agent.md) |
+| `app` | `Application` |
+| `context` | [`EngineContext`](#enginecontext) |
+| `currentSpell` | `Spell` |
+| `data` | { `[key: string]`: `unknown`;  } |
+| `module` | { `app?`: `Application` ; `inputs`: `Record`<`string`, `unknown`\> ; `outputs`: `Record`<`string`, `unknown`\> ; `publicVariables?`: `Record`<`string`, `string`\> ; `secrets?`: `Record`<`string`, `string`\>  } |
+| `module.app?` | `Application` |
+| `module.inputs` | `Record`<`string`, `unknown`\> |
+| `module.outputs` | `Record`<`string`, `unknown`\> |
+| `module.publicVariables?` | `Record`<`string`, `string`\> |
+| `module.secrets?` | `Record`<`string`, `string`\> |
+| `projectId` | `string` |
+| `socketInfo` | { `targetNode`: [`MagickNode`](#magicknode) ; `targetSocket`: `string`  } |
+| `socketInfo.targetNode` | [`MagickNode`](#magicknode) |
+| `socketInfo.targetSocket` | `string` |
+| `spellManager` | [`SpellManager`](classes/SpellManager.md) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L577)
+[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L577)
 
----
+___
 
 ### ModuleGraphData
 
@@ -1130,15 +1129,15 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name    | Type                                             |
-| :------ | :----------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `nodes` | `Record`<`string`, [`MagickNode`](#magicknode)\> |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
 
----
+___
 
 ### ModulePluginArgs
 
@@ -1146,16 +1145,16 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name       | Type                                             |
-| :--------- | :----------------------------------------------- |
-| `engine`   | [`MagickEngine`](interfaces/MagickEngine.md)     |
+| Name | Type |
+| :------ | :------ |
+| `engine` | [`MagickEngine`](interfaces/MagickEngine.md) |
 | `modules?` | `Record`<`string`, [`ModuleType`](#moduletype)\> |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
 
----
+___
 
 ### ModuleSocketType
 
@@ -1167,17 +1166,17 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name        | Type                                |
-| :---------- | :---------------------------------- |
-| `name`      | [`SocketNameType`](#socketnametype) |
-| `socket`    | `SocketType`                        |
-| `socketKey` | `string`                            |
+| Name | Type |
+| :------ | :------ |
+| `name` | [`SocketNameType`](#socketnametype) |
+| `socket` | `SocketType` |
+| `socketKey` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
 
----
+___
 
 ### ModuleType
 
@@ -1185,19 +1184,19 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name        | Type                      |
-| :---------- | :------------------------ |
-| `createdAt` | `string`                  |
-| `data`      | [`GraphData`](#graphdata) |
-| `id`        | `string`                  |
-| `name`      | `string`                  |
-| `updatedAt` | `string`                  |
+| Name | Type |
+| :------ | :------ |
+| `createdAt` | `string` |
+| `data` | [`GraphData`](#graphdata) |
+| `id` | `string` |
+| `name` | `string` |
+| `updatedAt` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L334)
+[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L334)
 
----
+___
 
 ### ModuleWorkerOutput
 
@@ -1205,9 +1204,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L439)
+[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L439)
 
----
+___
 
 ### NewSpellArgs
 
@@ -1215,16 +1214,16 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name    | Type     |
-| :------ | :------- |
-| `graph` | `Data`   |
-| `name`  | `string` |
+| Name | Type |
+| :------ | :------ |
+| `graph` | `Data` |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L421)
+[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L421)
 
----
+___
 
 ### NodeConnections
 
@@ -1232,18 +1231,18 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name      | Type                           |
-| :-------- | :----------------------------- |
-| `data`    | `Record`<`string`, `unknown`\> |
-| `input?`  | `string`                       |
-| `node`    | `number`                       |
-| `output?` | `string`                       |
+| Name | Type |
+| :------ | :------ |
+| `data` | `Record`<`string`, `unknown`\> |
+| `input?` | `string` |
+| `node` | `number` |
+| `output?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L366)
+[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L366)
 
----
+___
 
 ### NodeOutputs
 
@@ -1251,13 +1250,13 @@ Arguments passed to the `install` function
 
 #### Index signature
 
-▪ [outputKey: `string`]: { `connections`: [`NodeConnections`](#nodeconnections)[] }
+▪ [outputKey: `string`]: { `connections`: [`NodeConnections`](#nodeconnections)[]  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L373)
+[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L373)
 
----
+___
 
 ### OnDebug
 
@@ -1269,39 +1268,9 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name        | Type                                    |
-| :---------- | :-------------------------------------- |
-| `spellname` | `string`                                |
-| `callback`  | [`OnEditorCallback`](#oneditorcallback) |
-
-##### Returns
-
-`fn`
-
-▸ (): `void`
-
-##### Returns
-
-`void`
-
-#### Defined in
-
-[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L262)
-
----
-
-### OnEditor
-
-Ƭ **OnEditor**: (`callback`: [`OnEditorCallback`](#oneditorcallback)) => () => `void`
-
-#### Type declaration
-
-▸ (`callback`): () => `void`
-
-##### Parameters
-
-| Name       | Type                                    |
-| :--------- | :-------------------------------------- |
+| Name | Type |
+| :------ | :------ |
+| `spellname` | `string` |
 | `callback` | [`OnEditorCallback`](#oneditorcallback) |
 
 ##### Returns
@@ -1316,9 +1285,39 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L261)
+[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L262)
 
----
+___
+
+### OnEditor
+
+Ƭ **OnEditor**: (`callback`: [`OnEditorCallback`](#oneditorcallback)) => () => `void`
+
+#### Type declaration
+
+▸ (`callback`): () => `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | [`OnEditorCallback`](#oneditorcallback) |
+
+##### Returns
+
+`fn`
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L261)
+
+___
 
 ### OnEditorCallback
 
@@ -1330,8 +1329,8 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name   | Type                        |
-| :----- | :-------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`PubSubData`](#pubsubdata) |
 
 ##### Returns
@@ -1340,9 +1339,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L260)
+[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L260)
 
----
+___
 
 ### OnInspector
 
@@ -1354,9 +1353,9 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name       | Type                                          |
-| :--------- | :-------------------------------------------- |
-| `node`     | [`MagickNode`](#magicknode)                   |
+| Name | Type |
+| :------ | :------ |
+| `node` | [`MagickNode`](#magicknode) |
 | `callback` | [`OnInspectorCallback`](#oninspectorcallback) |
 
 ##### Returns
@@ -1371,9 +1370,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L256)
+[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L256)
 
----
+___
 
 ### OnInspectorCallback
 
@@ -1385,8 +1384,8 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name   | Type                           |
-| :----- | :----------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `data` | `Record`<`string`, `unknown`\> |
 
 ##### Returns
@@ -1395,9 +1394,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L255)
+[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L255)
 
----
+___
 
 ### OnSubspellUpdated
 
@@ -1409,8 +1408,8 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name    | Type                                |
-| :------ | :---------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `spell` | [`SpellInterface`](#spellinterface) |
 
 ##### Returns
@@ -1419,9 +1418,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L135)
+[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L135)
 
----
+___
 
 ### OutputComponentData
 
@@ -1429,19 +1428,19 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L360)
+[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L360)
 
----
+___
 
 ### PageLayout
 
-Ƭ **PageLayout**: `LazyExoticComponent`<() => `JSX.Element`\> \| `null`
+Ƭ **PageLayout**: `LazyExoticComponent`<() => `JSX.Element`\> \| ``null``
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L67)
+[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L67)
 
----
+___
 
 ### PluginClientRoute
 
@@ -1449,18 +1448,18 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name        | Type      |
-| :---------- | :-------- |
-| `component` | `FC`      |
-| `exact?`    | `boolean` |
-| `path`      | `string`  |
-| `plugin`    | `string`  |
+| Name | Type |
+| :------ | :------ |
+| `component` | `FC` |
+| `exact?` | `boolean` |
+| `path` | `string` |
+| `plugin` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L18)
+[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L18)
 
----
+___
 
 ### PluginDrawerItem
 
@@ -1468,17 +1467,17 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name   | Type     |
-| :----- | :------- |
-| `icon` | `FC`     |
+| Name | Type |
+| :------ | :------ |
+| `icon` | `FC` |
 | `path` | `string` |
 | `text` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L12)
+[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L12)
 
----
+___
 
 ### PluginIOType
 
@@ -1486,19 +1485,19 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name                     | Type                                                      |
-| :----------------------- | :-------------------------------------------------------- |
-| `defaultResponseOutput?` | `string`                                                  |
-| `handler?`               | (`{ output, agent, event }`: `any`) => `Promise`<`void`\> |
-| `inspectorControls?`     | `any`[]                                                   |
-| `name`                   | `string`                                                  |
-| `sockets?`               | `any`[]                                                   |
+| Name | Type |
+| :------ | :------ |
+| `defaultResponseOutput?` | `string` |
+| `handler?` | (`{ output, agent, event }`: `any`) => `Promise`<`void`\> |
+| `inspectorControls?` | `any`[] |
+| `name` | `string` |
+| `sockets?` | `any`[] |
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L27)
+[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L27)
 
----
+___
 
 ### PluginSecret
 
@@ -1506,18 +1505,18 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name      | Type      |
-| :-------- | :-------- |
-| `getUrl?` | `string`  |
+| Name | Type |
+| :------ | :------ |
+| `getUrl?` | `string` |
 | `global?` | `boolean` |
-| `key`     | `string`  |
-| `name`    | `string`  |
+| `key` | `string` |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L5)
+[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L5)
 
----
+___
 
 ### PluginServerRoute
 
@@ -1525,9 +1524,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L25)
+[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L25)
 
----
+___
 
 ### ProcessCode
 
@@ -1539,11 +1538,11 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name        | Type                                        |
-| :---------- | :------------------------------------------ |
-| `code`      | `unknown`                                   |
-| `inputs`    | [`MagickWorkerInputs`](#magickworkerinputs) |
-| `data`      | [`UnknownSpellData`](#unknownspelldata)     |
+| Name | Type |
+| :------ | :------ |
+| `code` | `unknown` |
+| `inputs` | [`MagickWorkerInputs`](#magickworkerinputs) |
+| `data` | [`UnknownSpellData`](#unknownspelldata) |
 | `language?` | [`SupportedLanguages`](#supportedlanguages) |
 
 ##### Returns
@@ -1552,9 +1551,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L182)
+[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L182)
 
----
+___
 
 ### PubSubCallback
 
@@ -1566,10 +1565,10 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name    | Type                        |
-| :------ | :-------------------------- |
-| `event` | `string`                    |
-| `data`  | [`PubSubData`](#pubsubdata) |
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` |
+| `data` | [`PubSubData`](#pubsubdata) |
 
 ##### Returns
 
@@ -1577,9 +1576,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L253)
+[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L253)
 
----
+___
 
 ### PubSubData
 
@@ -1587,9 +1586,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L252)
+[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L252)
 
----
+___
 
 ### PubSubEvents
 
@@ -1597,49 +1596,49 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name                              | Type                                                 |
-| :-------------------------------- | :--------------------------------------------------- |
-| `$CLOSE_EDITOR`                   | (`tabId`: `string`) => `string`                      |
-| `$CREATE_CONSOLE`                 | (`tabId`: `string`) => `string`                      |
-| `$CREATE_DEBUG_CONSOLE`           | (`tabId`: `string`) => `string`                      |
-| `$CREATE_INSPECTOR`               | (`tabId`: `string`) => `string`                      |
-| `$CREATE_MEDIAWINDOW`             | (`tabId`: `string`) => `string`                      |
-| `$CREATE_MESSAGE_REACTION_EDITOR` | (`tabId`: `string`) => `string`                      |
-| `$CREATE_PLAYTEST`                | (`tabId`: `string`) => `string`                      |
-| `$CREATE_PROJECT_WINDOW`          | (`tabId`: `string`) => `string`                      |
-| `$CREATE_TEXT_EDITOR`             | (`tabId`: `string`) => `string`                      |
-| `$DEBUG_INPUT`                    | (`tabId`: `string`) => `string`                      |
-| `$DEBUG_PRINT`                    | (`tabId`: `string`) => `string`                      |
-| `$DELETE`                         | (`tabId`: `string`) => `string`                      |
-| `$EXPORT`                         | (`tabId`: `string`) => `string`                      |
-| `$INSPECTOR_SET`                  | (`tabId`: `string`) => `string`                      |
-| `$MULTI_SELECT_COPY`              | (`tabId`: `string`) => `string`                      |
-| `$MULTI_SELECT_PASTE`             | (`tabId`: `string`) => `string`                      |
-| `$NODE_SET`                       | (`tabId`: `string`, `nodeId`: `number`) => `string`  |
-| `$PLAYTEST_INPUT`                 | (`tabId`: `string`) => `string`                      |
-| `$PLAYTEST_PRINT`                 | (`tabId`: `string`) => `string`                      |
-| `$PROCESS`                        | (`tabId`: `string`) => `string`                      |
-| `$REDO`                           | (`tabId`: `string`) => `string`                      |
-| `$REFRESH_EVENT_TABLE`            | (`tabId`: `string`) => `string`                      |
-| `$RUN_SPELL`                      | (`tabId?`: `string`) => `string`                     |
-| `$SAVE_SPELL`                     | (`tabId`: `string`) => `string`                      |
-| `$SAVE_SPELL_DIFF`                | (`tabId`: `string`) => `string`                      |
-| `$SUBSPELL_UPDATED`               | (`spellName`: `string`) => `string`                  |
-| `$TEXT_EDITOR_CLEAR`              | (`tabId`: `string`) => `string`                      |
-| `$TEXT_EDITOR_SET`                | (`tabId`: `string`) => `string`                      |
-| `$TRIGGER`                        | (`tabId`: `string`, `nodeId?`: `number`) => `string` |
-| `$UNDO`                           | (`tabId`: `string`) => `string`                      |
-| `ADD_SUBSPELL`                    | `string`                                             |
-| `DELETE_SUBSPELL`                 | `string`                                             |
-| `OPEN_TAB`                        | `string`                                             |
-| `TOGGLE_SNAP`                     | `string`                                             |
-| `UPDATE_SUBSPELL`                 | `string`                                             |
+| Name | Type |
+| :------ | :------ |
+| `$CLOSE_EDITOR` | (`tabId`: `string`) => `string` |
+| `$CREATE_CONSOLE` | (`tabId`: `string`) => `string` |
+| `$CREATE_DEBUG_CONSOLE` | (`tabId`: `string`) => `string` |
+| `$CREATE_INSPECTOR` | (`tabId`: `string`) => `string` |
+| `$CREATE_MEDIAWINDOW` | (`tabId`: `string`) => `string` |
+| `$CREATE_MESSAGE_REACTION_EDITOR` | (`tabId`: `string`) => `string` |
+| `$CREATE_PLAYTEST` | (`tabId`: `string`) => `string` |
+| `$CREATE_PROJECT_WINDOW` | (`tabId`: `string`) => `string` |
+| `$CREATE_TEXT_EDITOR` | (`tabId`: `string`) => `string` |
+| `$DEBUG_INPUT` | (`tabId`: `string`) => `string` |
+| `$DEBUG_PRINT` | (`tabId`: `string`) => `string` |
+| `$DELETE` | (`tabId`: `string`) => `string` |
+| `$EXPORT` | (`tabId`: `string`) => `string` |
+| `$INSPECTOR_SET` | (`tabId`: `string`) => `string` |
+| `$MULTI_SELECT_COPY` | (`tabId`: `string`) => `string` |
+| `$MULTI_SELECT_PASTE` | (`tabId`: `string`) => `string` |
+| `$NODE_SET` | (`tabId`: `string`, `nodeId`: `number`) => `string` |
+| `$PLAYTEST_INPUT` | (`tabId`: `string`) => `string` |
+| `$PLAYTEST_PRINT` | (`tabId`: `string`) => `string` |
+| `$PROCESS` | (`tabId`: `string`) => `string` |
+| `$REDO` | (`tabId`: `string`) => `string` |
+| `$REFRESH_EVENT_TABLE` | (`tabId`: `string`) => `string` |
+| `$RUN_SPELL` | (`tabId?`: `string`) => `string` |
+| `$SAVE_SPELL` | (`tabId`: `string`) => `string` |
+| `$SAVE_SPELL_DIFF` | (`tabId`: `string`) => `string` |
+| `$SUBSPELL_UPDATED` | (`spellName`: `string`) => `string` |
+| `$TEXT_EDITOR_CLEAR` | (`tabId`: `string`) => `string` |
+| `$TEXT_EDITOR_SET` | (`tabId`: `string`) => `string` |
+| `$TRIGGER` | (`tabId`: `string`, `nodeId?`: `number`) => `string` |
+| `$UNDO` | (`tabId`: `string`) => `string` |
+| `ADD_SUBSPELL` | `string` |
+| `DELETE_SUBSPELL` | `string` |
+| `OPEN_TAB` | `string` |
+| `TOGGLE_SNAP` | `string` |
+| `UPDATE_SUBSPELL` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L203)
+[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L203)
 
----
+___
 
 ### PublishEditorEvent
 
@@ -1651,8 +1650,8 @@ Arguments passed to the `install` function
 
 ##### Parameters
 
-| Name   | Type                        |
-| :----- | :-------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`PubSubData`](#pubsubdata) |
 
 ##### Returns
@@ -1661,9 +1660,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L267)
+[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L267)
 
----
+___
 
 ### RequestData
 
@@ -1671,17 +1670,17 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name        | Type     |
-| :---------- | :------- |
-| `nodeId`    | `number` |
+| Name | Type |
+| :------ | :------ |
+| `nodeId` | `number` |
 | `projectId` | `string` |
-| `spell`     | `string` |
+| `spell` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L627)
+[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L627)
 
----
+___
 
 ### RequestPayload
 
@@ -1689,29 +1688,29 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name            | Type                                |
-| :-------------- | :---------------------------------- |
-| `hidden?`       | `boolean`                           |
-| `model`         | `string`                            |
-| `nodeId?`       | `number`                            |
-| `parameters?`   | `string`                            |
-| `processed?`    | `boolean`                           |
-| `projectId`     | `string`                            |
-| `provider?`     | `string`                            |
-| `requestData`   | `string`                            |
-| `responseData?` | `string`                            |
-| `spell?`        | [`SpellInterface`](#spellinterface) |
-| `startTime`     | `number`                            |
-| `status?`       | `string`                            |
-| `statusCode?`   | `number`                            |
-| `totalTokens?`  | `number`                            |
-| `type?`         | `string`                            |
+| Name | Type |
+| :------ | :------ |
+| `hidden?` | `boolean` |
+| `model` | `string` |
+| `nodeId?` | `number` |
+| `parameters?` | `string` |
+| `processed?` | `boolean` |
+| `projectId` | `string` |
+| `provider?` | `string` |
+| `requestData` | `string` |
+| `responseData?` | `string` |
+| `spell?` | [`SpellInterface`](#spellinterface) |
+| `startTime` | `number` |
+| `status?` | `string` |
+| `statusCode?` | `number` |
+| `totalTokens?` | `number` |
+| `type?` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L609)
+[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L609)
 
----
+___
 
 ### Route
 
@@ -1719,25 +1718,25 @@ Arguments passed to the `install` function
 
 #### Type declaration
 
-| Name          | Type                          |
-| :------------ | :---------------------------- |
-| `del?`        | [`Handler`](#handler)         |
-| `delete?`     | [`Handler`](#handler)         |
-| `get?`        | [`Handler`](#handler)         |
-| `handler?`    | [`Handler`](#handler)         |
-| `head?`       | [`Handler`](#handler)         |
-| `method?`     | [`Method`](#method)           |
+| Name | Type |
+| :------ | :------ |
+| `del?` | [`Handler`](#handler) |
+| `delete?` | [`Handler`](#handler) |
+| `get?` | [`Handler`](#handler) |
+| `handler?` | [`Handler`](#handler) |
+| `head?` | [`Handler`](#handler) |
+| `method?` | [`Method`](#method) |
 | `middleware?` | [`Middleware`](#middleware)[] |
-| `patch?`      | [`Handler`](#handler)         |
-| `path`        | `string`                      |
-| `post?`       | [`Handler`](#handler)         |
-| `put?`        | [`Handler`](#handler)         |
+| `patch?` | [`Handler`](#handler) |
+| `path` | `string` |
+| `post?` | [`Handler`](#handler) |
+| `put?` | [`Handler`](#handler) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L669)
+[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L669)
 
----
+___
 
 ### RunSpell
 
@@ -1751,8 +1750,8 @@ Arguments passed to the `install` function
 
 #### Type parameters
 
-| Name       | Type                           |
-| :--------- | :----------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `DataType` | `Record`<`string`, `unknown`\> |
 
 #### Type declaration
@@ -1768,8 +1767,7 @@ Arguments passed to the `install` function
 ##### Parameters
 
 | Name | Type |
-| :--- | :--- |
-
+| :------ | :------ |
 | `{
   inputs,
   spellId,
@@ -1784,9 +1782,9 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L189)
+[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L189)
 
----
+___
 
 ### RunSpellArgs
 
@@ -1796,22 +1794,22 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Type declaration
 
-| Name               | Type                                                                   |
-| :----------------- | :--------------------------------------------------------------------- |
-| `agent?`           | `any`                                                                  |
-| `app?`             | `any`                                                                  |
-| `inputFormatter?`  | (`graph`: [`GraphData`](#graphdata)) => `Record`<`string`, `unknown`\> |
-| `inputs?`          | `Record`<`string`, `unknown`\>                                         |
-| `projectId`        | `string`                                                               |
-| `publicVariables?` | `Record`<`string`, `unknown`\>                                         |
-| `secrets`          | `Record`<`string`, `string`\>                                          |
-| `spellId`          | `string`                                                               |
+| Name | Type |
+| :------ | :------ |
+| `agent?` | `any` |
+| `app?` | `any` |
+| `inputFormatter?` | (`graph`: [`GraphData`](#graphdata)) => `Record`<`string`, `unknown`\> |
+| `inputs?` | `Record`<`string`, `unknown`\> |
+| `projectId` | `string` |
+| `publicVariables?` | `Record`<`string`, `unknown`\> |
+| `secrets` | `Record`<`string`, `string`\> |
+| `spellId` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/utils/runSpell.ts#L10)
+[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/runSpell.ts#L10)
 
----
+___
 
 ### SearchSchema
 
@@ -1819,34 +1817,34 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Type declaration
 
-| Name          | Type     |
-| :------------ | :------- |
+| Name | Type |
+| :------ | :------ |
 | `description` | `string` |
-| `title`       | `string` |
+| `title` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L457)
+[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L457)
 
----
+___
 
 ### ServerInit
 
-Ƭ **ServerInit**: () => `Promise`<`void`\> \| `null` \| `void`
+Ƭ **ServerInit**: () => `Promise`<`void`\> \| ``null`` \| `void`
 
 #### Type declaration
 
-▸ (): `Promise`<`void`\> \| `null` \| `void`
+▸ (): `Promise`<`void`\> \| ``null`` \| `void`
 
 ##### Returns
 
-`Promise`<`void`\> \| `null` \| `void`
+`Promise`<`void`\> \| ``null`` \| `void`
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L114)
+[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L114)
 
----
+___
 
 ### ServerInits
 
@@ -1854,9 +1852,9 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L115)
+[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L115)
 
----
+___
 
 ### SocketData
 
@@ -1864,29 +1862,29 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Type declaration
 
-| Name            | Type                                        |
-| :-------------- | :------------------------------------------ |
-| `error?`        | { `message`: `string` ; `stack`: `string` } |
-| `error.message` | `string`                                    |
-| `error.stack`   | `string`                                    |
-| `input?`        | [`MagickWorkerInputs`](#magickworkerinputs) |
-| `output?`       | `WorkerOutputs`                             |
+| Name | Type |
+| :------ | :------ |
+| `error?` | { `message`: `string` ; `stack`: `string`  } |
+| `error.message` | `string` |
+| `error.stack` | `string` |
+| `input?` | [`MagickWorkerInputs`](#magickworkerinputs) |
+| `output?` | `WorkerOutputs` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
 
----
+___
 
 ### SocketNameType
 
-Ƭ **SocketNameType**: `"Any"` \| `"Number"` \| `"Boolean"` \| `"Array"` \| `"String"` \| `"Object"` \| `"Trigger"` \| `"Event"` \| `"Task"` \| `"Audio"` \| `"Image"` \| `"Document"` \| `"Embedding"`
+Ƭ **SocketNameType**: ``"Any"`` \| ``"Number"`` \| ``"Boolean"`` \| ``"Array"`` \| ``"String"`` \| ``"Object"`` \| ``"Trigger"`` \| ``"Event"`` \| ``"Task"`` \| ``"Audio"`` \| ``"Image"`` \| ``"Document"`` \| ``"Embedding"``
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L8)
+[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L8)
 
----
+___
 
 ### SocketPluginArgs
 
@@ -1894,27 +1892,27 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Type declaration
 
-| Name      | Type        |
-| :-------- | :---------- |
-| `client?` | `any`       |
-| `server?` | `boolean`   |
+| Name | Type |
+| :------ | :------ |
+| `client?` | `any` |
+| `server?` | `boolean` |
 | `socket?` | `io.Socket` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
 
----
+___
 
 ### SocketType
 
-Ƭ **SocketType**: `"anySocket"` \| `"numberSocket"` \| `"booleanSocket"` \| `"arraySocket"` \| `"stringSocket"` \| `"objectSocket"` \| `"triggerSocket"` \| `"eventSocket"` \| `"taskSocket"` \| `"audioSocket"` \| `"imageSocket"` \| `"embeddingSocket"` \| `"taskSocket"` \| `"documentSocket"`
+Ƭ **SocketType**: ``"anySocket"`` \| ``"numberSocket"`` \| ``"booleanSocket"`` \| ``"arraySocket"`` \| ``"stringSocket"`` \| ``"objectSocket"`` \| ``"triggerSocket"`` \| ``"eventSocket"`` \| ``"taskSocket"`` \| ``"audioSocket"`` \| ``"imageSocket"`` \| ``"embeddingSocket"`` \| ``"taskSocket"`` \| ``"documentSocket"``
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L23)
+[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L23)
 
----
+___
 
 ### SpellInterface
 
@@ -1924,9 +1922,9 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L37)
+[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L37)
 
----
+___
 
 ### Subspell
 
@@ -1934,27 +1932,27 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type declaration
 
-| Name   | Type                      |
-| :----- | :------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`GraphData`](#graphdata) |
-| `id`   | `string`                  |
-| `name` | `string`                  |
+| `id` | `string` |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L342)
+[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L342)
 
----
+___
 
 ### SupportedLanguages
 
-Ƭ **SupportedLanguages**: `"python"` \| `"javascript"`
+Ƭ **SupportedLanguages**: ``"python"`` \| ``"javascript"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L172)
+[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L172)
 
----
+___
 
 ### TaskOptions
 
@@ -1962,18 +1960,18 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type declaration
 
-| Name           | Type                                                                                                                                    |
-| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
-| `init?`        | (`task`: [`Task`](classes/Task.md) \| `undefined`, `node`: `NodeData`) => `void`                                                        |
-| `onRun?`       | (`node`: `NodeData`, `task`: [`Task`](classes/Task.md), `data`: `unknown`, `socketInfo`: [`TaskSocketInfo`](#tasksocketinfo)) => `void` |
-| `outputs`      | `Record`<`string`, `unknown`\>                                                                                                          |
-| `runOneInput?` | `boolean`                                                                                                                               |
+| Name | Type |
+| :------ | :------ |
+| `init?` | (`task`: [`Task`](classes/Task.md) \| `undefined`, `node`: `NodeData`) => `void` |
+| `onRun?` | (`node`: `NodeData`, `task`: [`Task`](classes/Task.md), `data`: `unknown`, `socketInfo`: [`TaskSocketInfo`](#tasksocketinfo)) => `void` |
+| `outputs` | `Record`<`string`, `unknown`\> |
+| `runOneInput?` | `boolean` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
 
----
+___
 
 ### TaskOutput
 
@@ -1981,27 +1979,27 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type declaration
 
-| Name   | Type                                     |
-| :----- | :--------------------------------------- |
-| `key`  | `string`                                 |
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
 | `task` | [`MagickTask`](interfaces/MagickTask.md) |
-| `type` | [`TaskOutputTypes`](#taskoutputtypes)    |
+| `type` | [`TaskOutputTypes`](#taskoutputtypes) |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L433)
+[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L433)
 
----
+___
 
 ### TaskOutputTypes
 
-Ƭ **TaskOutputTypes**: `"option"` \| `"output"`
+Ƭ **TaskOutputTypes**: ``"option"`` \| ``"output"``
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:34](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/taskPlugin/task.ts#L34)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:34](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L34)
 
----
+___
 
 ### TaskSocketInfo
 
@@ -2009,26 +2007,26 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type declaration
 
-| Name           | Type                 |
-| :------------- | :------------------- |
-| `targetNode`   | `NodeData` \| `null` |
-| `targetSocket` | `string` \| `null`   |
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | `NodeData` \| ``null`` |
+| `targetSocket` | `string` \| ``null`` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
 
----
+___
 
 ### TaskType
 
-Ƭ **TaskType**: `"output"` \| `"option"`
+Ƭ **TaskType**: ``"output"`` \| ``"option"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L304)
+[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L304)
 
----
+___
 
 ### TextCompletionData
 
@@ -2036,33 +2034,33 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type declaration
 
-| Name                | Type       |
-| :------------------ | :--------- |
-| `apiKey?`           | `string`   |
-| `frequency_penalty` | `number`   |
-| `max_tokens`        | `number`   |
-| `model`             | `string`   |
-| `presence_penalty`  | `number`   |
-| `prompt`            | `string`   |
-| `stop`              | `string`[] |
-| `temperature`       | `number`   |
-| `top_p`             | `number`   |
+| Name | Type |
+| :------ | :------ |
+| `apiKey?` | `string` |
+| `frequency_penalty` | `number` |
+| `max_tokens` | `number` |
+| `model` | `string` |
+| `presence_penalty` | `number` |
+| `prompt` | `string` |
+| `stop` | `string`[] |
+| `temperature` | `number` |
+| `top_p` | `number` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L526)
+[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L526)
 
----
+___
 
 ### TextCompletionSubtype
 
-Ƭ **TextCompletionSubtype**: `"text"` \| `"embedding"` \| `"chat"`
+Ƭ **TextCompletionSubtype**: ``"text"`` \| ``"embedding"`` \| ``"chat"``
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L478)
+[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L478)
 
----
+___
 
 ### UnknownData
 
@@ -2070,9 +2068,9 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L162)
+[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L162)
 
----
+___
 
 ### UnknownSpellData
 
@@ -2080,9 +2078,9 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L163)
+[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L163)
 
----
+___
 
 ### UpdateModuleSockets
 
@@ -2094,11 +2092,11 @@ The interface for a spell object that's based on the `spellSchema`.
 
 ##### Parameters
 
-| Name             | Type                        |
-| :--------------- | :-------------------------- |
-| `node`           | [`MagickNode`](#magicknode) |
-| `graphData?`     | [`GraphData`](#graphdata)   |
-| `useSocketName?` | `boolean`                   |
+| Name | Type |
+| :------ | :------ |
+| `node` | [`MagickNode`](#magicknode) |
+| `graphData?` | [`GraphData`](#graphdata) |
+| `useSocketName?` | `boolean` |
 
 ##### Returns
 
@@ -2112,9 +2110,9 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
 
----
+___
 
 ### UserSpellManager
 
@@ -2122,19 +2120,19 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L683)
+[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L683)
 
----
+___
 
 ### WorkerData
 
-Ƭ **WorkerData**: `NodeData` & { `[key: string]`: `unknown`; `console?`: `MagickConsole` ; `data?`: [`MagickNodeData`](#magicknodedata) ; `spell?`: `string` }
+Ƭ **WorkerData**: `NodeData` & { `[key: string]`: `unknown`; `console?`: `MagickConsole` ; `data?`: [`MagickNodeData`](#magicknodedata) ; `spell?`: `string`  }
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L389)
+[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L389)
 
----
+___
 
 ### runSpellType
 
@@ -2142,47 +2140,57 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Type parameters
 
-| Name       | Type                                    |
-| :--------- | :-------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `DataType` | [`UnknownSpellData`](#unknownspelldata) |
 
 #### Type declaration
 
-| Name              | Type                                    |
-| :---------------- | :-------------------------------------- |
-| `inputs`          | [`MagickSpellInput`](#magickspellinput) |
-| `projectId`       | `string`                                |
-| `publicVariables` | `DataType`                              |
-| `secrets`         | `Record`<`string`, `string`\>           |
-| `spellId`         | `string`                                |
+| Name | Type |
+| :------ | :------ |
+| `inputs` | [`MagickSpellInput`](#magickspellinput) |
+| `projectId` | `string` |
+| `publicVariables` | `DataType` |
+| `secrets` | `Record`<`string`, `string`\> |
+| `spellId` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L165)
+[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L165)
 
 ## Variables
 
-### API_ROOT_URL
+### AGENT\_UPDATE\_TIME\_MSEC
 
-• `Const` **API_ROOT_URL**: `string`
+• `Const` **AGENT\_UPDATE\_TIME\_MSEC**: `number`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:44](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L44)
+[packages/core/shared/src/config.ts:75](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L75)
 
----
+___
 
-### COST_PER_TOKEN
+### API\_ROOT\_URL
 
-• `Const` **COST_PER_TOKEN**: [`CostPerToken`](#costpertoken)<[`TextModel`](enums/TextModel.md) \| [`EmbeddingModel`](enums/EmbeddingModel.md) \| [`ChatModel`](enums/ChatModel.md)\>
+• `Const` **API\_ROOT\_URL**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:44](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L44)
+
+___
+
+### COST\_PER\_TOKEN
+
+• `Const` **COST\_PER\_TOKEN**: [`CostPerToken`](#costpertoken)<[`TextModel`](enums/TextModel.md) \| [`EmbeddingModel`](enums/EmbeddingModel.md) \| [`ChatModel`](enums/ChatModel.md)\>
 
 The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/cost-calculator.ts#L40)
+[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L40)
 
----
+___
 
 ### CachePlugin
 
@@ -2190,16 +2198,16 @@ The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Type declaration
 
-| Name      | Type                                                            |
-| :-------- | :-------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`MagickEditor`](classes/MagickEditor.md)) => `void` |
-| `name`    | `string`                                                        |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
+[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
 
----
+___
 
 ### ConsolePlugin
 
@@ -2213,76 +2221,76 @@ module:consolePlugin
 
 #### Type declaration
 
-| Name      | Type                                                                                                                 |
-| :-------- | :------------------------------------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md), `[{?`: [`DebuggerArgs`](#debuggerargs)) => `void` |
-| `name`    | `string`                                                                                                             |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
 
----
+___
 
-### DATABASE_URL
+### DATABASE\_URL
 
-• `Const` **DATABASE_URL**: `undefined` \| `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L30)
-
----
-
-### DEFAULT_PROJECT_ID
-
-• `Const` **DEFAULT_PROJECT_ID**: `string`
+• `Const` **DATABASE\_URL**: `undefined` \| `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L31)
+[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L30)
 
----
+___
 
-### DEFAULT_USER_ID
+### DEFAULT\_PROJECT\_ID
 
-• `Const` **DEFAULT_USER_ID**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L33)
-
----
-
-### DEFAULT_USER_TOKEN
-
-• `Const` **DEFAULT_USER_TOKEN**: `string`
+• `Const` **DEFAULT\_PROJECT\_ID**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L34)
+[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L31)
 
----
+___
 
-### ELEVENLABS_API_KEY
+### DEFAULT\_USER\_ID
 
-• `Const` **ELEVENLABS_API_KEY**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L69)
-
----
-
-### ENABLE_SPEECH_SERVER
-
-• `Const` **ENABLE_SPEECH_SERVER**: `string` \| `true`
+• `Const` **DEFAULT\_USER\_ID**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:50](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L50)
+[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L33)
 
----
+___
+
+### DEFAULT\_USER\_TOKEN
+
+• `Const` **DEFAULT\_USER\_TOKEN**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L34)
+
+___
+
+### ELEVENLABS\_API\_KEY
+
+• `Const` **ELEVENLABS\_API\_KEY**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L69)
+
+___
+
+### ENABLE\_SPEECH\_SERVER
+
+• `Const` **ENABLE\_SPEECH\_SERVER**: `string` \| ``true``
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:50](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L50)
+
+___
 
 ### ErrorPlugin
 
@@ -2290,46 +2298,46 @@ module:consolePlugin
 
 #### Type declaration
 
-| Name      | Type                                                                                                                                                              |
-| :-------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `install` | (`engine`: [`IRunContextEditor`](interfaces/IRunContextEditor.md), `options`: { `server?`: `boolean` ; `throwError?`: (`error`: `unknown`) => `void` }) => `void` |
-| `name`    | `string`                                                                                                                                                          |
+| Name | Type |
+| :------ | :------ |
+| `install` | (`engine`: [`IRunContextEditor`](interfaces/IRunContextEditor.md), `options`: { `server?`: `boolean` ; `throwError?`: (`error`: `unknown`) => `void`  }) => `void` |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
+[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
 
----
+___
 
-### FILE_SERVER_PORT
+### FILE\_SERVER\_PORT
 
-• `Const` **FILE_SERVER_PORT**: `string` \| `65530`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L53)
-
----
-
-### FILE_SERVER_URL
-
-• `Const` **FILE_SERVER_URL**: `string`
+• `Const` **FILE\_SERVER\_PORT**: `string` \| ``65530``
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:55](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L55)
+[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L53)
 
----
+___
 
-### GOOGLE_APPLICATION_CREDENTIALS
+### FILE\_SERVER\_URL
 
-• `Const` **GOOGLE_APPLICATION_CREDENTIALS**: `any`
+• `Const` **FILE\_SERVER\_URL**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:46](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L46)
+[packages/core/shared/src/config.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L55)
 
----
+___
+
+### GOOGLE\_APPLICATION\_CREDENTIALS
+
+• `Const` **GOOGLE\_APPLICATION\_CREDENTIALS**: `any`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:46](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L46)
+
+___
 
 ### HistoryPlugin
 
@@ -2337,26 +2345,26 @@ module:consolePlugin
 
 #### Type declaration
 
-| Name      | Type                                             |
-| :-------- | :----------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: `any`, `options`: `Object`) => `void` |
-| `name`    | `string`                                         |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
+[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
 
----
+___
 
-### IGNORE_AUTH
+### IGNORE\_AUTH
 
-• `Const` **IGNORE_AUTH**: `boolean`
+• `Const` **IGNORE\_AUTH**: `boolean`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L29)
+[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L29)
 
----
+___
 
 ### InspectorPlugin
 
@@ -2364,26 +2372,26 @@ module:consolePlugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
+[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
 
----
+___
 
-### JWT_SECRET
+### JWT\_SECRET
 
-• `Const` **JWT_SECRET**: `string`
+• `Const` **JWT\_SECRET**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L62)
+[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L62)
 
----
+___
 
 ### KeyCodePlugin
 
@@ -2391,16 +2399,16 @@ module:consolePlugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
+[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
 
----
+___
 
 ### LifecyclePlugin
 
@@ -2410,16 +2418,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                       |
-| :-------- | :----------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: `NodeEditor`<`any`\>) => `void` |
-| `name`    | `string`                                   |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
+[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
 
----
+___
 
 ### ModulePlugin
 
@@ -2427,16 +2435,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                                                                                                       |
-| :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`runContext`: [`ModuleIRunContextEditor`](interfaces/ModuleIRunContextEditor.md), `__namedParameters`: [`ModulePluginArgs`](#modulepluginargs)) => `void` |
-| `name`    | `string`                                                                                                                                                   |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
 
----
+___
 
 ### MultiCopyPlugin
 
@@ -2444,16 +2452,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
+[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
 
----
+___
 
 ### MultiSocketGenerator
 
@@ -2461,26 +2469,26 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
+[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
 
----
+___
 
-### NODE_ENV
+### NODE\_ENV
 
-• `Const` **NODE_ENV**: `string`
+• `Const` **NODE\_ENV**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L58)
+[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L58)
 
----
+___
 
 ### NodeClickPlugin
 
@@ -2488,56 +2496,66 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
+[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
 
----
+___
 
-### PAGINATE_DEFAULT
+### PAGINATE\_DEFAULT
 
-• `Const` **PAGINATE_DEFAULT**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:60](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L60)
-
----
-
-### PAGINATE_MAX
-
-• `Const` **PAGINATE_MAX**: `string`
+• `Const` **PAGINATE\_DEFAULT**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L61)
+[packages/core/shared/src/config.ts:60](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L60)
 
----
+___
 
-### POSTHOG_API_KEY
+### PAGINATE\_MAX
 
-• `Const` **POSTHOG_API_KEY**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:66](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L66)
-
----
-
-### POSTHOG_ENABLED
-
-• `Const` **POSTHOG_ENABLED**: `boolean`
+• `Const` **PAGINATE\_MAX**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:64](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L64)
+[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L61)
 
----
+___
+
+### PING\_AGENT\_TIME\_MSEC
+
+• `Const` **PING\_AGENT\_TIME\_MSEC**: `number`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L76)
+
+___
+
+### POSTHOG\_API\_KEY
+
+• `Const` **POSTHOG\_API\_KEY**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:66](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L66)
+
+___
+
+### POSTHOG\_ENABLED
+
+• `Const` **POSTHOG\_ENABLED**: `boolean`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L64)
+
+___
 
 ### PRODUCTION
 
@@ -2545,59 +2563,59 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L37)
+[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L37)
 
----
+___
 
-### REDISCLOUD_URL
+### REDISCLOUD\_URL
 
-• `Const` **REDISCLOUD_URL**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L67)
-
----
-
-### SERVER_HOST
-
-• `Const` **SERVER_HOST**: `string`
+• `Const` **REDISCLOUD\_URL**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L39)
+[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L67)
 
----
+___
 
-### SERVER_PORT
+### SERVER\_HOST
 
-• `Const` **SERVER_PORT**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L38)
-
----
-
-### SPEECH_SERVER_PORT
-
-• `Const` **SPEECH_SERVER_PORT**: `string` \| `65532`
+• `Const` **SERVER\_HOST**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:48](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L48)
+[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L39)
 
----
+___
 
-### SPEECH_SERVER_URL
+### SERVER\_PORT
 
-• `Const` **SPEECH_SERVER_URL**: `string`
+• `Const` **SERVER\_PORT**: `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L40)
+[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L38)
 
----
+___
+
+### SPEECH\_SERVER\_PORT
+
+• `Const` **SPEECH\_SERVER\_PORT**: `string` \| ``65532``
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:48](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L48)
+
+___
+
+### SPEECH\_SERVER\_URL
+
+• `Const` **SPEECH\_SERVER\_URL**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L40)
+
+___
 
 ### SelectionPlugin
 
@@ -2605,16 +2623,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                        |
-| :-------- | :---------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: `NodeEditor`<`any`\>, `params`: `Cfg`) => `void` |
-| `name`    | `string`                                                    |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
+[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
 
----
+___
 
 ### SocketGeneratorPlugin
 
@@ -2622,16 +2640,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
+[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
 
----
+___
 
 ### SocketOverridePlugin
 
@@ -2639,16 +2657,16 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                         |
-| :-------- | :--------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md)) => `void` |
-| `name`    | `string`                                                                     |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
+[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
 
----
+___
 
 ### SocketPlugin
 
@@ -2656,26 +2674,26 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                                                                                                       |
-| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`IRunContextEditor`](interfaces/IRunContextEditor.md), `__namedParameters`: [`SocketPluginArgs`](#socketpluginargs)) => `void` |
-| `name`    | `string`                                                                                                                                   |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
 
----
+___
 
-### TRUSTED_PARENT_URL
+### TRUSTED\_PARENT\_URL
 
-• `Const` **TRUSTED_PARENT_URL**: `null` \| `string`
+• `Const` **TRUSTED\_PARENT\_URL**: ``null`` \| `string`
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:42](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L42)
+[packages/core/shared/src/config.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L42)
 
----
+___
 
 ### TaskPlugin
 
@@ -2683,58 +2701,58 @@ Lifecycle Plugin
 
 #### Type declaration
 
-| Name      | Type                                                            |
-| :-------- | :-------------------------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `install` | (`editor`: [`MagickEditor`](classes/MagickEditor.md)) => `void` |
-| `name`    | `string`                                                        |
+| `name` | `string` |
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
+[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
 
----
+___
 
 ### USESSL
 
-• `Const` **USESSL**: `string` \| `false`
+• `Const` **USESSL**: `string` \| ``false``
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:57](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L57)
+[packages/core/shared/src/config.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L57)
 
----
+___
 
-### USSSL_SPEECH
+### USSSL\_SPEECH
 
-• `Const` **USSSL_SPEECH**: `string` \| `true`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:52](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L52)
-
----
-
-### VITE_APP_TRUSTED_PARENT_URL
-
-• `Const` **VITE_APP_TRUSTED_PARENT_URL**: `string`
+• `Const` **USSSL\_SPEECH**: `string` \| ``true``
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/config.ts#L72)
+[packages/core/shared/src/config.ts:52](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L52)
 
----
+___
+
+### VITE\_APP\_TRUSTED\_PARENT\_URL
+
+• `Const` **VITE\_APP\_TRUSTED\_PARENT\_URL**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L72)
+
+___
 
 ### agentSchema
 
-• `Const` **agentSchema**: `TObject`<{ `data`: `TOptional`<`TAny`\> ; `enabled`: `TOptional`<`TBoolean`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `pingedAt`: `TOptional`<`TString`<`string`\>\> ; `projectId`: `TString`<`string`\> ; `publicVariables`: `TOptional`<`TAny`\> ; `rootSpell`: `TOptional`<`TAny`\> ; `secrets`: `TOptional`<`TString`<`string`\>\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\> }\>
+• `Const` **agentSchema**: `TObject`<{ `data`: `TOptional`<`TAny`\> ; `enabled`: `TOptional`<`TBoolean`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `pingedAt`: `TOptional`<`TString`<`string`\>\> ; `projectId`: `TString`<`string`\> ; `publicVariables`: `TOptional`<`TAny`\> ; `rootSpell`: `TOptional`<`TAny`\> ; `secrets`: `TOptional`<`TString`<`string`\>\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\>  }\>
 
 Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L53)
+[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L53)
 
----
+___
 
 ### anySocket
 
@@ -2742,9 +2760,9 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L55)
+[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L55)
 
----
+___
 
 ### arraySocket
 
@@ -2752,9 +2770,9 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L58)
+[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L58)
 
----
+___
 
 ### audioSocket
 
@@ -2762,9 +2780,9 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L63)
+[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L63)
 
----
+___
 
 ### booleanSocket
 
@@ -2772,9 +2790,9 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L57)
+[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L57)
 
----
+___
 
 ### components
 
@@ -2782,21 +2800,21 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/nodes/index.ts#L71)
+[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/nodes/index.ts#L71)
 
----
+___
 
 ### documentSchema
 
-• `Const` **documentSchema**: `TObject`<{ `content`: `TOptional`<`TString`<`string`\>\> ; `date`: `TOptional`<`TString`<`string`\>\> ; `embedding`: `TOptional`<`TAny`\> ; `id`: `TString`<`string`\> ; `projectId`: `TString`<`string`\> ; `type`: `TOptional`<`TString`<`string`\>\> }\>
+• `Const` **documentSchema**: `TObject`<{ `content`: `TOptional`<`TString`<`string`\>\> ; `date`: `TOptional`<`TString`<`string`\>\> ; `embedding`: `TOptional`<`TAny`\> ; `id`: `TString`<`string`\> ; `projectId`: `TString`<`string`\> ; `type`: `TOptional`<`TString`<`string`\>\>  }\>
 
 Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L87)
+[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L87)
 
----
+___
 
 ### documentSocket
 
@@ -2804,9 +2822,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L64)
+[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L64)
 
----
+___
 
 ### embeddingSocket
 
@@ -2814,9 +2832,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L65)
+[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L65)
 
----
+___
 
 ### eventSocket
 
@@ -2824,9 +2842,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L62)
+[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L62)
 
----
+___
 
 ### globalsManager
 
@@ -2834,9 +2852,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/globals.ts#L38)
+[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/globals.ts#L38)
 
----
+___
 
 ### imageSocket
 
@@ -2844,9 +2862,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L67)
+[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L67)
 
----
+___
 
 ### numberSocket
 
@@ -2854,9 +2872,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L56)
+[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L56)
 
----
+___
 
 ### objectSocket
 
@@ -2864,9 +2882,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L60)
+[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L60)
 
----
+___
 
 ### pluginManager
 
@@ -2874,9 +2892,9 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/plugin.ts#L463)
+[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L463)
 
----
+___
 
 ### socketNameMap
 
@@ -2884,21 +2902,21 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L39)
+[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L39)
 
----
+___
 
 ### spellSchema
 
-• `Const` **spellSchema**: `TObject`<{ `createdAt`: `TOptional`<`TString`<`string`\>\> ; `graph`: `TObject`<{ `id`: `TString`<`string`\> ; `nodes`: `TAny` }\> ; `hash`: `TString`<`string`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `projectId`: `TString`<`string`\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\> }\>
+• `Const` **spellSchema**: `TObject`<{ `createdAt`: `TOptional`<`TString`<`string`\>\> ; `graph`: `TObject`<{ `id`: `TString`<`string`\> ; `nodes`: `TAny`  }\> ; `hash`: `TString`<`string`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `projectId`: `TString`<`string`\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\>  }\>
 
 Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/schemas.ts#L17)
+[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L17)
 
----
+___
 
 ### stringSocket
 
@@ -2906,9 +2924,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L59)
+[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L59)
 
----
+___
 
 ### taskSocket
 
@@ -2916,9 +2934,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L66)
+[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L66)
 
----
+___
 
 ### triggerSocket
 
@@ -2926,7 +2944,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/sockets.ts#L61)
+[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L61)
 
 ## Functions
 
@@ -2936,8 +2954,8 @@ Full data model schema for a spell.
 
 #### Parameters
 
-| Name   | Type                          |
-| :----- | :---------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `data` | `InputsData` \| `OutputsData` |
 
 #### Returns
@@ -2946,9 +2964,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L398)
+[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L398)
 
----
+___
 
 ### AsInputsAndOutputsData
 
@@ -2956,8 +2974,8 @@ Full data model schema for a spell.
 
 #### Parameters
 
-| Name   | Type                                  |
-| :----- | :------------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`DataSocketType`](#datasockettype)[] |
 
 #### Returns
@@ -2966,9 +2984,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L410)
+[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L410)
 
----
+___
 
 ### AsInputsData
 
@@ -2976,8 +2994,8 @@ Full data model schema for a spell.
 
 #### Parameters
 
-| Name   | Type                                  |
-| :----- | :------------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`DataSocketType`](#datasockettype)[] |
 
 #### Returns
@@ -2986,9 +3004,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L402)
+[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L402)
 
----
+___
 
 ### AsOutputsData
 
@@ -2996,8 +3014,8 @@ Full data model schema for a spell.
 
 #### Parameters
 
-| Name   | Type                                  |
-| :----- | :------------------------------------ |
+| Name | Type |
+| :------ | :------ |
 | `data` | [`DataSocketType`](#datasockettype)[] |
 
 #### Returns
@@ -3006,9 +3024,9 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/types.ts#L406)
+[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L406)
 
----
+___
 
 ### calculateCompletionCost
 
@@ -3019,11 +3037,11 @@ for a given TextModel or ChatModel
 
 #### Parameters
 
-| Name                 | Type                                                                   | Description                     |
-| :------------------- | :--------------------------------------------------------------------- | :------------------------------ |
-| `params`             | `Object`                                                               | The parameters for the function |
-| `params.model`       | [`TextModel`](enums/TextModel.md) \| [`ChatModel`](enums/ChatModel.md) | The model to be used            |
-| `params.totalTokens` | `number`                                                               | The total number of tokens      |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | The parameters for the function |
+| `params.model` | [`TextModel`](enums/TextModel.md) \| [`ChatModel`](enums/ChatModel.md) | The model to be used |
+| `params.totalTokens` | `number` | The total number of tokens |
 
 #### Returns
 
@@ -3031,9 +3049,9 @@ for a given TextModel or ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/cost-calculator.ts#L62)
+[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L62)
 
----
+___
 
 ### calculateEmbeddingCost
 
@@ -3044,11 +3062,11 @@ for a given EmbeddingModel
 
 #### Parameters
 
-| Name            | Type                                        | Description                     |
-| :-------------- | :------------------------------------------ | :------------------------------ |
-| `params`        | `Object`                                    | The parameters for the function |
-| `params.model`  | [`EmbeddingModel`](enums/EmbeddingModel.md) | The model to be used            |
-| `params.tokens` | `number`                                    | The number of tokens            |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `params` | `Object` | The parameters for the function |
+| `params.model` | [`EmbeddingModel`](enums/EmbeddingModel.md) | The model to be used |
+| `params.tokens` | `number` | The number of tokens |
 
 #### Returns
 
@@ -3056,13 +3074,13 @@ for a given EmbeddingModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/cost-calculator.ts#L80)
+[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L80)
 
----
+___
 
 ### configureManager
 
-▸ **configureManager**(): (`app`: { `userSpellManagers?`: [`UserSpellManager`](#userspellmanager) }) => `void`
+▸ **configureManager**(): (`app`: { `userSpellManagers?`: [`UserSpellManager`](#userspellmanager)  }) => `void`
 
 #### Returns
 
@@ -3072,9 +3090,9 @@ for a given EmbeddingModel
 
 ##### Parameters
 
-| Name                     | Type                                    |
-| :----------------------- | :-------------------------------------- |
-| `app`                    | `Object`                                |
+| Name | Type |
+| :------ | :------ |
+| `app` | `Object` |
 | `app.userSpellManagers?` | [`UserSpellManager`](#userspellmanager) |
 
 ##### Returns
@@ -3083,9 +3101,9 @@ for a given EmbeddingModel
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/spellManager/configureManager.ts#L3)
+[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/spellManager/configureManager.ts#L3)
 
----
+___
 
 ### extractModuleInputKeys
 
@@ -3095,8 +3113,8 @@ Extracts all module inputs based upon a given key.
 
 #### Parameters
 
-| Name   | Type   | Description                                                        |
-| :----- | :----- | :----------------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `data` | `Data` | The data object which contains the GraphData to search inputs for. |
 
 #### Returns
@@ -3107,9 +3125,9 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
+[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
 
----
+___
 
 ### extractNodes
 
@@ -3117,10 +3135,10 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Parameters
 
-| Name    | Type                                            |
-| :------ | :---------------------------------------------- |
-| `nodes` | `NodesData`                                     |
-| `map`   | `Map`<`string`, `unknown`\> \| `Set`<`string`\> |
+| Name | Type |
+| :------ | :------ |
+| `nodes` | `NodesData` |
+| `map` | `Map`<`string`, `unknown`\> \| `Set`<`string`\> |
 
 #### Returns
 
@@ -3128,9 +3146,9 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:100](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L100)
+[packages/core/shared/src/engine.ts:100](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L100)
 
----
+___
 
 ### getLogger
 
@@ -3142,9 +3160,9 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/logger/index.ts#L27)
+[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/logger/index.ts#L27)
 
----
+___
 
 ### getNodes
 
@@ -3160,9 +3178,9 @@ An array of sorted MagickComponents.
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/nodes/index.ts#L163)
+[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/nodes/index.ts#L163)
 
----
+___
 
 ### getSpell
 
@@ -3172,8 +3190,8 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Parameters
 
-| Name    | Type       | Description                                              |
-| :------ | :--------- | :------------------------------------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `input` | `GetSpell` | Object containing the app, id of the spell and projectId |
 
 #### Returns
@@ -3184,9 +3202,9 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/utils/getSpell.ts#L18)
+[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/getSpell.ts#L18)
 
----
+___
 
 ### getTriggeredNode
 
@@ -3194,11 +3212,11 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Parameters
 
-| Name        | Type                                            |
-| :---------- | :---------------------------------------------- |
-| `data`      | `Data`                                          |
-| `socketKey` | `string`                                        |
-| `map`       | `Map`<`string`, `unknown`\> \| `Set`<`string`\> |
+| Name | Type |
+| :------ | :------ |
+| `data` | `Data` |
+| `socketKey` | `string` |
+| `map` | `Map`<`string`, `unknown`\> \| `Set`<`string`\> |
 
 #### Returns
 
@@ -3206,9 +3224,9 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:113](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L113)
+[packages/core/shared/src/engine.ts:113](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L113)
 
----
+___
 
 ### initLogger
 
@@ -3216,8 +3234,8 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Parameters
 
-| Name   | Type     | Default value       |
-| :----- | :------- | :------------------ |
+| Name | Type | Default value |
+| :------ | :------ | :------ |
 | `opts` | `object` | `defaultLoggerOpts` |
 
 #### Returns
@@ -3226,9 +3244,9 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/logger/index.ts#L8)
+[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/logger/index.ts#L8)
 
----
+___
 
 ### initSharedEngine
 
@@ -3236,8 +3254,8 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Parameters
 
-| Name             | Type                                          |
-| :--------------- | :-------------------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `«destructured»` | [`InitEngineArguments`](#initenginearguments) |
 
 #### Returns
@@ -3246,13 +3264,13 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:64](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/engine.ts#L64)
+[packages/core/shared/src/engine.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L64)
 
----
+___
 
 ### mapStatusCode
 
-▸ **mapStatusCode**(`customErrorCode`): `400` \| `401` \| `404` \| `500` \| `239`
+▸ **mapStatusCode**(`customErrorCode`): ``400`` \| ``401`` \| ``404`` \| ``500`` \| ``239``
 
 Maps the custom error code to its corresponding HTTP status code.
 
@@ -3260,21 +3278,21 @@ Maps the custom error code to its corresponding HTTP status code.
 
 #### Parameters
 
-| Name              | Type                                    | Description                  |
-| :---------------- | :-------------------------------------- | :--------------------------- |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `customErrorCode` | [`CustomErrorCodes`](#customerrorcodes) | The code of the custom error |
 
 #### Returns
 
-`400` \| `401` \| `404` \| `500` \| `239`
+``400`` \| ``401`` \| ``404`` \| ``500`` \| ``239``
 
 The corresponding HTTP status code
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/utils/SpellError.ts#L51)
+[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/SpellError.ts#L51)
 
----
+___
 
 ### processCode
 
@@ -3284,11 +3302,11 @@ Process the code based on the given inputs.
 
 #### Parameters
 
-| Name       | Type                                        | Default value  | Description                                                              |
-| :--------- | :------------------------------------------ | :------------- | :----------------------------------------------------------------------- |
-| `code`     | `unknown`                                   | `undefined`    | The code to process.                                                     |
-| `inputs`   | [`MagickWorkerInputs`](#magickworkerinputs) | `undefined`    | The input values for the code.                                           |
-| `data`     | [`UnknownData`](#unknowndata)               | `undefined`    | The data values required for processing the code.                        |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `code` | `unknown` | `undefined` | The code to process. |
+| `inputs` | [`MagickWorkerInputs`](#magickworkerinputs) | `undefined` | The input values for the code. |
+| `data` | [`UnknownData`](#unknowndata) | `undefined` | The data values required for processing the code. |
 | `language` | [`SupportedLanguages`](#supportedlanguages) | `'javascript'` | The supported language for processing the code. Default is `javascript`. |
 
 #### Returns
@@ -3299,9 +3317,9 @@ The result of processing the code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/functions/processCode.ts#L23)
+[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/processCode.ts#L23)
 
----
+___
 
 ### runPython
 
@@ -3311,11 +3329,11 @@ Run Python code using Pyodide and return the result.
 
 #### Parameters
 
-| Name    | Type  | Description                                 |
-| :------ | :---- | :------------------------------------------ |
-| `code`  | `any` | The Python code to run.                     |
-| `entry` | `any` | The input values for the Python code.       |
-| `data`  | `any` | Additional data to pass to the Python code. |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `code` | `any` | The Python code to run. |
+| `entry` | `any` | The input values for the Python code. |
+| `data` | `any` | Additional data to pass to the Python code. |
 
 #### Returns
 
@@ -3325,13 +3343,13 @@ The result of the executed Python code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/functions/ProcessPython.ts#L17)
+[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/ProcessPython.ts#L17)
 
----
+___
 
 ### runSpell
 
-▸ **runSpell**(`params`): `Promise`<{ `name`: `string` ; `outputs`: `Record`<`string`, `unknown`\> }\>
+▸ **runSpell**(`params`): `Promise`<{ `name`: `string` ; `outputs`: `Record`<`string`, `unknown`\>  }\>
 
 Run a spell with the given parameters.
 
@@ -3341,21 +3359,21 @@ Run a spell with the given parameters.
 
 #### Parameters
 
-| Name     | Type                            | Description                           |
-| :------- | :------------------------------ | :------------------------------------ |
+| Name | Type | Description |
+| :------ | :------ | :------ |
 | `params` | [`RunSpellArgs`](#runspellargs) | The parameters needed to run a spell. |
 
 #### Returns
 
-`Promise`<{ `name`: `string` ; `outputs`: `Record`<`string`, `unknown`\> }\>
+`Promise`<{ `name`: `string` ; `outputs`: `Record`<`string`, `unknown`\>  }\>
 
 - The outputs from the spell and its name.
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/utils/runSpell.ts#L28)
+[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/runSpell.ts#L28)
 
----
+___
 
 ### saveRequest
 
@@ -3365,8 +3383,8 @@ Calculate and save request details in the module.
 
 #### Parameters
 
-| Name             | Type                                |
-| :--------------- | :---------------------------------- |
+| Name | Type |
+| :------ | :------ |
 | `«destructured»` | [`RequestPayload`](#requestpayload) |
 
 #### Returns
@@ -3377,4 +3395,4 @@ A promise that resolves the saved request object.
 
 #### Defined in
 
-[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/e13715ba/packages/core/shared/src/functions/saveRequest.ts#L27)
+[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/saveRequest.ts#L27)

--- a/apps/docs/docs/api/index.md
+++ b/apps/docs/docs/api/index.md
@@ -59,7 +59,7 @@ The interface for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L75)
+[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L75)
 
 ___
 
@@ -71,7 +71,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L73)
+[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L73)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L73)
+[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L73)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L84)
+[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L84)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L633)
+[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L633)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L480)
+[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L480)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L543)
+[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L543)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L538)
+[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L538)
 
 ___
 
@@ -208,7 +208,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L462)
+[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L462)
 
 ___
 
@@ -227,7 +227,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L600)
+[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L600)
 
 ___
 
@@ -247,7 +247,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L493)
+[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L493)
 
 ___
 
@@ -273,7 +273,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L507)
+[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L507)
 
 ___
 
@@ -291,7 +291,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L482)
+[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L482)
 
 ___
 
@@ -301,7 +301,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L474)
+[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L474)
 
 ___
 
@@ -317,7 +317,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L352)
+[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L352)
 
 ___
 
@@ -327,7 +327,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L305)
+[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L305)
 
 ___
 
@@ -345,7 +345,7 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L33)
+[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/cost-calculator.ts#L33)
 
 ___
 
@@ -367,7 +367,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L63)
+[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L63)
 
 ___
 
@@ -377,7 +377,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L55)
+[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L55)
 
 ___
 
@@ -387,7 +387,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L110)
+[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L110)
 
 ___
 
@@ -399,7 +399,7 @@ The possible custom error codes to be used in the application.
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/SpellError.ts#L5)
+[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/utils/SpellError.ts#L5)
 
 ___
 
@@ -420,7 +420,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L307)
+[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L307)
 
 ___
 
@@ -439,7 +439,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
 
 ___
 
@@ -460,7 +460,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L46)
+[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L46)
 
 ___
 
@@ -478,7 +478,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L557)
+[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L557)
 
 ___
 
@@ -502,7 +502,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L197)
+[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L197)
 
 ___
 
@@ -518,7 +518,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L158)
+[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L158)
 
 ___
 
@@ -548,7 +548,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L92)
+[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L92)
 
 ___
 
@@ -558,7 +558,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L133)
+[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L133)
 
 ___
 
@@ -586,7 +586,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L284)
+[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L284)
 
 ___
 
@@ -596,7 +596,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L455)
+[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L455)
 
 ___
 
@@ -606,7 +606,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L57)
+[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L57)
 
 ___
 
@@ -631,7 +631,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L112)
+[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L112)
 
 ___
 
@@ -672,7 +672,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L174)
+[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L174)
 
 ___
 
@@ -690,7 +690,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L127)
+[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L127)
 
 ___
 
@@ -700,7 +700,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L448)
+[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L448)
 
 ___
 
@@ -710,7 +710,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L344)
+[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L344)
 
 ___
 
@@ -734,7 +734,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L667)
+[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L667)
 
 ___
 
@@ -744,7 +744,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L346)
+[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L346)
 
 ___
 
@@ -760,7 +760,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L42)
+[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L42)
 
 ___
 
@@ -770,7 +770,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L476)
+[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L476)
 
 ___
 
@@ -791,7 +791,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L33)
+[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L33)
 
 ___
 
@@ -811,7 +811,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L55)
+[packages/core/shared/src/engine.ts:55](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L55)
 
 ___
 
@@ -821,7 +821,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L359)
+[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L359)
 
 ___
 
@@ -842,7 +842,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
+[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
 
 ___
 
@@ -852,7 +852,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L123)
+[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L123)
 
 ___
 
@@ -862,7 +862,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L316)
+[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L316)
 
 ___
 
@@ -872,7 +872,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L317)
+[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L317)
 
 ___
 
@@ -888,7 +888,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:221](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L221)
+[packages/core/shared/src/engine.ts:221](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L221)
 
 ___
 
@@ -898,7 +898,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L322)
+[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L322)
 
 ___
 
@@ -923,7 +923,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L379)
+[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L379)
 
 ___
 
@@ -942,7 +942,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L426)
+[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L426)
 
 ___
 
@@ -952,7 +952,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L418)
+[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L418)
 
 ___
 
@@ -962,7 +962,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L419)
+[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L419)
 
 ___
 
@@ -972,7 +972,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L441)
+[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L441)
 
 ___
 
@@ -986,7 +986,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L442)
+[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L442)
 
 ___
 
@@ -996,7 +996,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L443)
+[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L443)
 
 ___
 
@@ -1006,7 +1006,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L607)
+[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L607)
 
 ___
 
@@ -1025,7 +1025,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L467)
+[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L467)
 
 ___
 
@@ -1035,7 +1035,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L655)
+[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L655)
 
 ___
 
@@ -1060,7 +1060,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L653)
+[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L653)
 
 ___
 
@@ -1078,7 +1078,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L416)
+[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L416)
 
 ___
 
@@ -1088,7 +1088,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L362)
+[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L362)
 
 ___
 
@@ -1119,7 +1119,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L577)
+[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L577)
 
 ___
 
@@ -1135,7 +1135,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
 
 ___
 
@@ -1152,7 +1152,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
 
 ___
 
@@ -1174,7 +1174,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
 
 ___
 
@@ -1194,7 +1194,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L334)
+[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L334)
 
 ___
 
@@ -1204,7 +1204,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L439)
+[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L439)
 
 ___
 
@@ -1221,7 +1221,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L421)
+[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L421)
 
 ___
 
@@ -1240,7 +1240,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L366)
+[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L366)
 
 ___
 
@@ -1254,7 +1254,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L373)
+[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L373)
 
 ___
 
@@ -1285,7 +1285,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L262)
+[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L262)
 
 ___
 
@@ -1315,7 +1315,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L261)
+[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L261)
 
 ___
 
@@ -1339,7 +1339,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L260)
+[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L260)
 
 ___
 
@@ -1370,7 +1370,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L256)
+[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L256)
 
 ___
 
@@ -1394,7 +1394,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L255)
+[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L255)
 
 ___
 
@@ -1418,7 +1418,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L135)
+[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L135)
 
 ___
 
@@ -1428,7 +1428,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L360)
+[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L360)
 
 ___
 
@@ -1438,7 +1438,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L67)
+[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L67)
 
 ___
 
@@ -1457,7 +1457,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L18)
+[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L18)
 
 ___
 
@@ -1475,7 +1475,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L12)
+[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L12)
 
 ___
 
@@ -1495,7 +1495,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L27)
+[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L27)
 
 ___
 
@@ -1514,7 +1514,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L5)
+[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L5)
 
 ___
 
@@ -1524,7 +1524,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L25)
+[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L25)
 
 ___
 
@@ -1551,7 +1551,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L182)
+[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L182)
 
 ___
 
@@ -1576,7 +1576,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L253)
+[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L253)
 
 ___
 
@@ -1586,7 +1586,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L252)
+[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L252)
 
 ___
 
@@ -1636,7 +1636,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L203)
+[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L203)
 
 ___
 
@@ -1660,7 +1660,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L267)
+[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L267)
 
 ___
 
@@ -1678,7 +1678,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L627)
+[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L627)
 
 ___
 
@@ -1708,7 +1708,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L609)
+[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L609)
 
 ___
 
@@ -1734,7 +1734,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L669)
+[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L669)
 
 ___
 
@@ -1782,7 +1782,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L189)
+[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L189)
 
 ___
 
@@ -1807,7 +1807,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/runSpell.ts#L10)
+[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/utils/runSpell.ts#L10)
 
 ___
 
@@ -1824,7 +1824,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L457)
+[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L457)
 
 ___
 
@@ -1842,7 +1842,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L114)
+[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L114)
 
 ___
 
@@ -1852,7 +1852,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L115)
+[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L115)
 
 ___
 
@@ -1872,7 +1872,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
 
 ___
 
@@ -1882,7 +1882,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L8)
+[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L8)
 
 ___
 
@@ -1900,7 +1900,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
 
 ___
 
@@ -1910,7 +1910,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L23)
+[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L23)
 
 ___
 
@@ -1922,7 +1922,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L37)
+[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L37)
 
 ___
 
@@ -1940,7 +1940,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L342)
+[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L342)
 
 ___
 
@@ -1950,7 +1950,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L172)
+[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L172)
 
 ___
 
@@ -1969,7 +1969,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
 
 ___
 
@@ -1987,7 +1987,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L433)
+[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L433)
 
 ___
 
@@ -1997,7 +1997,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:34](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L34)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:34](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/taskPlugin/task.ts#L34)
 
 ___
 
@@ -2014,7 +2014,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
 
 ___
 
@@ -2024,7 +2024,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L304)
+[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L304)
 
 ___
 
@@ -2048,7 +2048,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L526)
+[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L526)
 
 ___
 
@@ -2058,7 +2058,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L478)
+[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L478)
 
 ___
 
@@ -2068,7 +2068,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L162)
+[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L162)
 
 ___
 
@@ -2078,7 +2078,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L163)
+[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L163)
 
 ___
 
@@ -2110,7 +2110,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
 
 ___
 
@@ -2120,7 +2120,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L683)
+[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L683)
 
 ___
 
@@ -2130,7 +2130,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L389)
+[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L389)
 
 ___
 
@@ -2156,7 +2156,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L165)
+[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L165)
 
 ## Variables
 
@@ -2166,7 +2166,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:75](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L75)
+[packages/core/shared/src/config.ts:75](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L75)
 
 ___
 
@@ -2176,7 +2176,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:44](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L44)
+[packages/core/shared/src/config.ts:44](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L44)
 
 ___
 
@@ -2188,7 +2188,7 @@ The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L40)
+[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/cost-calculator.ts#L40)
 
 ___
 
@@ -2205,7 +2205,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
+[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
 
 ___
 
@@ -2228,7 +2228,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
 
 ___
 
@@ -2238,7 +2238,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L30)
+[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L30)
 
 ___
 
@@ -2248,7 +2248,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L31)
+[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L31)
 
 ___
 
@@ -2258,7 +2258,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L33)
+[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L33)
 
 ___
 
@@ -2268,7 +2268,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L34)
+[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L34)
 
 ___
 
@@ -2278,7 +2278,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L69)
+[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L69)
 
 ___
 
@@ -2288,7 +2288,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:50](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L50)
+[packages/core/shared/src/config.ts:50](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L50)
 
 ___
 
@@ -2305,7 +2305,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
+[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
 
 ___
 
@@ -2315,7 +2315,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L53)
+[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L53)
 
 ___
 
@@ -2325,7 +2325,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L55)
+[packages/core/shared/src/config.ts:55](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L55)
 
 ___
 
@@ -2335,7 +2335,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:46](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L46)
+[packages/core/shared/src/config.ts:46](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L46)
 
 ___
 
@@ -2352,7 +2352,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
+[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
 
 ___
 
@@ -2362,7 +2362,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L29)
+[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L29)
 
 ___
 
@@ -2379,7 +2379,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
+[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
 
 ___
 
@@ -2389,7 +2389,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L62)
+[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L62)
 
 ___
 
@@ -2406,7 +2406,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
+[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
 
 ___
 
@@ -2425,7 +2425,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
+[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
 
 ___
 
@@ -2442,7 +2442,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
 
 ___
 
@@ -2459,7 +2459,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
+[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
 
 ___
 
@@ -2476,7 +2476,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
+[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
 
 ___
 
@@ -2486,7 +2486,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L58)
+[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L58)
 
 ___
 
@@ -2503,7 +2503,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
+[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
 
 ___
 
@@ -2513,7 +2513,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:60](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L60)
+[packages/core/shared/src/config.ts:60](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L60)
 
 ___
 
@@ -2523,7 +2523,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L61)
+[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L61)
 
 ___
 
@@ -2533,7 +2533,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L76)
+[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L76)
 
 ___
 
@@ -2543,7 +2543,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:66](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L66)
+[packages/core/shared/src/config.ts:66](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L66)
 
 ___
 
@@ -2553,7 +2553,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L64)
+[packages/core/shared/src/config.ts:64](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L64)
 
 ___
 
@@ -2563,7 +2563,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L37)
+[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L37)
 
 ___
 
@@ -2573,7 +2573,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L67)
+[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L67)
 
 ___
 
@@ -2583,7 +2583,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L39)
+[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L39)
 
 ___
 
@@ -2593,7 +2593,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L38)
+[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L38)
 
 ___
 
@@ -2603,7 +2603,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:48](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L48)
+[packages/core/shared/src/config.ts:48](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L48)
 
 ___
 
@@ -2613,7 +2613,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L40)
+[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L40)
 
 ___
 
@@ -2630,7 +2630,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
+[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
 
 ___
 
@@ -2647,7 +2647,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
+[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
 
 ___
 
@@ -2664,7 +2664,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
+[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
 
 ___
 
@@ -2681,7 +2681,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
 
 ___
 
@@ -2691,7 +2691,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:42](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L42)
+[packages/core/shared/src/config.ts:42](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L42)
 
 ___
 
@@ -2708,7 +2708,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
+[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
 
 ___
 
@@ -2718,7 +2718,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L57)
+[packages/core/shared/src/config.ts:57](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L57)
 
 ___
 
@@ -2728,7 +2728,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:52](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L52)
+[packages/core/shared/src/config.ts:52](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L52)
 
 ___
 
@@ -2738,7 +2738,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/config.ts#L72)
+[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/config.ts#L72)
 
 ___
 
@@ -2750,7 +2750,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L53)
+[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L53)
 
 ___
 
@@ -2760,7 +2760,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L55)
+[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L55)
 
 ___
 
@@ -2770,7 +2770,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L58)
+[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L58)
 
 ___
 
@@ -2780,7 +2780,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L63)
+[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L63)
 
 ___
 
@@ -2790,7 +2790,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L57)
+[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L57)
 
 ___
 
@@ -2800,7 +2800,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/nodes/index.ts#L71)
+[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/nodes/index.ts#L71)
 
 ___
 
@@ -2812,7 +2812,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L87)
+[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L87)
 
 ___
 
@@ -2822,7 +2822,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L64)
+[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L64)
 
 ___
 
@@ -2832,7 +2832,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L65)
+[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L65)
 
 ___
 
@@ -2842,7 +2842,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L62)
+[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L62)
 
 ___
 
@@ -2852,7 +2852,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/globals.ts#L38)
+[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/globals.ts#L38)
 
 ___
 
@@ -2862,7 +2862,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L67)
+[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L67)
 
 ___
 
@@ -2872,7 +2872,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L56)
+[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L56)
 
 ___
 
@@ -2882,7 +2882,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L60)
+[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L60)
 
 ___
 
@@ -2892,7 +2892,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/plugin.ts#L463)
+[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/plugin.ts#L463)
 
 ___
 
@@ -2902,7 +2902,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L39)
+[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L39)
 
 ___
 
@@ -2914,7 +2914,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/schemas.ts#L17)
+[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/schemas.ts#L17)
 
 ___
 
@@ -2924,7 +2924,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L59)
+[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L59)
 
 ___
 
@@ -2934,7 +2934,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L66)
+[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L66)
 
 ___
 
@@ -2944,7 +2944,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/sockets.ts#L61)
+[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/sockets.ts#L61)
 
 ## Functions
 
@@ -2964,7 +2964,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L398)
+[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L398)
 
 ___
 
@@ -2984,7 +2984,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L410)
+[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L410)
 
 ___
 
@@ -3004,7 +3004,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L402)
+[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L402)
 
 ___
 
@@ -3024,7 +3024,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/types.ts#L406)
+[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/types.ts#L406)
 
 ___
 
@@ -3049,7 +3049,7 @@ for a given TextModel or ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L62)
+[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/cost-calculator.ts#L62)
 
 ___
 
@@ -3074,7 +3074,7 @@ for a given EmbeddingModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/cost-calculator.ts#L80)
+[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/cost-calculator.ts#L80)
 
 ___
 
@@ -3101,7 +3101,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/spellManager/configureManager.ts#L3)
+[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/spellManager/configureManager.ts#L3)
 
 ___
 
@@ -3125,7 +3125,7 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
+[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
 
 ___
 
@@ -3146,7 +3146,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:100](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L100)
+[packages/core/shared/src/engine.ts:100](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L100)
 
 ___
 
@@ -3160,7 +3160,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/logger/index.ts#L27)
+[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/logger/index.ts#L27)
 
 ___
 
@@ -3178,7 +3178,7 @@ An array of sorted MagickComponents.
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/nodes/index.ts#L163)
+[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/nodes/index.ts#L163)
 
 ___
 
@@ -3202,7 +3202,7 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/getSpell.ts#L18)
+[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/utils/getSpell.ts#L18)
 
 ___
 
@@ -3224,7 +3224,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:113](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L113)
+[packages/core/shared/src/engine.ts:113](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L113)
 
 ___
 
@@ -3244,7 +3244,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/logger/index.ts#L8)
+[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/logger/index.ts#L8)
 
 ___
 
@@ -3264,7 +3264,7 @@ ___
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:64](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/engine.ts#L64)
+[packages/core/shared/src/engine.ts:64](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/engine.ts#L64)
 
 ___
 
@@ -3290,7 +3290,7 @@ The corresponding HTTP status code
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/SpellError.ts#L51)
+[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/utils/SpellError.ts#L51)
 
 ___
 
@@ -3317,7 +3317,7 @@ The result of processing the code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/processCode.ts#L23)
+[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/functions/processCode.ts#L23)
 
 ___
 
@@ -3343,7 +3343,7 @@ The result of the executed Python code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/ProcessPython.ts#L17)
+[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/functions/ProcessPython.ts#L17)
 
 ___
 
@@ -3371,7 +3371,7 @@ Run a spell with the given parameters.
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/utils/runSpell.ts#L28)
+[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/utils/runSpell.ts#L28)
 
 ___
 
@@ -3395,4 +3395,4 @@ A promise that resolves the saved request object.
 
 #### Defined in
 
-[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/31e93b97/packages/core/shared/src/functions/saveRequest.ts#L27)
+[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/47159c1b/packages/core/shared/src/functions/saveRequest.ts#L27)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,14 +16,18 @@ import {
   Route,
   spells
 } from '@magickml/server-core'
+import { initLogger, getLogger } from '@magickml/core'
 import { Context } from 'koa'
 import koaBody from 'koa-body'
 import compose from 'koa-compose'
 import 'regenerator-runtime/runtime'
 
+initLogger({ name: 'server' })
+const logger = getLogger()
+
 // log handle errors
 process.on('uncaughtException', (err: Error) => {
-  console.error('uncaughtException', err)
+  logger.error('uncaughtException %s', err)
 })
 
 process.on(
@@ -33,7 +37,7 @@ process.on(
       /* null */
     },
     p: Promise<any>
-  ) => console.error('Unhandled Rejection at: Promise ', p, reason)
+  ) => logger.error('Unhandled Rejection at: Promise %o with reason %s', p, reason)
 )
 
 // initialize server routes from the plugin manager
@@ -51,8 +55,8 @@ async function init() {
   // load plugins
   await (async () => {
     const plugins = (await import('./plugins')).default
-    console.log(
-      'loaded plugins on server',
+    logger.info(
+      'loaded plugins on server %o',
       Object.values(plugins)
         .map((p: any) => p.name)
         .join(', ')
@@ -84,7 +88,7 @@ async function init() {
   app.use(cors(options))
 
   process.on('unhandledRejection', (err: Error) => {
-    console.error('Unhandled Rejection:' + err + ' - ' + err.stack)
+    logger.error('Unhandled Rejection:' + err + ' - ' + err.stack)
   })
 
   // Middleware used by every request. For route-specific middleware, add it to you route middleware specification
@@ -156,13 +160,13 @@ async function init() {
     }
   })
 
-  process.on('uncaughtException in Editor Server', console.error)
+  process.on('uncaughtException in Editor Server', logger.error)
 
   // adding router middlewares to Koa app
   app.use(router.routes()).use(router.allowedMethods())
 
   app.listen(app.get('port'), () => {
-    console.log('Server started on port ', app.get('port'))
+    logger.info('Server started on port %s', app.get('port'))
   })
 }
 

--- a/packages/core/shared/src/agents/AgentManager.ts
+++ b/packages/core/shared/src/agents/AgentManager.ts
@@ -23,7 +23,7 @@ export class AgentManager {
    */
   getAgent({ agent }) {
     if (!agent) {
-      this.logger.trace("AgentManager can't find agent %o", agent)
+      this.logger.error("AgentManager can't find agent %o", agent)
     }
     return this.agents[agent.id]
   }
@@ -35,9 +35,7 @@ export class AgentManager {
     this.app = app
     // Update agents every second
     setInterval(async () => {
-      this.logger.debug('Updating agents...')
       await this.updateAgents()
-      this.logger.debug('Agents updated.')
     }, AGENT_UPDATE_TIME_MSEC)
   }
 
@@ -98,7 +96,7 @@ export class AgentManager {
    * Update agent instances.
    */
   async updateAgents() {
-    this.logger.debug('Updating agents...')
+    this.logger.trace('Updating agents...')
 
     this.newAgents = (
       await this.app.service('agents').find({
@@ -109,8 +107,7 @@ export class AgentManager {
     )?.data
 
     if (!this.newAgents || this.newAgents.length === 0) {
-      this.logger.debug('No new agents found.')
-      this.logger.debug('Done updating agents.')
+      this.logger.trace('No new agents found.')
       return
     }
 
@@ -173,5 +170,6 @@ export class AgentManager {
         handler({ agent: this.agents[agent.id], agentData: agent })
       )
     })
+    this.logger.trace('Agents updated.')
   }
 }


### PR DESCRIPTION
## What Changed:

Added initLogger calls to each app and lowered the log level of agent manager update logs

## How to test:

ensure that people using npm run dev don't get spammed with update agent logs and that server, agent, and client start without logger related errors

Should resolve some of the spam mentioned in #939 
