### PR TITLE
Fix subspells when importing project

### DIFF
--- a/packages/core/server/src/services/spells/spells.ts
+++ b/packages/core/server/src/services/spells/spells.ts
@@ -66,37 +66,36 @@ export const spell = (app: Application) => {
       create: [
         schemaHooks.validateData(spellDataValidator),
         schemaHooks.resolveData(spellDataResolver),
-        async (context: HookContext) => {
-          const { data, service } = context
-          context.data = {
-            [service.id]: uuidv4(),
-            ...data,
-          }
-          await context.service
-            .find({
-              query: {
-                projectId: data.projectId,
-                name: data.name,
-              },
-            })
-            .then(async param => {
-              if (param.data.length >= 1) {
-                await context.service
-                  .find({
-                    query: {
-                      projectId: data.projectId,
-                      name: {
-                        $ilike: data.name + ' (%)',
-                      },
-                    },
-                  })
-                  .then(val => {
-                    context.data.name =
-                      data.name + ' (' + (1 + val.data.length) + ')'
-                  })
-              }
-            })
-        },
+        // async (context: HookContext) => {
+        //   const { data, service } = context
+        //   context.data = {
+        //     [service.id]: uuidv4(),
+        //     ...data,
+        //   }
+        //   await context.service
+        //     .find({
+        //       query: {
+        //         projectId: data.projectId,
+        //         name: data.name,
+        //       },
+        //     })
+        //     .then(async param => {
+        //       if (param.data.length >= 1) {
+        //         await context.service
+        //           .find({
+        //             query: {
+        //               projectId: data.projectId,
+        //               name: {
+        //                 $ilike: data.name + ' (%)',
+        //               },
+        //             },
+        //           })
+        //           .then(val => {
+        //             context.data.name = data.name + ' (' + (1 + val.data.length) + ')'
+        //           })
+        //       }
+        //     })
+        // },
       ],
       patch: [
         schemaHooks.validateData(spellPatchValidator),

--- a/packages/core/server/src/services/spells/spells.ts
+++ b/packages/core/server/src/services/spells/spells.ts
@@ -5,8 +5,7 @@
 
 // Imports
 import { hooks as schemaHooks } from '@feathersjs/schema'
-import { v4 as uuidv4 } from 'uuid'
-import type { Application, HookContext } from '../../declarations'
+import type { Application } from '../../declarations'
 import {
   checkForSpellInManager,
   updateSpellInManager,

--- a/packages/editor/src/components/ProjectRow.tsx
+++ b/packages/editor/src/components/ProjectRow.tsx
@@ -57,9 +57,8 @@ const ProjectRow = ({
   return (
     <div
       role="button"
-      className={`${css['project-row']} ${
-        css[selectedSpell?.name === label ? 'selected' : '']
-      }`}
+      className={`${css['project-row']} ${css[selectedSpell?.id === spell?.id ? 'selected' : '']
+        }`}
       onClick={e => {
         onClick(e)
       }}

--- a/packages/editor/src/screens/HomeScreen/AllProjects.tsx
+++ b/packages/editor/src/screens/HomeScreen/AllProjects.tsx
@@ -135,6 +135,7 @@ const AllProjects: React.FC<AllProjectsProps> = ({
         <FileInput loadFile={loadFile} />
         <Button
           onClick={() => {
+            console.log('selectedSpell', selectedSpell)
             openSpell(selectedSpell)
           }}
           className={!selectedSpell ? 'disabled' : 'primary'}


### PR DESCRIPTION
Currently in development, importing projects with subspells (spell node) leads to broken references.

This PR remaps the UUIDs to new UUIDs on import so that they work properly. Also fixes the Duplicate name handling. Spells will now just have the same name. In the future we might want to add part of the UUID in a light color to indicate different same-named spells, but for now this is clean and the least painful.