### PR TITLE
Allow text-editor to save code

### DIFF
--- a/packages/editor/src/windows/TextEditorWindow/index.tsx
+++ b/packages/editor/src/windows/TextEditorWindow/index.tsx
@@ -49,7 +49,7 @@ const TextEditor = props => {
 
   useEffect(() => {
     if (!inspectorData?.data.inputs || !inspectorData?.data.inputs.length) {
-      if (inspectorData?.category !== 'Code') {
+      if (inspectorData?.category === 'Text') {
         setCode(inspectorData?.data?.fewshot)
         return
       }


### PR DESCRIPTION
## What Changed:

On the frontend Monaco editor, the problem is that the code block only updates using _Python_ and _Javascript_ nodes (from **Code** category). This change allows the code block to update for other categories.