### PR TITLE
Adds check to ensure spell's have id on creation

### DIFF
--- a/packages/agents/src/lib/AgentManager.ts
+++ b/packages/agents/src/lib/AgentManager.ts
@@ -2,7 +2,11 @@
 import Agent from './Agent'
 import _ from 'lodash'
 import pino from 'pino'
-import { AGENT_UPDATE_TIME_MSEC, PING_AGENT_TIME_MSEC, getLogger } from '@magickml/core'
+import {
+  AGENT_UPDATE_TIME_MSEC,
+  PING_AGENT_TIME_MSEC,
+  getLogger,
+} from '@magickml/core'
 
 /**
  * Class for managing agents.
@@ -108,12 +112,12 @@ export class AgentManager {
       })
     )?.data
 
+    await this.deleteOldAgents()
+
     if (!this.newAgents || this.newAgents.length === 0) {
       this.logger.trace('No new agents found.')
       return
     }
-
-    await this.deleteOldAgents()
 
     this.newAgents?.forEach(async (agent: any) => {
       if (!agent) {
@@ -135,7 +139,8 @@ export class AgentManager {
 
       const pingedAt = new Date(agent.pingedAt)
 
-      if (new Date().getTime() - pingedAt.getTime() < PING_AGENT_TIME_MSEC * 5) return
+      if (new Date().getTime() - pingedAt.getTime() < PING_AGENT_TIME_MSEC * 5)
+        return
 
       const old = this.currentAgents?.find(a => a && a.id === agent.id)
 

--- a/packages/core/server/src/services/spells/spells.ts
+++ b/packages/core/server/src/services/spells/spells.ts
@@ -63,6 +63,16 @@ export const spell = (app: Application) => {
       find: [],
       get: [],
       create: [
+        // if there's no spellId, generate a new uuidv4 id
+        async (context: HookContext) => {
+          const { data } = context
+          if (!data.spellId) {
+            context.data = {
+              ...data,
+              id: uuidv4(),
+            }
+          }
+        },
         schemaHooks.validateData(spellDataValidator),
         schemaHooks.resolveData(spellDataResolver),
         // async (context: HookContext) => {


### PR DESCRIPTION
## What Changed:

Added a pre-create hook for spells that should set their id before trying to create them. Just in case they have a missing id.

## How to test:

Create a spell using cloud

## Additional information:

This is to fix a cloud issue where spells can't be created from a spell template