### PR TITLE
Fix delete and cleanup of agent when only one agent

### DIFF
--- a/packages/agents/src/lib/AgentManager.ts
+++ b/packages/agents/src/lib/AgentManager.ts
@@ -2,7 +2,11 @@
 import Agent from './Agent'
 import _ from 'lodash'
 import pino from 'pino'
-import { AGENT_UPDATE_TIME_MSEC, PING_AGENT_TIME_MSEC, getLogger } from '@magickml/core'
+import {
+  AGENT_UPDATE_TIME_MSEC,
+  PING_AGENT_TIME_MSEC,
+  getLogger,
+} from '@magickml/core'
 
 /**
  * Class for managing agents.
@@ -108,12 +112,12 @@ export class AgentManager {
       })
     )?.data
 
+    await this.deleteOldAgents()
+
     if (!this.newAgents || this.newAgents.length === 0) {
       this.logger.trace('No new agents found.')
       return
     }
-
-    await this.deleteOldAgents()
 
     this.newAgents?.forEach(async (agent: any) => {
       if (!agent) {
@@ -135,7 +139,8 @@ export class AgentManager {
 
       const pingedAt = new Date(agent.pingedAt)
 
-      if (new Date().getTime() - pingedAt.getTime() < PING_AGENT_TIME_MSEC * 5) return
+      if (new Date().getTime() - pingedAt.getTime() < PING_AGENT_TIME_MSEC * 5)
+        return
 
       const old = this.currentAgents?.find(a => a && a.id === agent.id)
 


### PR DESCRIPTION
## What Changed:
Right now the agent doesn't delete if the newAgent count === 0. This changes the order of logic to allow the deleteOldAgents function to run before the conditional check