### PR TITLE
Two posthogs, one popup

### DIFF
--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -87,7 +87,6 @@ if (window === window.parent) {
       if (type === 'INIT') {
         // TODO: store configuration in localstorage
         const { config } = payload as { config: AppConfig }
-        console.log('config', config)
         const Root = () => {
           if (POSTHOG_ENABLED && config?.posthogEnabled) {
             return (

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -86,9 +86,10 @@ if (window === window.parent) {
       // Initialize and render the MagickIDE when message type is 'INIT'
       if (type === 'INIT') {
         // TODO: store configuration in localstorage
-        const { config } = payload
+        const { config } = payload as { config: AppConfig }
+        console.log('config', config)
         const Root = () => {
-          if (POSTHOG_ENABLED) {
+          if (POSTHOG_ENABLED && config?.posthogEnabled) {
             return (
               <PostHogProvider
                 apiKey={POSTHOG_API_KEY}

--- a/apps/docs/docs/api/index.md
+++ b/apps/docs/docs/api/index.md
@@ -59,7 +59,11 @@ The interface for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L75)
+=======
+[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L75)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -71,7 +75,11 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L73)
+=======
+[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L73)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -94,7 +102,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L73)
+=======
+[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L73)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -114,7 +126,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L84)
+=======
+[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L84)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -138,7 +154,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L633)
+=======
+[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L633)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -148,7 +168,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L480)
+=======
+[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L480)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -174,7 +198,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L543)
+=======
+[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L543)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -191,7 +219,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L538)
+=======
+[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L538)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -208,7 +240,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L462)
+=======
+[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L462)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -227,7 +263,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L600)
+=======
+[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L600)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -247,7 +287,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L493)
+=======
+[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L493)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -273,7 +317,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L507)
+=======
+[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L507)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -291,7 +339,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L482)
+=======
+[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L482)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -301,7 +353,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L474)
+=======
+[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L474)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -317,7 +373,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L352)
+=======
+[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L352)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -327,7 +387,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L305)
+=======
+[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L305)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -345,7 +409,11 @@ Represents the cost per token for a given model
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L33)
+=======
+[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/cost-calculator.ts#L33)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -367,7 +435,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L63)
+=======
+[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L63)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -377,7 +449,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L55)
+=======
+[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L55)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -387,7 +463,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L110)
+=======
+[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L110)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -399,7 +479,11 @@ The possible custom error codes to be used in the application.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/SpellError.ts#L5)
+=======
+[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/utils/SpellError.ts#L5)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -420,7 +504,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L307)
+=======
+[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L307)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -439,7 +527,11 @@ Arguments passed to the `install` function
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
+=======
+[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -460,7 +552,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L46)
+=======
+[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L46)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -478,7 +574,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L557)
+=======
+[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L557)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -502,7 +602,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L197)
+=======
+[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L197)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -518,7 +622,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L158)
+=======
+[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L158)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -548,7 +656,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L92)
+=======
+[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L92)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -558,7 +670,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L133)
+=======
+[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L133)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -586,7 +702,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L284)
+=======
+[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L284)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -596,7 +716,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L455)
+=======
+[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L455)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -606,7 +730,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L57)
+=======
+[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L57)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -631,7 +759,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L112)
+=======
+[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L112)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -672,7 +804,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L174)
+=======
+[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L174)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -690,7 +826,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L127)
+=======
+[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L127)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -700,7 +840,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L448)
+=======
+[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L448)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -710,7 +854,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L344)
+=======
+[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L344)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -734,7 +882,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L667)
+=======
+[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L667)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -744,7 +896,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L346)
+=======
+[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L346)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -760,7 +916,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L42)
+=======
+[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L42)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -770,7 +930,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L476)
+=======
+[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L476)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -791,7 +955,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L33)
+=======
+[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L33)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -811,7 +979,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L56)
+=======
+[packages/core/shared/src/engine.ts:56](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L56)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -821,7 +993,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L359)
+=======
+[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L359)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -842,7 +1018,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
+=======
+[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -852,7 +1032,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:133](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L133)
+=======
+[packages/core/shared/src/engine.ts:133](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L133)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -862,7 +1046,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L316)
+=======
+[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L316)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -872,7 +1060,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L317)
+=======
+[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L317)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -888,7 +1080,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:231](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L231)
+=======
+[packages/core/shared/src/engine.ts:231](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L231)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -898,7 +1094,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L322)
+=======
+[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L322)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -923,7 +1123,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L379)
+=======
+[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L379)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -942,7 +1146,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L426)
+=======
+[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L426)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -952,7 +1160,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L418)
+=======
+[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L418)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -962,7 +1174,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L419)
+=======
+[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L419)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -972,7 +1188,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L441)
+=======
+[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L441)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -986,7 +1206,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L442)
+=======
+[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L442)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -996,7 +1220,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L443)
+=======
+[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L443)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1006,7 +1234,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L607)
+=======
+[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L607)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1025,7 +1257,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L467)
+=======
+[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L467)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1035,7 +1271,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L655)
+=======
+[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L655)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1060,7 +1300,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L653)
+=======
+[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L653)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1078,7 +1322,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L416)
+=======
+[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L416)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1088,7 +1336,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L362)
+=======
+[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L362)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1119,7 +1371,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L577)
+=======
+[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L577)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1135,7 +1391,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
+=======
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1152,7 +1412,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
+=======
+[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1174,7 +1438,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
+=======
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1194,7 +1462,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L334)
+=======
+[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L334)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1204,7 +1476,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L439)
+=======
+[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L439)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1221,7 +1497,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L421)
+=======
+[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L421)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1240,7 +1520,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L366)
+=======
+[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L366)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1254,7 +1538,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L373)
+=======
+[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L373)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1285,7 +1573,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L262)
+=======
+[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L262)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1315,7 +1607,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L261)
+=======
+[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L261)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1339,7 +1635,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L260)
+=======
+[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L260)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1370,7 +1670,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L256)
+=======
+[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L256)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1394,7 +1698,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L255)
+=======
+[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L255)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1418,7 +1726,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L135)
+=======
+[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L135)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1428,7 +1740,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L360)
+=======
+[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L360)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1438,7 +1754,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L67)
+=======
+[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L67)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1457,7 +1777,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L18)
+=======
+[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L18)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1475,7 +1799,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L12)
+=======
+[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L12)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1495,7 +1823,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L27)
+=======
+[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L27)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1514,7 +1846,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L5)
+=======
+[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L5)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1524,7 +1860,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L25)
+=======
+[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L25)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1551,7 +1891,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L182)
+=======
+[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L182)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1576,7 +1920,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L253)
+=======
+[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L253)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1586,7 +1934,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L252)
+=======
+[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L252)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1636,7 +1988,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L203)
+=======
+[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L203)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1660,7 +2016,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L267)
+=======
+[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L267)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1678,7 +2038,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L627)
+=======
+[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L627)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1708,7 +2072,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L609)
+=======
+[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L609)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1734,7 +2102,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L669)
+=======
+[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L669)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1782,7 +2154,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L189)
+=======
+[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L189)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1807,7 +2183,11 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/runSpell.ts#L10)
+=======
+[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/utils/runSpell.ts#L10)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1824,7 +2204,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L457)
+=======
+[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L457)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1842,7 +2226,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L114)
+=======
+[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L114)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1852,7 +2240,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L115)
+=======
+[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L115)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1872,7 +2264,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
+=======
+[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1882,7 +2278,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L8)
+=======
+[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L8)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1900,7 +2300,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
+=======
+[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1910,7 +2314,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L23)
+=======
+[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L23)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1922,7 +2330,11 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L37)
+=======
+[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L37)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1940,7 +2352,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L342)
+=======
+[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L342)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1950,7 +2366,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L172)
+=======
+[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L172)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1969,7 +2389,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
+=======
+[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1987,7 +2411,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L433)
+=======
+[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L433)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -1997,7 +2425,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/taskPlugin/task.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L39)
+=======
+[packages/core/shared/src/plugins/taskPlugin/task.ts:39](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/taskPlugin/task.ts#L39)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2014,7 +2446,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
+=======
+[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2024,7 +2460,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L304)
+=======
+[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L304)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2048,7 +2488,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L526)
+=======
+[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L526)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2058,7 +2502,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L478)
+=======
+[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L478)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2068,7 +2516,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L162)
+=======
+[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L162)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2078,7 +2530,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L163)
+=======
+[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L163)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2110,7 +2566,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
+=======
+[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2120,7 +2580,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L683)
+=======
+[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L683)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2130,7 +2594,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L389)
+=======
+[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L389)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2156,7 +2624,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L165)
+=======
+[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L165)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ## Variables
 
@@ -2166,7 +2638,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L76)
+=======
+[packages/core/shared/src/config.ts:82](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L82)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2176,7 +2652,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:45](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L45)
+=======
+[packages/core/shared/src/config.ts:45](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L45)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2188,7 +2668,11 @@ The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L40)
+=======
+[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/cost-calculator.ts#L40)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2205,7 +2689,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
+=======
+[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2228,7 +2716,11 @@ module:consolePlugin
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
+=======
+[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2238,7 +2730,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L30)
+=======
+[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L30)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2248,7 +2744,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L31)
+=======
+[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L31)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2258,7 +2758,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L33)
+=======
+[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L33)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2268,7 +2772,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L34)
+=======
+[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L34)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2278,7 +2786,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:70](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L70)
+=======
+[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L76)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2288,7 +2800,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:51](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L51)
+=======
+[packages/core/shared/src/config.ts:51](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L51)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2305,7 +2821,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
+=======
+[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2315,7 +2835,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:54](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L54)
+=======
+[packages/core/shared/src/config.ts:54](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L54)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2325,7 +2849,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L56)
+=======
+[packages/core/shared/src/config.ts:56](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L56)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2335,7 +2863,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:47](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L47)
+=======
+[packages/core/shared/src/config.ts:47](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L47)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2352,7 +2884,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
+=======
+[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2362,7 +2898,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L29)
+=======
+[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L29)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2379,7 +2919,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
+=======
+[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2389,7 +2933,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L63)
+=======
+[packages/core/shared/src/config.ts:63](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L63)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2406,7 +2954,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
+=======
+[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2425,7 +2977,11 @@ Lifecycle Plugin
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
+=======
+[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2442,7 +2998,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
+=======
+[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2459,7 +3019,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
+=======
+[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2476,7 +3040,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
+=======
+[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2486,7 +3054,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:59](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L59)
+=======
+[packages/core/shared/src/config.ts:59](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L59)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2503,7 +3075,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
+=======
+[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2513,7 +3089,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L61)
+=======
+[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L61)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2523,7 +3103,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L62)
+=======
+[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L62)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2533,7 +3117,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:79](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L79)
+=======
+[packages/core/shared/src/config.ts:85](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L85)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2543,7 +3131,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L67)
+=======
+[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L67)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2553,7 +3145,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:65](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L65)
+=======
+[packages/core/shared/src/config.ts:65](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L65)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2563,7 +3159,51 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L38)
+=======
+[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L38)
+
+___
+
+### REDISCLOUD\_DB
+
+• `Const` **REDISCLOUD\_DB**: `number`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L72)
+
+___
+
+### REDISCLOUD\_HOST
+
+• `Const` **REDISCLOUD\_HOST**: `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:68](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L68)
+
+___
+
+### REDISCLOUD\_PASSWORD
+
+• `Const` **REDISCLOUD\_PASSWORD**: `undefined` \| `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:73](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L73)
+
+___
+
+### REDISCLOUD\_PORT
+
+• `Const` **REDISCLOUD\_PORT**: `number`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L69)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2573,7 +3213,21 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:68](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L68)
+=======
+[packages/core/shared/src/config.ts:70](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L70)
+
+___
+
+### REDISCLOUD\_USERNAME
+
+• `Const` **REDISCLOUD\_USERNAME**: `undefined` \| `string`
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:74](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L74)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2583,7 +3237,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L40)
+=======
+[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L40)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2593,7 +3251,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L39)
+=======
+[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L39)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2603,7 +3265,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:49](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L49)
+=======
+[packages/core/shared/src/config.ts:49](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L49)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2613,7 +3279,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:41](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L41)
+=======
+[packages/core/shared/src/config.ts:41](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L41)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2623,7 +3293,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L37)
+=======
+[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L37)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2640,7 +3314,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
+=======
+[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2657,7 +3335,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
+=======
+[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2674,7 +3356,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
+=======
+[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2691,7 +3377,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
+=======
+[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2701,7 +3391,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:43](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L43)
+=======
+[packages/core/shared/src/config.ts:43](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L43)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2718,7 +3412,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
+=======
+[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2728,7 +3426,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L58)
+=======
+[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L58)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2738,7 +3440,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L53)
+=======
+[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L53)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2748,7 +3454,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/config.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L73)
+=======
+[packages/core/shared/src/config.ts:79](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L79)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2760,7 +3470,11 @@ Full data model schema for an agent.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L53)
+=======
+[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L53)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2770,7 +3484,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L55)
+=======
+[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L55)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2780,7 +3498,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L58)
+=======
+[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L58)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2790,7 +3512,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L63)
+=======
+[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L63)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2800,7 +3526,31 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L57)
+=======
+[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L57)
+
+___
+
+### bullMQConnection
+
+• `Const` **bullMQConnection**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `db` | `number` |
+| `host` | `string` |
+| `password` | `undefined` \| `string` |
+| `port` | `number` |
+| `username` | `undefined` \| `string` |
+
+#### Defined in
+
+[packages/core/shared/src/config.ts:89](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/config.ts#L89)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2810,7 +3560,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/nodes/index.ts#L71)
+=======
+[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/nodes/index.ts#L71)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2822,7 +3576,11 @@ Full data model schema for a document.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L87)
+=======
+[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L87)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2832,7 +3590,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L64)
+=======
+[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L64)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2842,7 +3604,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L65)
+=======
+[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L65)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2852,7 +3618,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L62)
+=======
+[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L62)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2862,7 +3632,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/globals.ts#L38)
+=======
+[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/globals.ts#L38)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2872,7 +3646,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L67)
+=======
+[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L67)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2882,7 +3660,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L56)
+=======
+[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L56)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2892,7 +3674,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L60)
+=======
+[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L60)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2902,7 +3688,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L463)
+=======
+[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/plugin.ts#L463)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2912,7 +3702,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L39)
+=======
+[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L39)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2924,7 +3718,11 @@ Full data model schema for a spell.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L17)
+=======
+[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/schemas.ts#L17)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2934,7 +3732,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L59)
+=======
+[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L59)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2944,7 +3746,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L66)
+=======
+[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L66)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2954,7 +3760,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L61)
+=======
+[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/sockets.ts#L61)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ## Functions
 
@@ -2974,7 +3784,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L398)
+=======
+[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L398)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -2994,7 +3808,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L410)
+=======
+[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L410)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3014,7 +3832,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L402)
+=======
+[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L402)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3034,7 +3856,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L406)
+=======
+[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/types.ts#L406)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3059,7 +3885,11 @@ for a given TextModel or ChatModel
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L62)
+=======
+[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/cost-calculator.ts#L62)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3084,7 +3914,11 @@ for a given EmbeddingModel
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L80)
+=======
+[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/cost-calculator.ts#L80)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3111,7 +3945,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/spellManager/configureManager.ts#L3)
+=======
+[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/spellManager/configureManager.ts#L3)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3135,7 +3973,11 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
+=======
+[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3156,7 +3998,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:110](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L110)
+=======
+[packages/core/shared/src/engine.ts:110](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L110)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3170,7 +4016,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/logger/index.ts#L27)
+=======
+[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/logger/index.ts#L27)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3188,7 +4038,11 @@ An array of sorted MagickComponents.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/nodes/index.ts#L163)
+=======
+[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/nodes/index.ts#L163)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3212,7 +4066,11 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/getSpell.ts#L18)
+=======
+[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/utils/getSpell.ts#L18)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3234,7 +4092,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L123)
+=======
+[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L123)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3254,7 +4116,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/logger/index.ts#L8)
+=======
+[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/logger/index.ts#L8)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3274,7 +4140,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/engine.ts:66](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L66)
+=======
+[packages/core/shared/src/engine.ts:66](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/engine.ts#L66)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3300,7 +4170,11 @@ The corresponding HTTP status code
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/SpellError.ts#L51)
+=======
+[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/utils/SpellError.ts#L51)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3327,7 +4201,11 @@ The result of processing the code.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/processCode.ts#L23)
+=======
+[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/functions/processCode.ts#L23)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3353,7 +4231,11 @@ The result of the executed Python code.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/ProcessPython.ts#L17)
+=======
+[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/functions/ProcessPython.ts#L17)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3381,7 +4263,11 @@ Run a spell with the given parameters.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/runSpell.ts#L28)
+=======
+[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/utils/runSpell.ts#L28)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool
 
 ___
 
@@ -3405,4 +4291,8 @@ A promise that resolves the saved request object.
 
 #### Defined in
 
+<<<<<<< HEAD
 [packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/saveRequest.ts#L27)
+=======
+[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/54607bbd/packages/core/shared/src/functions/saveRequest.ts#L27)
+>>>>>>> 783d5c22... update AppConfig to handle posthogEnabled bool

--- a/packages/core/client/src/providers/ConfigProvider.tsx
+++ b/packages/core/client/src/providers/ConfigProvider.tsx
@@ -8,6 +8,7 @@ export type AppConfig = {
   apiUrl: string;
   projectId: string;
   token: string;
+  posthogEnabled?: boolean;
 };
 
 // Define ConfigContext interface


### PR DESCRIPTION
## What Changed:

This adds posthogEnabled in the AppConfig type. This is used for passing a token from Cloud -> AIDE which we handle in main.tsx.
This is so that we can avoid having two cookie consent popups in each app and just have one in the cloud.

## How to test:

You can test this now. Clone cloud-dev and when you arrive you should be greeted with a cookie popup. Accepting/declining this will set the cookie status for the aide as well.

## Additional information:

N/A
