### PR TITLE
Stops calling removeHandlers for null oldAgents

### DIFF
--- a/packages/agents/src/lib/AgentManager.ts
+++ b/packages/agents/src/lib/AgentManager.ts
@@ -153,9 +153,8 @@ export class AgentManager {
         agent.id
       )
 
-      this.removeHandlers.forEach(handler => handler({ agent: oldAgent }))
-
       if (oldAgent) {
+        this.removeHandlers.forEach(handler => handler({ agent: oldAgent }))
         await oldAgent.onDestroy()
       }
 


### PR DESCRIPTION
## What Changed:

We now check if oldAgent exists before running the remove handlers.

## How to test:

Make 2 agents, start both, then disable one of them, observe that the worker doesn't crash.

## Additional information:

Loopmanager.removeAgent is getting a null agent in our dev environment and crashes the workers, this should stop that.
