### PR TITLE
Node ux improvements

### DIFF
--- a/apps/docs/docs/api/index.md
+++ b/apps/docs/docs/api/index.md
@@ -57,7 +57,7 @@ The interface for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:77](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L77)
+[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L75)
 
 ---
 
@@ -69,7 +69,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:75](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L75)
+[packages/core/shared/src/schemas.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L73)
 
 ---
 
@@ -92,7 +92,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L73)
+[packages/core/shared/src/types.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L73)
 
 ---
 
@@ -112,7 +112,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L84)
+[packages/core/shared/src/types.ts:84](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L84)
 
 ---
 
@@ -136,7 +136,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:641](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L641)
+[packages/core/shared/src/types.ts:633](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L633)
 
 ---
 
@@ -146,7 +146,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L480)
+[packages/core/shared/src/types.ts:480](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L480)
 
 ---
 
@@ -172,7 +172,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:551](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L551)
+[packages/core/shared/src/types.ts:543](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L543)
 
 ---
 
@@ -189,7 +189,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:546](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L546)
+[packages/core/shared/src/types.ts:538](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L538)
 
 ---
 
@@ -206,7 +206,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L462)
+[packages/core/shared/src/types.ts:462](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L462)
 
 ---
 
@@ -225,7 +225,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:608](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L608)
+[packages/core/shared/src/types.ts:600](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L600)
 
 ---
 
@@ -245,7 +245,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:500](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L500)
+[packages/core/shared/src/types.ts:493](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L493)
 
 ---
 
@@ -271,7 +271,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:514](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L514)
+[packages/core/shared/src/types.ts:507](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L507)
 
 ---
 
@@ -289,7 +289,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:489](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L489)
+[packages/core/shared/src/types.ts:482](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L482)
 
 ---
 
@@ -299,7 +299,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L474)
+[packages/core/shared/src/types.ts:474](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L474)
 
 ---
 
@@ -315,7 +315,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L352)
+[packages/core/shared/src/types.ts:352](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L352)
 
 ---
 
@@ -325,7 +325,7 @@ The type for an agent object that's based on the `agentSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L305)
+[packages/core/shared/src/types.ts:305](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L305)
 
 ---
 
@@ -343,7 +343,7 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/cost-calculator.ts#L33)
+[packages/core/shared/src/cost-calculator.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L33)
 
 ---
 
@@ -365,7 +365,7 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L63)
+[packages/core/shared/src/types.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L63)
 
 ---
 
@@ -375,7 +375,7 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L55)
+[packages/core/shared/src/types.ts:55](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L55)
 
 ---
 
@@ -385,7 +385,7 @@ Represents the cost per token for a given model
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L110)
+[packages/core/shared/src/types.ts:110](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L110)
 
 ---
 
@@ -397,7 +397,7 @@ The possible custom error codes to be used in the application.
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/utils/SpellError.ts#L5)
+[packages/core/shared/src/utils/SpellError.ts:5](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/SpellError.ts#L5)
 
 ---
 
@@ -418,7 +418,7 @@ The possible custom error codes to be used in the application.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L307)
+[packages/core/shared/src/types.ts:307](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L307)
 
 ---
 
@@ -447,7 +447,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/consolePlugin/index.ts#L18)
 
 ---
 
@@ -468,7 +468,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L46)
+[packages/core/shared/src/types.ts:46](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L46)
 
 ---
 
@@ -486,7 +486,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:565](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L565)
+[packages/core/shared/src/types.ts:557](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L557)
 
 ---
 
@@ -510,7 +510,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L197)
+[packages/core/shared/src/types.ts:197](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L197)
 
 ---
 
@@ -526,7 +526,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L158)
+[packages/core/shared/src/types.ts:158](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L158)
 
 ---
 
@@ -556,7 +556,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L92)
+[packages/core/shared/src/types.ts:92](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L92)
 
 ---
 
@@ -566,7 +566,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L133)
+[packages/core/shared/src/types.ts:133](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L133)
 
 ---
 
@@ -594,7 +594,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L284)
+[packages/core/shared/src/types.ts:284](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L284)
 
 ---
 
@@ -604,7 +604,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L455)
+[packages/core/shared/src/types.ts:455](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L455)
 
 ---
 
@@ -614,7 +614,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L57)
+[packages/core/shared/src/types.ts:57](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L57)
 
 ---
 
@@ -639,7 +639,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L112)
+[packages/core/shared/src/types.ts:112](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L112)
 
 ---
 
@@ -681,7 +681,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L174)
+[packages/core/shared/src/types.ts:174](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L174)
 
 ---
 
@@ -699,7 +699,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L127)
+[packages/core/shared/src/types.ts:127](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L127)
 
 ---
 
@@ -709,7 +709,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L448)
+[packages/core/shared/src/types.ts:448](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L448)
 
 ---
 
@@ -719,7 +719,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L344)
+[packages/core/shared/src/types.ts:344](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L344)
 
 ---
 
@@ -743,7 +743,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:675](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L675)
+[packages/core/shared/src/types.ts:667](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L667)
 
 ---
 
@@ -753,7 +753,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L346)
+[packages/core/shared/src/types.ts:346](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L346)
 
 ---
 
@@ -769,7 +769,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L42)
+[packages/core/shared/src/types.ts:42](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L42)
 
 ---
 
@@ -779,7 +779,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L476)
+[packages/core/shared/src/types.ts:476](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L476)
 
 ---
 
@@ -800,7 +800,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L33)
+[packages/core/shared/src/types.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L33)
 
 ---
 
@@ -813,7 +813,6 @@ Arguments passed to the `install` function
 | Name          | Type                                                          |
 | :------------ | :------------------------------------------------------------ |
 | `components`  | [`MagickComponent`](classes/MagickComponent.md)<`unknown`\>[] |
-| `emit?`       | `EmitPluginArgs`[``"emit"``]                                  |
 | `name`        | `string`                                                      |
 | `server`      | `boolean`                                                     |
 | `socket?`     | `io.Socket`                                                   |
@@ -821,7 +820,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:56](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L56)
+[packages/core/shared/src/engine.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L56)
 
 ---
 
@@ -831,7 +830,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L359)
+[packages/core/shared/src/types.ts:359](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L359)
 
 ---
 
@@ -852,7 +851,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
+[packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts#L27)
 
 ---
 
@@ -862,7 +861,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:133](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L133)
+[packages/core/shared/src/engine.ts:133](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L133)
 
 ---
 
@@ -872,7 +871,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L316)
+[packages/core/shared/src/types.ts:316](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L316)
 
 ---
 
@@ -882,7 +881,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L317)
+[packages/core/shared/src/types.ts:317](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L317)
 
 ---
 
@@ -898,7 +897,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:232](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L232)
+[packages/core/shared/src/engine.ts:231](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L231)
 
 ---
 
@@ -908,7 +907,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L322)
+[packages/core/shared/src/types.ts:322](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L322)
 
 ---
 
@@ -933,7 +932,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L379)
+[packages/core/shared/src/types.ts:379](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L379)
 
 ---
 
@@ -952,7 +951,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L426)
+[packages/core/shared/src/types.ts:426](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L426)
 
 ---
 
@@ -962,7 +961,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L418)
+[packages/core/shared/src/types.ts:418](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L418)
 
 ---
 
@@ -972,7 +971,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L419)
+[packages/core/shared/src/types.ts:419](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L419)
 
 ---
 
@@ -982,7 +981,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L441)
+[packages/core/shared/src/types.ts:441](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L441)
 
 ---
 
@@ -996,7 +995,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L442)
+[packages/core/shared/src/types.ts:442](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L442)
 
 ---
 
@@ -1006,7 +1005,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L443)
+[packages/core/shared/src/types.ts:443](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L443)
 
 ---
 
@@ -1016,7 +1015,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:615](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L615)
+[packages/core/shared/src/types.ts:607](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L607)
 
 ---
 
@@ -1035,7 +1034,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L467)
+[packages/core/shared/src/types.ts:467](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L467)
 
 ---
 
@@ -1045,7 +1044,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:663](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L663)
+[packages/core/shared/src/types.ts:655](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L655)
 
 ---
 
@@ -1070,7 +1069,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:661](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L661)
+[packages/core/shared/src/types.ts:653](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L653)
 
 ---
 
@@ -1088,7 +1087,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L416)
+[packages/core/shared/src/types.ts:416](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L416)
 
 ---
 
@@ -1098,7 +1097,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L362)
+[packages/core/shared/src/types.ts:362](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L362)
 
 ---
 
@@ -1110,7 +1109,7 @@ Arguments passed to the `install` function
 
 | Name                      | Type                                                                                                                                                                                                             |
 | :------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent?`                  | `Agent`                                                                                                                                                                                                          |
+| `agent`                   | [`Agent`](classes/Agent.md)                                                                                                                                                                                      |
 | `app`                     | `Application`                                                                                                                                                                                                    |
 | `context`                 | [`EngineContext`](#enginecontext)                                                                                                                                                                                |
 | `currentSpell`            | `Spell`                                                                                                                                                                                                          |
@@ -1129,7 +1128,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:585](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L585)
+[packages/core/shared/src/types.ts:577](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L577)
 
 ---
 
@@ -1145,7 +1144,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:26](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L26)
 
 ---
 
@@ -1162,7 +1161,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:42](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L42)
 
 ---
 
@@ -1184,7 +1183,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
+[packages/core/shared/src/plugins/modulePlugin/module-manager.ts:19](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/module-manager.ts#L19)
 
 ---
 
@@ -1204,7 +1203,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L334)
+[packages/core/shared/src/types.ts:334](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L334)
 
 ---
 
@@ -1214,7 +1213,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L439)
+[packages/core/shared/src/types.ts:439](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L439)
 
 ---
 
@@ -1231,7 +1230,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L421)
+[packages/core/shared/src/types.ts:421](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L421)
 
 ---
 
@@ -1250,7 +1249,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L366)
+[packages/core/shared/src/types.ts:366](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L366)
 
 ---
 
@@ -1264,7 +1263,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L373)
+[packages/core/shared/src/types.ts:373](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L373)
 
 ---
 
@@ -1295,7 +1294,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L262)
+[packages/core/shared/src/types.ts:262](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L262)
 
 ---
 
@@ -1325,7 +1324,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L261)
+[packages/core/shared/src/types.ts:261](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L261)
 
 ---
 
@@ -1349,7 +1348,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L260)
+[packages/core/shared/src/types.ts:260](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L260)
 
 ---
 
@@ -1380,7 +1379,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L256)
+[packages/core/shared/src/types.ts:256](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L256)
 
 ---
 
@@ -1404,7 +1403,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L255)
+[packages/core/shared/src/types.ts:255](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L255)
 
 ---
 
@@ -1428,7 +1427,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L135)
+[packages/core/shared/src/types.ts:135](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L135)
 
 ---
 
@@ -1438,7 +1437,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L360)
+[packages/core/shared/src/types.ts:360](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L360)
 
 ---
 
@@ -1448,7 +1447,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L67)
+[packages/core/shared/src/plugin.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L67)
 
 ---
 
@@ -1467,7 +1466,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L18)
+[packages/core/shared/src/plugin.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L18)
 
 ---
 
@@ -1485,7 +1484,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L12)
+[packages/core/shared/src/plugin.ts:12](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L12)
 
 ---
 
@@ -1505,7 +1504,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L27)
+[packages/core/shared/src/plugin.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L27)
 
 ---
 
@@ -1524,7 +1523,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L5)
+[packages/core/shared/src/plugin.ts:5](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L5)
 
 ---
 
@@ -1534,7 +1533,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L25)
+[packages/core/shared/src/plugin.ts:25](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L25)
 
 ---
 
@@ -1561,7 +1560,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L182)
+[packages/core/shared/src/types.ts:182](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L182)
 
 ---
 
@@ -1586,7 +1585,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L253)
+[packages/core/shared/src/types.ts:253](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L253)
 
 ---
 
@@ -1596,7 +1595,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L252)
+[packages/core/shared/src/types.ts:252](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L252)
 
 ---
 
@@ -1612,8 +1611,10 @@ Arguments passed to the `install` function
 | `$CREATE_CONSOLE`                 | (`tabId`: `string`) => `string`                      |
 | `$CREATE_DEBUG_CONSOLE`           | (`tabId`: `string`) => `string`                      |
 | `$CREATE_INSPECTOR`               | (`tabId`: `string`) => `string`                      |
+| `$CREATE_MEDIAWINDOW`             | (`tabId`: `string`) => `string`                      |
 | `$CREATE_MESSAGE_REACTION_EDITOR` | (`tabId`: `string`) => `string`                      |
 | `$CREATE_PLAYTEST`                | (`tabId`: `string`) => `string`                      |
+| `$CREATE_PROJECT_WINDOW`          | (`tabId`: `string`) => `string`                      |
 | `$CREATE_TEXT_EDITOR`             | (`tabId`: `string`) => `string`                      |
 | `$DEBUG_INPUT`                    | (`tabId`: `string`) => `string`                      |
 | `$DEBUG_PRINT`                    | (`tabId`: `string`) => `string`                      |
@@ -1628,7 +1629,6 @@ Arguments passed to the `install` function
 | `$PROCESS`                        | (`tabId`: `string`) => `string`                      |
 | `$REDO`                           | (`tabId`: `string`) => `string`                      |
 | `$REFRESH_EVENT_TABLE`            | (`tabId`: `string`) => `string`                      |
-| `$RUN_AGENT`                      | (`tabId`: `string`) => `string`                      |
 | `$RUN_SPELL`                      | (`tabId?`: `string`) => `string`                     |
 | `$SAVE_SPELL`                     | (`tabId`: `string`) => `string`                      |
 | `$SAVE_SPELL_DIFF`                | (`tabId`: `string`) => `string`                      |
@@ -1640,13 +1640,12 @@ Arguments passed to the `install` function
 | `ADD_SUBSPELL`                    | `string`                                             |
 | `DELETE_SUBSPELL`                 | `string`                                             |
 | `OPEN_TAB`                        | `string`                                             |
-| `RUN_AGENT`                       | `string`                                             |
 | `TOGGLE_SNAP`                     | `string`                                             |
 | `UPDATE_SUBSPELL`                 | `string`                                             |
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L203)
+[packages/core/shared/src/types.ts:203](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L203)
 
 ---
 
@@ -1670,7 +1669,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L267)
+[packages/core/shared/src/types.ts:267](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L267)
 
 ---
 
@@ -1688,7 +1687,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:635](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L635)
+[packages/core/shared/src/types.ts:627](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L627)
 
 ---
 
@@ -1718,7 +1717,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:617](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L617)
+[packages/core/shared/src/types.ts:609](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L609)
 
 ---
 
@@ -1744,7 +1743,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:677](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L677)
+[packages/core/shared/src/types.ts:669](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L669)
 
 ---
 
@@ -1793,7 +1792,7 @@ Arguments passed to the `install` function
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L189)
+[packages/core/shared/src/types.ts:189](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L189)
 
 ---
 
@@ -1818,7 +1817,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/utils/runSpell.ts#L10)
+[packages/core/shared/src/utils/runSpell.ts:10](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/runSpell.ts#L10)
 
 ---
 
@@ -1835,7 +1834,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L457)
+[packages/core/shared/src/types.ts:457](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L457)
 
 ---
 
@@ -1853,7 +1852,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L114)
+[packages/core/shared/src/plugin.ts:114](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L114)
 
 ---
 
@@ -1863,7 +1862,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L115)
+[packages/core/shared/src/plugin.ts:115](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L115)
 
 ---
 
@@ -1883,7 +1882,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:20](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L20)
 
 ---
 
@@ -1893,7 +1892,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L8)
+[packages/core/shared/src/sockets.ts:8](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L8)
 
 ---
 
@@ -1911,7 +1910,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:13](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L13)
 
 ---
 
@@ -1921,7 +1920,7 @@ Type definition for the arguments of the `runSpell` function.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L23)
+[packages/core/shared/src/sockets.ts:23](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L23)
 
 ---
 
@@ -1933,7 +1932,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L37)
+[packages/core/shared/src/schemas.ts:37](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L37)
 
 ---
 
@@ -1951,7 +1950,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L342)
+[packages/core/shared/src/types.ts:342](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L342)
 
 ---
 
@@ -1961,7 +1960,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L172)
+[packages/core/shared/src/types.ts:172](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L172)
 
 ---
 
@@ -1980,7 +1979,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L18)
 
 ---
 
@@ -1998,7 +1997,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L433)
+[packages/core/shared/src/types.ts:433](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L433)
 
 ---
 
@@ -2008,7 +2007,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:39](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/taskPlugin/task.ts#L39)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L39)
 
 ---
 
@@ -2025,7 +2024,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
+[packages/core/shared/src/plugins/taskPlugin/task.ts:13](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/task.ts#L13)
 
 ---
 
@@ -2035,7 +2034,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L304)
+[packages/core/shared/src/types.ts:304](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L304)
 
 ---
 
@@ -2059,7 +2058,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:534](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L534)
+[packages/core/shared/src/types.ts:526](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L526)
 
 ---
 
@@ -2069,7 +2068,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L478)
+[packages/core/shared/src/types.ts:478](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L478)
 
 ---
 
@@ -2079,7 +2078,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L162)
+[packages/core/shared/src/types.ts:162](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L162)
 
 ---
 
@@ -2089,7 +2088,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L163)
+[packages/core/shared/src/types.ts:163](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L163)
 
 ---
 
@@ -2121,7 +2120,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:31](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L31)
 
 ---
 
@@ -2131,7 +2130,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:691](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L691)
+[packages/core/shared/src/types.ts:683](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L683)
 
 ---
 
@@ -2141,7 +2140,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L389)
+[packages/core/shared/src/types.ts:389](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L389)
 
 ---
 
@@ -2167,7 +2166,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L165)
+[packages/core/shared/src/types.ts:165](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L165)
 
 ## Variables
 
@@ -2177,7 +2176,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:82](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L82)
+[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L76)
 
 ---
 
@@ -2187,7 +2186,7 @@ The interface for a spell object that's based on the `spellSchema`.
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:45](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L45)
+[packages/core/shared/src/config.ts:45](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L45)
 
 ---
 
@@ -2199,7 +2198,7 @@ The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/cost-calculator.ts#L40)
+[packages/core/shared/src/cost-calculator.ts:40](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L40)
 
 ---
 
@@ -2216,7 +2215,7 @@ The cost per token for each TextModel, EmbeddingModel and ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
+[packages/core/shared/src/plugins/cachePlugin/index.ts:90](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/cachePlugin/index.ts#L90)
 
 ---
 
@@ -2239,7 +2238,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
+[packages/core/shared/src/plugins/consolePlugin/index.ts:80](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/consolePlugin/index.ts#L80)
 
 ---
 
@@ -2249,7 +2248,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L30)
+[packages/core/shared/src/config.ts:30](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L30)
 
 ---
 
@@ -2259,7 +2258,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L31)
+[packages/core/shared/src/config.ts:31](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L31)
 
 ---
 
@@ -2269,7 +2268,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L33)
+[packages/core/shared/src/config.ts:33](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L33)
 
 ---
 
@@ -2279,7 +2278,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L34)
+[packages/core/shared/src/config.ts:34](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L34)
 
 ---
 
@@ -2289,7 +2288,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:76](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L76)
+[packages/core/shared/src/config.ts:70](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L70)
 
 ---
 
@@ -2299,7 +2298,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:51](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L51)
+[packages/core/shared/src/config.ts:51](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L51)
 
 ---
 
@@ -2316,7 +2315,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
+[packages/core/shared/src/plugins/errorPlugin/index.ts:48](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/errorPlugin/index.ts#L48)
 
 ---
 
@@ -2326,7 +2325,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:54](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L54)
+[packages/core/shared/src/config.ts:54](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L54)
 
 ---
 
@@ -2336,7 +2335,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:56](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L56)
+[packages/core/shared/src/config.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L56)
 
 ---
 
@@ -2346,7 +2345,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:47](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L47)
+[packages/core/shared/src/config.ts:47](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L47)
 
 ---
 
@@ -2363,7 +2362,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
+[packages/core/shared/src/plugins/historyPlugin/index.ts:77](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/historyPlugin/index.ts#L77)
 
 ---
 
@@ -2373,7 +2372,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L29)
+[packages/core/shared/src/config.ts:29](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L29)
 
 ---
 
@@ -2390,7 +2389,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
+[packages/core/shared/src/plugins/inspectorPlugin/index.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/inspectorPlugin/index.ts#L63)
 
 ---
 
@@ -2400,7 +2399,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:63](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L63)
+[packages/core/shared/src/config.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L63)
 
 ---
 
@@ -2417,7 +2416,7 @@ module:consolePlugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
+[packages/core/shared/src/plugins/keyCodePlugin/index.ts:41](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/keyCodePlugin/index.ts#L41)
 
 ---
 
@@ -2436,7 +2435,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
+[packages/core/shared/src/plugins/lifecyclePlugin/index.ts:92](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/lifecyclePlugin/index.ts#L92)
 
 ---
 
@@ -2453,7 +2452,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
+[packages/core/shared/src/plugins/modulePlugin/index.ts:279](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/modulePlugin/index.ts#L279)
 
 ---
 
@@ -2470,7 +2469,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
+[packages/core/shared/src/plugins/multiCopyPlugin/index.ts:164](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/multiCopyPlugin/index.ts#L164)
 
 ---
 
@@ -2487,7 +2486,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
+[packages/core/shared/src/plugins/multiSocketGenerator/index.ts:70](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/multiSocketGenerator/index.ts#L70)
 
 ---
 
@@ -2497,7 +2496,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:59](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L59)
+[packages/core/shared/src/config.ts:59](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L59)
 
 ---
 
@@ -2514,7 +2513,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
+[packages/core/shared/src/plugins/nodeClickPlugin/index.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/nodeClickPlugin/index.ts#L38)
 
 ---
 
@@ -2524,7 +2523,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L61)
+[packages/core/shared/src/config.ts:61](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L61)
 
 ---
 
@@ -2534,7 +2533,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L62)
+[packages/core/shared/src/config.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L62)
 
 ---
 
@@ -2544,7 +2543,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:85](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L85)
+[packages/core/shared/src/config.ts:79](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L79)
 
 ---
 
@@ -2554,7 +2553,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L67)
+[packages/core/shared/src/config.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L67)
 
 ---
 
@@ -2564,7 +2563,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:65](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L65)
+[packages/core/shared/src/config.ts:65](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L65)
 
 ---
 
@@ -2574,47 +2573,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L38)
-
----
-
-### REDISCLOUD_DB
-
-• `Const` **REDISCLOUD_DB**: `number`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:72](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L72)
-
----
-
-### REDISCLOUD_HOST
-
-• `Const` **REDISCLOUD_HOST**: `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:68](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L68)
-
----
-
-### REDISCLOUD_PASSWORD
-
-• `Const` **REDISCLOUD_PASSWORD**: `undefined` \| `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:73](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L73)
-
----
-
-### REDISCLOUD_PORT
-
-• `Const` **REDISCLOUD_PORT**: `number`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:69](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L69)
+[packages/core/shared/src/config.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L38)
 
 ---
 
@@ -2624,17 +2583,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:70](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L70)
-
----
-
-### REDISCLOUD_USERNAME
-
-• `Const` **REDISCLOUD_USERNAME**: `undefined` \| `string`
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:74](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L74)
+[packages/core/shared/src/config.ts:68](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L68)
 
 ---
 
@@ -2644,7 +2593,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L40)
+[packages/core/shared/src/config.ts:40](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L40)
 
 ---
 
@@ -2654,7 +2603,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L39)
+[packages/core/shared/src/config.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L39)
 
 ---
 
@@ -2664,7 +2613,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:49](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L49)
+[packages/core/shared/src/config.ts:49](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L49)
 
 ---
 
@@ -2674,7 +2623,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:41](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L41)
+[packages/core/shared/src/config.ts:41](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L41)
 
 ---
 
@@ -2684,7 +2633,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L37)
+[packages/core/shared/src/config.ts:37](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L37)
 
 ---
 
@@ -2701,7 +2650,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
+[packages/core/shared/src/plugins/selectionPlugin/index.ts:292](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/selectionPlugin/index.ts#L292)
 
 ---
 
@@ -2718,7 +2667,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
+[packages/core/shared/src/plugins/socketGenerator/index.ts:71](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketGenerator/index.ts#L71)
 
 ---
 
@@ -2735,7 +2684,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
+[packages/core/shared/src/plugins/socketOverridePlugin/index.ts:24](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketOverridePlugin/index.ts#L24)
 
 ---
 
@@ -2752,7 +2701,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
+[packages/core/shared/src/plugins/socketPlugin/index.ts:134](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/socketPlugin/index.ts#L134)
 
 ---
 
@@ -2762,7 +2711,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:43](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L43)
+[packages/core/shared/src/config.ts:43](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L43)
 
 ---
 
@@ -2779,7 +2728,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
+[packages/core/shared/src/plugins/taskPlugin/index.ts:108](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugins/taskPlugin/index.ts#L108)
 
 ---
 
@@ -2789,7 +2738,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L58)
+[packages/core/shared/src/config.ts:58](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L58)
 
 ---
 
@@ -2799,7 +2748,7 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L53)
+[packages/core/shared/src/config.ts:53](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L53)
 
 ---
 
@@ -2809,19 +2758,19 @@ Lifecycle Plugin
 
 #### Defined in
 
-[packages/core/shared/src/config.ts:79](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L79)
+[packages/core/shared/src/config.ts:73](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/config.ts#L73)
 
 ---
 
 ### agentSchema
 
-• `Const` **agentSchema**: `TObject`<{ `data`: `TOptional`<`TAny`\> ; `enabled`: `TOptional`<`TBoolean`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `pingedAt`: `TOptional`<`TString`<`string`\>\> ; `projectId`: `TString`<`string`\> ; `publicVariables`: `TOptional`<`TAny`\> ; `rootSpell`: `TOptional`<`TAny`\> ; `runState`: `TOptional`<`TString`<`string`\>\> ; `secrets`: `TOptional`<`TString`<`string`\>\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\> }\>
+• `Const` **agentSchema**: `TObject`<{ `data`: `TOptional`<`TAny`\> ; `enabled`: `TOptional`<`TBoolean`\> ; `id`: `TString`<`string`\> ; `name`: `TString`<`string`\> ; `pingedAt`: `TOptional`<`TString`<`string`\>\> ; `projectId`: `TString`<`string`\> ; `publicVariables`: `TOptional`<`TAny`\> ; `rootSpell`: `TOptional`<`TAny`\> ; `secrets`: `TOptional`<`TString`<`string`\>\> ; `updatedAt`: `TOptional`<`TString`<`string`\>\> }\>
 
 Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:54](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L54)
+[packages/core/shared/src/schemas.ts:53](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L53)
 
 ---
 
@@ -2831,7 +2780,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L55)
+[packages/core/shared/src/sockets.ts:55](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L55)
 
 ---
 
@@ -2841,7 +2790,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L58)
+[packages/core/shared/src/sockets.ts:58](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L58)
 
 ---
 
@@ -2851,7 +2800,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L63)
+[packages/core/shared/src/sockets.ts:63](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L63)
 
 ---
 
@@ -2861,27 +2810,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L57)
-
----
-
-### bullMQConnection
-
-• `Const` **bullMQConnection**: `Object`
-
-#### Type declaration
-
-| Name       | Type                    |
-| :--------- | :---------------------- |
-| `db`       | `number`                |
-| `host`     | `string`                |
-| `password` | `undefined` \| `string` |
-| `port`     | `number`                |
-| `username` | `undefined` \| `string` |
-
-#### Defined in
-
-[packages/core/shared/src/config.ts:89](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/config.ts#L89)
+[packages/core/shared/src/sockets.ts:57](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L57)
 
 ---
 
@@ -2891,7 +2820,7 @@ Full data model schema for an agent.
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:76](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/nodes/index.ts#L76)
+[packages/core/shared/src/nodes/index.ts:71](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/nodes/index.ts#L71)
 
 ---
 
@@ -2903,7 +2832,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:89](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L89)
+[packages/core/shared/src/schemas.ts:87](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L87)
 
 ---
 
@@ -2913,7 +2842,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L64)
+[packages/core/shared/src/sockets.ts:64](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L64)
 
 ---
 
@@ -2923,7 +2852,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L65)
+[packages/core/shared/src/sockets.ts:65](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L65)
 
 ---
 
@@ -2933,7 +2862,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L62)
+[packages/core/shared/src/sockets.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L62)
 
 ---
 
@@ -2943,7 +2872,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/globals.ts#L38)
+[packages/core/shared/src/globals.ts:38](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/globals.ts#L38)
 
 ---
 
@@ -2953,7 +2882,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L67)
+[packages/core/shared/src/sockets.ts:67](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L67)
 
 ---
 
@@ -2963,7 +2892,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L56)
+[packages/core/shared/src/sockets.ts:56](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L56)
 
 ---
 
@@ -2973,7 +2902,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L60)
+[packages/core/shared/src/sockets.ts:60](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L60)
 
 ---
 
@@ -2983,7 +2912,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/plugin.ts#L463)
+[packages/core/shared/src/plugin.ts:463](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/plugin.ts#L463)
 
 ---
 
@@ -2993,7 +2922,7 @@ Full data model schema for a document.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L39)
+[packages/core/shared/src/sockets.ts:39](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L39)
 
 ---
 
@@ -3005,7 +2934,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/schemas.ts#L17)
+[packages/core/shared/src/schemas.ts:17](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/schemas.ts#L17)
 
 ---
 
@@ -3015,7 +2944,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L59)
+[packages/core/shared/src/sockets.ts:59](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L59)
 
 ---
 
@@ -3025,7 +2954,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L66)
+[packages/core/shared/src/sockets.ts:66](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L66)
 
 ---
 
@@ -3035,7 +2964,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/sockets.ts#L61)
+[packages/core/shared/src/sockets.ts:61](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/sockets.ts#L61)
 
 ## Functions
 
@@ -3055,7 +2984,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L398)
+[packages/core/shared/src/types.ts:398](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L398)
 
 ---
 
@@ -3075,7 +3004,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L410)
+[packages/core/shared/src/types.ts:410](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L410)
 
 ---
 
@@ -3095,7 +3024,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L402)
+[packages/core/shared/src/types.ts:402](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L402)
 
 ---
 
@@ -3115,7 +3044,7 @@ Full data model schema for a spell.
 
 #### Defined in
 
-[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/types.ts#L406)
+[packages/core/shared/src/types.ts:406](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/types.ts#L406)
 
 ---
 
@@ -3140,7 +3069,7 @@ for a given TextModel or ChatModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/cost-calculator.ts#L62)
+[packages/core/shared/src/cost-calculator.ts:62](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L62)
 
 ---
 
@@ -3165,7 +3094,7 @@ for a given EmbeddingModel
 
 #### Defined in
 
-[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/cost-calculator.ts#L80)
+[packages/core/shared/src/cost-calculator.ts:80](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/cost-calculator.ts#L80)
 
 ---
 
@@ -3192,7 +3121,7 @@ for a given EmbeddingModel
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/spellManager/configureManager.ts#L3)
+[packages/core/shared/src/spellManager/configureManager.ts:3](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/spellManager/configureManager.ts#L3)
 
 ---
 
@@ -3216,7 +3145,7 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
+[packages/core/shared/src/spellManager/graphHelpers.ts:9](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/spellManager/graphHelpers.ts#L9)
 
 ---
 
@@ -3237,7 +3166,7 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:110](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L110)
+[packages/core/shared/src/engine.ts:110](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L110)
 
 ---
 
@@ -3251,7 +3180,7 @@ An array containing string values of all input keys found in the GraphData.
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/logger/index.ts#L27)
+[packages/core/shared/src/logger/index.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/logger/index.ts#L27)
 
 ---
 
@@ -3269,7 +3198,7 @@ An array of sorted MagickComponents.
 
 #### Defined in
 
-[packages/core/shared/src/nodes/index.ts:173](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/nodes/index.ts#L173)
+[packages/core/shared/src/nodes/index.ts:163](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/nodes/index.ts#L163)
 
 ---
 
@@ -3293,7 +3222,7 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/utils/getSpell.ts#L18)
+[packages/core/shared/src/utils/getSpell.ts:18](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/getSpell.ts#L18)
 
 ---
 
@@ -3315,7 +3244,7 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L123)
+[packages/core/shared/src/engine.ts:123](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L123)
 
 ---
 
@@ -3335,7 +3264,7 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/logger/index.ts#L8)
+[packages/core/shared/src/logger/index.ts:8](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/logger/index.ts#L8)
 
 ---
 
@@ -3355,7 +3284,7 @@ Fetch a specific spell from the project's spells based on its id.
 
 #### Defined in
 
-[packages/core/shared/src/engine.ts:66](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/engine.ts#L66)
+[packages/core/shared/src/engine.ts:66](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/engine.ts#L66)
 
 ---
 
@@ -3381,7 +3310,7 @@ The corresponding HTTP status code
 
 #### Defined in
 
-[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/utils/SpellError.ts#L51)
+[packages/core/shared/src/utils/SpellError.ts:51](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/SpellError.ts#L51)
 
 ---
 
@@ -3408,7 +3337,7 @@ The result of processing the code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/functions/processCode.ts#L23)
+[packages/core/shared/src/functions/processCode.ts:23](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/processCode.ts#L23)
 
 ---
 
@@ -3434,7 +3363,7 @@ The result of the executed Python code.
 
 #### Defined in
 
-[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/functions/ProcessPython.ts#L17)
+[packages/core/shared/src/functions/ProcessPython.ts:17](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/ProcessPython.ts#L17)
 
 ---
 
@@ -3462,7 +3391,7 @@ Run a spell with the given parameters.
 
 #### Defined in
 
-[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/utils/runSpell.ts#L28)
+[packages/core/shared/src/utils/runSpell.ts:28](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/utils/runSpell.ts#L28)
 
 ---
 
@@ -3486,4 +3415,4 @@ A promise that resolves the saved request object.
 
 #### Defined in
 
-[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/1f9f5624/packages/core/shared/src/functions/saveRequest.ts#L27)
+[packages/core/shared/src/functions/saveRequest.ts:27](https://github.com/Oneirocom/Magick/blob/dbd53981/packages/core/shared/src/functions/saveRequest.ts#L27)

--- a/packages/core/client/src/components/Window/window.module.css
+++ b/packages/core/client/src/components/Window/window.module.css
@@ -13,7 +13,7 @@
   background-color: var(--dark-2);
 }
 .window.darker .window-layout {
-  background-color: var(--dark-1);
+  background-color: var(--dark-0);
 }
 .window-layout {
   border-radius: 4px;

--- a/packages/core/server/src/declarations.ts
+++ b/packages/core/server/src/declarations.ts
@@ -1,11 +1,14 @@
-// DOCUMENTED 
+// DOCUMENTED
 // For more information about this file, see https://dove.feathersjs.com/guides/cli/.html
-import { HookContext as FeathersHookContext, NextFunction } from '@feathersjs/feathers';
-import { Application as FeathersApplication } from '@feathersjs/koa';
-import { ApplicationConfiguration } from './config/configuration';
-import { UserSpellManager } from '@magickml/core';
+import {
+  HookContext as FeathersHookContext,
+  NextFunction,
+} from '@feathersjs/feathers'
+import { Application as FeathersApplication } from '@feathersjs/koa'
+import { ApplicationConfiguration } from './config/configuration'
+import { UserSpellManager } from '@magickml/core'
 
-export { NextFunction };
+export type { NextFunction }
 
 /**
  * The types for app.get(name) and app.set(name).
@@ -22,8 +25,9 @@ export interface ServiceTypes {}
  * The application instance type that will be used everywhere else.
  * @extends FeathersApplication<ServiceTypes, Configuration>
  */
-export interface Application extends FeathersApplication<ServiceTypes, Configuration> {
-  userSpellManagers?: UserSpellManager;
+export interface Application
+  extends FeathersApplication<ServiceTypes, Configuration> {
+  userSpellManagers?: UserSpellManager
 }
 
 /**
@@ -31,4 +35,4 @@ export interface Application extends FeathersApplication<ServiceTypes, Configura
  * @template S - Type of the service. By default, it is set to `any`.
  * @extends FeathersHookContext<Application, S>
  */
-export type HookContext<S = any> = FeathersHookContext<Application, S>;
+export type HookContext<S = any> = FeathersHookContext<Application, S>

--- a/packages/core/shared/src/logger/index.ts
+++ b/packages/core/shared/src/logger/index.ts
@@ -6,28 +6,28 @@ let logger: pino.Logger | null = null
 const defaultLoggerOpts = {}
 
 export const initLogger = (opts: object = defaultLoggerOpts) => {
-    if (NODE_ENV === 'development') {
-        logger = pino({
-            transport: {
-                target: 'pino-pretty',
-                options: {
-                    colorize: true,
-                }
-            },
-            ...opts,
-            level: 'debug',
-        })
+  if (NODE_ENV === 'development') {
+    logger = pino({
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+        },
+      },
+      ...opts,
+      level: 'info',
+    })
 
-        return
-    }
+    return
+  }
 
-    logger = pino(opts)
+  logger = pino(opts)
 }
 
 export const getLogger: () => pino.Logger = () => {
-    if (logger !== null) {
-        return logger
-    }
+  if (logger !== null) {
+    return logger
+  }
 
-    throw new Error("Logger not initialized. Please call initLogger() first.")
+  throw new Error('Logger not initialized. Please call initLogger() first.')
 }

--- a/packages/core/shared/src/nodes/events/EventRecall.ts
+++ b/packages/core/shared/src/nodes/events/EventRecall.ts
@@ -45,8 +45,6 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       'Event',
       info
     )
-
-    this.runFromCache = true
   }
 
   /**

--- a/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
@@ -1,32 +1,32 @@
-// DOCUMENTED 
-import { NodeEditor } from 'rete';
+// DOCUMENTED
+import { NodeEditor } from 'rete'
 
-import { MagickComponent } from '../../engine';
-import { ComponentData, MagickNode } from '../../types';
-import { Inspector } from './Inspector';
+import { MagickComponent } from '../../engine'
+import { ComponentData, ControlData, MagickNode } from '../../types'
+import { Inspector } from './Inspector'
 
 // Add TSDoc comment to the class.
 /**
  * A general class for the data controls.
  */
 export abstract class DataControl {
-  inspector: Inspector | null = null;
-  editor: NodeEditor | null = null;
-  node: MagickNode | null = null;
-  component: MagickComponent<unknown> | null = null;
-  id: string | null = null;
-  dataKey: string;
-  name: string;
-  defaultValue: unknown;
-  componentData: ComponentData;
-  componentKey: string;
-  options: Record<string, unknown>;
-  icon: string;
-  write: boolean;
-  type: string;
-  placeholder: string;
-  data: ComponentData;
-  expanded?: boolean;
+  inspector: Inspector | null = null
+  editor: NodeEditor | null = null
+  node: MagickNode | null = null
+  component: MagickComponent<unknown> | null = null
+  id: string | null = null
+  dataKey: string
+  name: string
+  defaultValue: unknown
+  componentData: ComponentData
+  componentKey: string
+  options: Record<string, unknown>
+  icon: string
+  write: boolean
+  type: string
+  placeholder: string
+  data: ComponentData
+  expanded?: boolean
 
   // Add TSDoc comment to the constructor.
   /**
@@ -54,39 +54,39 @@ export abstract class DataControl {
     type = 'string',
     placeholder = '',
   }: {
-    dataKey: string;
-    name: string;
-    component: string;
-    data?: ComponentData;
-    options?: Record<string, unknown>;
-    write?: boolean;
-    icon?: string;
-    defaultValue?: unknown;
-    type?: string;
-    placeholder?: string;
+    dataKey: string
+    name: string
+    component: string
+    data?: ComponentData
+    options?: Record<string, unknown>
+    write?: boolean
+    icon?: string
+    defaultValue?: unknown
+    type?: string
+    placeholder?: string
   }) {
-    if (!dataKey) throw new Error('Data key is required');
-    if (!name) throw new Error('Name is required');
-    if (!component) throw new Error('Component name is required');
+    if (!dataKey) throw new Error('Data key is required')
+    if (!name) throw new Error('Name is required')
+    if (!component) throw new Error('Component name is required')
 
-    this.dataKey = dataKey;
-    this.name = name;
-    this.componentData = data;
-    this.componentKey = component;
-    this.options = options;
-    this.icon = icon;
-    this.write = write;
-    this.defaultValue = defaultValue;
-    this.type = type;
-    this.placeholder = placeholder;
-    this.data = data;
+    this.dataKey = dataKey
+    this.name = name
+    this.componentData = data
+    this.componentKey = component
+    this.options = options
+    this.icon = icon
+    this.write = write
+    this.defaultValue = defaultValue
+    this.type = type
+    this.placeholder = placeholder
+    this.data = data
   }
 
   // Add TSDoc comment to the method.
   /**
    * Serializer to easily extract the data control's information for publishing.
    */
-  get control() {
+  get control(): ControlData {
     return {
       dataKey: this.dataKey,
       name: this.name,
@@ -97,7 +97,7 @@ export abstract class DataControl {
       icon: this.icon,
       type: this.type,
       placeholder: this.placeholder,
-    };
+    }
   }
 
   // Add TSDoc comment to the method.
@@ -105,7 +105,7 @@ export abstract class DataControl {
    * Abstract method to execute when a control is added.
    */
   onAdd(): void | undefined {
-    return;
+    return
   }
 
   // Add TSDoc comment to the method.
@@ -113,7 +113,7 @@ export abstract class DataControl {
    * Abstract method to execute when a control is removed.
    */
   onRemove(): void | undefined {
-    return;
+    return
   }
 
   // Add TSDoc comment to the (optional) method.
@@ -121,5 +121,5 @@ export abstract class DataControl {
    * Abstract method to handle updating data (optional).
    * @param args - An array of unknown arguments
    */
-  onData?(...args: unknown[]): Promise<void> | void;
+  onData?(...args: unknown[]): Promise<void> | void
 }

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -134,6 +134,18 @@ export type EventResponse = Event[]
 
 export type OnSubspellUpdated = (spell: SpellInterface) => void
 
+export type ControlData = {
+  dataKey: string
+  name: string
+  component: string
+  data: ComponentData
+  options: Record<string, unknown>
+  id: string | null
+  icon: string
+  type: string
+  placeholder: string
+}
+
 export class MagickEditor extends NodeEditor<EventsTypes> {
   declare tasks: Task[]
   declare currentSpell: SpellInterface

--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -14,79 +14,6 @@ body,
   height: 100%;
 }
 
-.socket.output.any-type,
-.socket.input.any-type {
-  background: #838383;
-}
-
-.socket.output.boolean,
-.socket.input.boolean {
-  background: #f54703;
-}
-
-.socket.output.string,
-.socket.input.string {
-  background: #f59403;
-}
-
-.socket.output.array,
-.socket.input.array {
-  background: #1290ce;
-}
-
-.socket.output.object,
-.socket.input.object {
-  background: #21b534;
-}
-
-.socket.output.number,
-.socket.input.number {
-  background: #fcbd03;
-}
-
-.socket.output.trigger,
-.socket.input.trigger {
-  background: var(--primary);
-}
-
-.socket.output.event,
-.socket.input.event {
-  background: #0e10a4;
-}
-
-.socket {
-  height: var(--small);
-  width: var(--small);
-  border: 1px solid var(--primary);
-}
-
-.socket.output {
-  position: relative;
-  right: -5px;
-}
-
-.socket.input {
-  position: relative;
-  left: -5px;
-}
-
-.socket:hover {
-  background-color: var(--dark-1);
-}
-
-.node.selected {
-  background-color: #05c807 !important;
-}
-
-.connection .main-path {
-  stroke-width: 2px;
-  stroke: #9d12a4;
-  /* filter: drop-shadow(0px 1px 0px var(--dark-0))
-    drop-shadow(0px -1px 0px var(--dark-0))
-    drop-shadow(-1px 0px 0px var(--dark-0))
-    drop-shadow(1px 0px 0px var(--dark-0)); */
-}
-
 button {
   box-sizing: border-box;
   color: #fff;
@@ -153,6 +80,68 @@ button.disabled {
   pointer-events: none;
   opacity: 0.5;
   background-color: var(--dark-2);
+}
+
+.socket.output.any-type,
+.socket.input.any-type {
+  background: #838383;
+}
+
+.socket.output.boolean,
+.socket.input.boolean {
+  background: #f54703;
+}
+
+.socket.output.string,
+.socket.input.string {
+  background: #f59403;
+}
+
+.socket.output.array,
+.socket.input.array {
+  background: #1290ce;
+}
+
+.socket.output.object,
+.socket.input.object {
+  background: #21b534;
+}
+
+.socket.output.number,
+.socket.input.number {
+  background: #fcbd03;
+}
+
+.socket.output.trigger,
+.socket.input.trigger {
+  background: var(--primary);
+}
+
+.socket.output.event,
+.socket.input.event {
+  background: #0e10a4;
+}
+
+.socket {
+  height: var(--small);
+  width: var(--small);
+}
+
+.socket:hover {
+  background-color: var(--dark-1);
+}
+
+.node.selected {
+  background-color: #05c807 !important;
+}
+
+.connection .main-path {
+  stroke-width: 2px;
+  stroke: #9d12a4;
+  /* filter: drop-shadow(0px 1px 0px var(--dark-0))
+    drop-shadow(0px -1px 0px var(--dark-0))
+    drop-shadow(-1px 0px 0px var(--dark-0))
+    drop-shadow(1px 0px 0px var(--dark-0)); */
 }
 
 .node.selected button {
@@ -467,21 +456,6 @@ input:focus-visible {
   height: 1.5rem;
   border-radius: 0.4rem;
   margin: 0 0.5rem;
-}
-
-.bare-input {
-  padding: 0;
-  margin: 0;
-  border: 0;
-  background: transparent;
-  outline: none;
-  font-size: 0.975rem;
-}
-
-.input-title,
-.output-title,
-div.item {
-  font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
 }
 
 .flexlayout__layout {

--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -14,8 +14,25 @@ body,
   height: 100%;
 }
 
+.expanding {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: var(--extra-small);
+  width: var(--extra-small);
+  border-radius: 100%;
+  transition: transform 0.2s ease;
+}
+
+.expanding:hover {
+  transform: scale(1.5);
+}
+
 .socket.output.any-type,
-.socket.input.any-type {
+.socket.input.any-type,
+.expanding.any {
   background: #838383;
 }
 
@@ -24,7 +41,8 @@ body,
 }
 
 .socket.output.boolean,
-.socket.input.boolean {
+.socket.input.boolean,
+.expanding.boolean {
   background: var(--red);
 }
 
@@ -33,7 +51,8 @@ body,
 }
 
 .socket.output.string,
-.socket.input.string {
+.socket.input.string,
+.expanding.string {
   background: var(--orange);
 }
 
@@ -42,7 +61,8 @@ body,
 }
 
 .socket.output.array,
-.socket.input.array {
+.socket.input.array,
+.expanding.array {
   background: var(--blue);
 }
 
@@ -51,7 +71,8 @@ body,
 }
 
 .socket.output.object,
-.socket.input.object {
+.socket.input.object,
+.expanding.object {
   background: var(--green);
 }
 
@@ -60,7 +81,8 @@ body,
 }
 
 .socket.output.number,
-.socket.input.number {
+.socket.input.number,
+.expanding.number {
   background: var(--yellow);
 }
 
@@ -69,7 +91,8 @@ body,
 }
 
 .socket.output.trigger,
-.socket.input.trigger {
+.socket.input.trigger,
+.expanding.trigger {
   background: var(--purple);
 }
 
@@ -78,7 +101,8 @@ body,
 }
 
 .socket.output.event,
-.socket.input.event {
+.socket.input.event,
+.expanding.event {
   background: var(--deep-blue);
 }
 
@@ -92,6 +116,7 @@ body,
 
 .connection .main-path:hover {
   stroke-width: 5px !important;
+  opacity: 1 !important;
   /* stroke: var(--glow) !important; */
 }
 
@@ -118,9 +143,9 @@ body,
   left: -5px;
 }
 
-.socket:hover {
+/* .socket:hover {
   background-color: var(--dark-0);
-}
+} */
 
 .node.selected {
   background-color: #05c807 !important;
@@ -136,7 +161,7 @@ button {
   padding: 9px 16px;
   padding-left: var(--small);
   padding-right: var(--small);
-  font-family: 'IBM Plex Mono', 'sans-serif' !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', 'sans-serif' !important;
   font-size: 11px;
   text-transform: uppercase;
   box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.2);
@@ -204,7 +229,7 @@ button.disabled {
   border-radius: 0px 0px 4px 4px;
   border: 1px solid #333;
   border-top: 0;
-  font-family: 'IBM Plex Mono';
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono';
 }
 
 .flexlayout__tabset {
@@ -233,7 +258,7 @@ button.disabled {
 
 .flexlayout__tabset {
   font-size: 14px;
-  font-family: 'IBM Plex Mono', 'sans-serif' !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', 'sans-serif' !important;
 }
 
 .flexlayout__tab {
@@ -271,7 +296,7 @@ button.disabled {
 }
 
 /* .view-line span {
-  font-family: 'IBM Plex Mono', sans-serif;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', sans-serif;
 } */
 
 input {
@@ -286,7 +311,7 @@ input {
   cursor: default;
   border: 1px solid var(--dark-4);
   box-shadow: inset 0px 5px 5px rgba(0, 0, 0, 0.1);
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   font-size: 11px;
   height: var(--c4);
 }
@@ -355,7 +380,7 @@ input:focus-visible {
 .form-item-label {
   display: block;
   margin-bottom: 0.5em;
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
 
   color: var(--dark-4);
 }
@@ -379,7 +404,7 @@ input:focus-visible {
   cursor: default;
   border: 1px solid var(--dark-3);
   box-shadow: inset 0px 5px 5px rgba(0, 0, 0, 0.1);
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   font-size: 11px;
   height: var(--c4);
 }
@@ -520,13 +545,14 @@ input:focus-visible {
 .input-title,
 .output-title,
 div.item {
-  font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
+    sans-serif;
 }
 
 .flexlayout__layout {
   background-color: var(--dark-1) !important;
   color: var(--dark-4);
-  font-family: 'IBM Plex Mono';
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono';
 }
 
 .MuiInputBase-root input,

--- a/packages/editor/src/App.css
+++ b/packages/editor/src/App.css
@@ -1,6 +1,6 @@
 html,
 body {
-  background-color: var(--dark-1);
+  background-color: var(--dark-0);
   color: var(--dark-4);
   overflow: hidden;
   padding: 0;
@@ -14,13 +14,125 @@ body,
   height: 100%;
 }
 
+.socket.output.any-type,
+.socket.input.any-type {
+  background: #838383;
+}
+
+.any .main-path {
+  stroke: #838383 !important;
+}
+
+.socket.output.boolean,
+.socket.input.boolean {
+  background: var(--red);
+}
+
+.boolean .main-path {
+  stroke: var(--red) !important;
+}
+
+.socket.output.string,
+.socket.input.string {
+  background: var(--orange);
+}
+
+.string .main-path {
+  stroke: var(--orange) !important;
+}
+
+.socket.output.array,
+.socket.input.array {
+  background: var(--blue);
+}
+
+.array .main-path {
+  stroke: var(--blue) !important;
+}
+
+.socket.output.object,
+.socket.input.object {
+  background: var(--green);
+}
+
+.object .main-path {
+  stroke: var(--green) !important;
+}
+
+.socket.output.number,
+.socket.input.number {
+  background: var(--yellow);
+}
+
+.number .main-path {
+  stroke: var(--yellow) !important;
+}
+
+.socket.output.trigger,
+.socket.input.trigger {
+  background: var(--purple);
+}
+
+.trigger .main-path {
+  stroke: var(--purple) !important;
+}
+
+.socket.output.event,
+.socket.input.event {
+  background: var(--deep-blue);
+}
+
+.event .main-path {
+  stroke: var(--deep-blue) !important;
+}
+
+.connection .main-path {
+  stroke-width: 2px !important;
+}
+
+.connection .main-path:hover {
+  stroke-width: 5px !important;
+  /* stroke: var(--glow) !important; */
+}
+
+.selected .main-path {
+  stroke-width: 5px !important;
+}
+
+.transparent .main-path {
+  opacity: 0.5 !important;
+}
+
+.socket {
+  height: var(--small);
+  width: var(--small);
+}
+
+.socket.output {
+  position: relative;
+  right: -5px;
+}
+
+.socket.input {
+  position: relative;
+  left: -5px;
+}
+
+.socket:hover {
+  background-color: var(--dark-0);
+}
+
+.node.selected {
+  background-color: #05c807 !important;
+}
+
 button {
   box-sizing: border-box;
   color: #fff;
   border-radius: 4px;
   cursor: default;
-  background-color: var(--dark-3);
-  border: 1px solid var(--dark-4);
+  background-color: var(--dark-2);
+  border: 1px solid var(--dark-3);
   padding: 9px 16px;
   padding-left: var(--small);
   padding-right: var(--small);
@@ -41,25 +153,25 @@ button.option {
 
 button.primary {
   background-color: var(--primary);
-  color: var(--dark-5);
+  color: var(--dark-4);
 }
 
 button.list {
-  background-color: var(--dark-2);
+  background-color: var(--dark-1);
   padding: 3px;
   padding-left: var(--small);
   padding-right: var(--small);
 }
 
 button.small {
-  background-color: var(--dark-3s);
+  background-color: var(--dark-2);
   padding: 8px;
   padding-left: var(--small);
   padding-right: var(--small);
 }
 
 button.extra-small {
-  background-color: var(--dark-3);
+  background-color: var(--dark-2);
   padding: 4px;
   padding-left: var(--extraSmall);
   padding-right: var(--extraSmall);
@@ -79,69 +191,7 @@ button.disabled {
   box-shadow: none;
   pointer-events: none;
   opacity: 0.5;
-  background-color: var(--dark-2);
-}
-
-.socket.output.any-type,
-.socket.input.any-type {
-  background: #838383;
-}
-
-.socket.output.boolean,
-.socket.input.boolean {
-  background: #f54703;
-}
-
-.socket.output.string,
-.socket.input.string {
-  background: #f59403;
-}
-
-.socket.output.array,
-.socket.input.array {
-  background: #1290ce;
-}
-
-.socket.output.object,
-.socket.input.object {
-  background: #21b534;
-}
-
-.socket.output.number,
-.socket.input.number {
-  background: #fcbd03;
-}
-
-.socket.output.trigger,
-.socket.input.trigger {
-  background: var(--primary);
-}
-
-.socket.output.event,
-.socket.input.event {
-  background: #0e10a4;
-}
-
-.socket {
-  height: var(--small);
-  width: var(--small);
-}
-
-.socket:hover {
   background-color: var(--dark-1);
-}
-
-.node.selected {
-  background-color: #05c807 !important;
-}
-
-.connection .main-path {
-  stroke-width: 2px;
-  stroke: #9d12a4;
-  /* filter: drop-shadow(0px 1px 0px var(--dark-0))
-    drop-shadow(0px -1px 0px var(--dark-0))
-    drop-shadow(-1px 0px 0px var(--dark-0))
-    drop-shadow(1px 0px 0px var(--dark-0)); */
 }
 
 .node.selected button {
@@ -150,7 +200,7 @@ button.disabled {
 
 .flexlayout__tab {
   overflow: hidden;
-  background-color: var(--dark-1) !important;
+  background-color: var(--dark-0) !important;
   border-radius: 0px 0px 4px 4px;
   border: 1px solid #333;
   border-top: 0;
@@ -174,7 +224,7 @@ button.disabled {
 
 .flexlayout__tabset_tabbar_inner_tab_container_top {
   border-top: none;
-  background-color: var(--dark-2);
+  background-color: var(--dark-1);
 }
 
 .flexlayout__tabset_tabbar_outer_top {
@@ -187,16 +237,16 @@ button.disabled {
 }
 
 .flexlayout__tab {
-  background-color: var(--dark-3);
+  background-color: var(--dark-2);
 }
 
 .flexlayout__tab_toolbar {
-  background-color: var(--dark-2);
+  background-color: var(--dark-1);
 }
 
 .flexlayout__tab_button {
   margin: 0;
-  background-color: var(--dark-3);
+  background-color: var(--dark-2);
   box-shadow: none;
   padding-left: var(--extraSmall);
   padding-right: var(--extraSmall);
@@ -228,7 +278,7 @@ input {
   box-sizing: border-box;
   padding: var(--extraSmall);
   /* not using a var here to optically correct for base + cap of typeface */
-  background-color: var(--dark-2);
+  background-color: var(--dark-1);
   padding-left: var(--small);
   padding-right: var(--small);
   color: #fff;
@@ -307,12 +357,12 @@ input:focus-visible {
   margin-bottom: 0.5em;
   font-family: 'IBM Plex Mono', monospace !important;
 
-  color: var(--dark-5);
+  color: var(--dark-4);
 }
 
 .select {
   padding: 0.4em;
-  border: 1px solid var(--dark-4);
+  border: 1px solid var(--dark-3);
   border-radius: 4px;
 }
 
@@ -323,11 +373,11 @@ input:focus-visible {
   box-sizing: border-box;
   padding: var(--extraSmall);
   /* not using a var here to optically correct for base + cap of typeface */
-  background-color: var(--dark-2);
+  background-color: var(--dark-1);
   color: #fff;
   border-radius: 4px;
   cursor: default;
-  border: 1px solid var(--dark-4);
+  border: 1px solid var(--dark-3);
   box-shadow: inset 0px 5px 5px rgba(0, 0, 0, 0.1);
   font-family: 'IBM Plex Mono', monospace !important;
   font-size: 11px;
@@ -458,8 +508,23 @@ input:focus-visible {
   margin: 0 0.5rem;
 }
 
+.bare-input {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  outline: none;
+  font-size: 0.975rem;
+}
+
+.input-title,
+.output-title,
+div.item {
+  font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
+}
+
 .flexlayout__layout {
-  background-color: var(--dark-2) !important;
+  background-color: var(--dark-1) !important;
   color: var(--dark-4);
   font-family: 'IBM Plex Mono';
 }

--- a/packages/editor/src/components/MenuBar/menuBar.module.css
+++ b/packages/editor/src/components/MenuBar/menuBar.module.css
@@ -85,7 +85,7 @@ li.list-item:only-child {
   padding: var(--extraSmall);
   padding-left: var(--small);
   padding-right: var(--small);
-  font-family: 'IBM Plex Mono';
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono';
   text-transform: uppercase;
   list-style: none;
 

--- a/packages/editor/src/components/Modals/DeleteModal.tsx
+++ b/packages/editor/src/components/Modals/DeleteModal.tsx
@@ -40,7 +40,7 @@ const DeleteModal = ({ closeModal, handledelete, id }) => {
 
   const options = [
     {
-      className: css.deleteBtn,
+      className: css['delete-btn'],
       label: 'Delete',
       onClick: onSubmit
     }
@@ -51,7 +51,7 @@ const DeleteModal = ({ closeModal, handledelete, id }) => {
       title="Confirm Delete"
       options={options}
       icon="info"
-      className={css.deleteModal}
+      className={css['delete-modal']}
     />
   );
 }

--- a/packages/editor/src/components/Node/Node.module.css
+++ b/packages/editor/src/components/Node/Node.module.css
@@ -13,7 +13,7 @@
   transition: background-color 0.05s ease;
   min-width: var(--c30);
   width: var(--c30);
-  border-radius: var(--small);
+  border-radius: var(--extraSmall);
   outline: 1px solid var(--glow-dark);
   box-shadow: 0 4px 5px rgba(0, 0, 0, 0.2);
   background-color: #0011168f;
@@ -32,11 +32,11 @@
   /* backdrop-filter: blur(15px); */
 }
 .node.error {
-  border-color: var(--red) !important;
+  outline-color: var(--red) !important;
   /* backdrop-filter: blur(15px); */
 }
 .node.success {
-  border-color: var(--green) !important;
+  outline-color: var(--green) !important;
   border: 2px solid var(--green);
 }
 .node-depricated {
@@ -163,4 +163,8 @@
 div.item {
   font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
     sans-serif;
+}
+
+.socket-wrapper {
+  display: inherit;
 }

--- a/packages/editor/src/components/Node/Node.module.css
+++ b/packages/editor/src/components/Node/Node.module.css
@@ -16,7 +16,7 @@
   border-radius: var(--small);
   outline: 1px solid var(--glow-dark);
   box-shadow: 0 4px 5px rgba(0, 0, 0, 0.2);
-  background-color: #0011167a;
+  background-color: #0011168f;
   color: var(--glow);
   resize: both;
   /* backdrop-filter: blur(3px); */
@@ -66,7 +66,7 @@
   padding: var(--extraSmall);
   border-bottom: 1px solid var(--dark-2);
   color: var(--glow);
-  background: none;
+  background: var(--dark-0);
   border-radius: var(--extraSmall) var(--extraSmall) 0px 0px;
   display: flex;
 }

--- a/packages/editor/src/components/Node/Node.module.css
+++ b/packages/editor/src/components/Node/Node.module.css
@@ -13,16 +13,31 @@
   transition: background-color 0.05s ease;
   min-width: var(--c30);
   width: var(--c30);
-  border-radius: var(--extraSmall);
-  border: 1px solid transparent;
+  border-radius: var(--small);
+  outline: 1px solid var(--glow-dark);
   box-shadow: 0 4px 5px rgba(0, 0, 0, 0.2);
-  background-color: rgba(70, 70, 70, 1.0);
-  color: #aaa;
+  background-color: #0011167a;
+  color: var(--glow);
   resize: both;
   /* backdrop-filter: blur(3px); */
 }
 .node:hover {
-  border: 1px solid var(--dark-4);
+  outline: 4px solid var(--glow-dark);
+}
+.node.selected {
+  /* color: var(--glow); */
+  background-color: #001116bb;
+  box-shadow: var(--glow);
+  outline: 4px solid var(--glow);
+  /* backdrop-filter: blur(15px); */
+}
+.node.error {
+  border-color: var(--red) !important;
+  /* backdrop-filter: blur(15px); */
+}
+.node.success {
+  border-color: var(--green) !important;
+  border: 2px solid var(--green);
 }
 .node-depricated {
   position: absolute;
@@ -43,19 +58,17 @@
   color: var(--green);
 }
 .node-title {
-font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
+    sans-serif;
   /* text-transform: uppercase; */
   letter-spacing: 0.1em;
   font-weight: 900;
   padding: var(--extraSmall);
-  padding-bottom: var(--small);
-  padding-top: var(--small);
   border-bottom: 1px solid var(--dark-2);
-  color: #fff;
+  color: var(--glow);
   background: none;
   border-radius: var(--extraSmall) var(--extraSmall) 0px 0px;
   display: flex;
-  opacity: 0.5;
 }
 .input,
 .output {
@@ -64,9 +77,10 @@ font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
 
 .connections-container {
   display: flex;
+  padding: var(--extraSmall);
 }
 .bottom-container {
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   border-top: 1px solid var(--dark-2);
   padding: var(--extraSmall);
   display: flex;
@@ -74,41 +88,28 @@ font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
   gap: var(--extraSmall);
 }
 .bottom-container .control {
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   flex: 1;
 }
 .bottom-container .control:last-child {
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   flex: 0.5;
 }
 .bottom-container .control:first-child {
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   flex: 1;
 }
 
 .control button {
   background-color: var(--primary);
   width: 100%;
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
 }
 .control input {
   box-sizing: border-box;
   width: 100%;
 }
-.node.selected {
-  color: var(--dark-5);
-  background-color: rgba(70, 70, 70, 1.0);
-  border-color: var(--glow);
-  /* backdrop-filter: blur(15px); */
-}
-.node.error {
-  border-color: var(--red) !important;
-  /* backdrop-filter: blur(15px); */
-}
-.node.success {
-  border-color: var(--green) !important;
-  border: 2px solid var(--green);
-}
+
 .node.selected .node-title {
   opacity: 1;
   border-bottom: 1px solid var(--dark-1);
@@ -118,11 +119,7 @@ font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
   border-top: 1px solid var(--dark-1);
 }
 .connection-container {
-  padding: var(--extraSmall);
   flex: 1;
-}
-.connection-container.out {
-  background-color: rgba(0, 0, 0, 0.3);
 }
 .input {
   justify-content: flex-start;
@@ -150,4 +147,20 @@ font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
   width: 99%;
   height: 99%;
   margin: auto;
+}
+
+.bare-input {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  outline: none;
+  font-size: 0.975rem;
+}
+
+.input-title,
+.output-title,
+div.item {
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
+    sans-serif;
 }

--- a/packages/editor/src/components/Node/Node.tsx
+++ b/packages/editor/src/components/Node/Node.tsx
@@ -34,7 +34,7 @@ export class MyNode extends Node {
    * @returns The JSX representation of the component.
    */
   render() {
-    const { node, bindSocket, bindControl } = this.props;
+    const { node, bindSocket, bindControl, editor } = this.props;
     const { outputs, controls, inputs, selected } = this.state;
     const name = node.displayName ? node.displayName : node.name;
     const fullName = node.data.name ?? name;
@@ -42,6 +42,20 @@ export class MyNode extends Node {
     const hasSuccess = node.data.success;
     const img_url = node.data.image;
     const html = node.data.func;
+
+    const handleMouseEnter = (socket) => {
+      socket.connections.forEach(connection => {
+        const el = editor.view.connections.get(connection).el
+        el.classList.add('selected')
+      })
+    }
+
+    const handleMouseLeave = (socket) => {
+      socket.connections.forEach(connection => {
+        const el = editor.view.connections.get(connection).el
+        el.classList.remove('selected')
+      })
+    }
 
     return (
       <div
@@ -72,12 +86,18 @@ export class MyNode extends Node {
             <div className={css['connection-container']}>
               {inputs.map(input => (
                 <div className={css['input']} key={input.key}>
-                  <Socket
-                    type="input"
-                    socket={input.socket}
-                    io={input}
-                    innerRef={bindSocket}
-                  />
+                  <div
+
+                    onMouseEnter={() => handleMouseEnter(input)}
+                    onMouseLeave={() => handleMouseLeave(input)}>
+                    <Socket
+                      type="input"
+                      socket={input.socket}
+                      io={input}
+                      innerRef={bindSocket}
+                    />
+
+                  </div>
                   {!input.showControl() && (
                     <div className="input-title">{input.name}</div>
                   )}
@@ -101,12 +121,16 @@ export class MyNode extends Node {
                       element.data = { ...element.data, hello: 'hello' };
                     })}
                   <div className="output-title">{output.name}</div>
-                  <Socket
-                    type="output"
-                    socket={output.socket}
-                    io={output}
-                    innerRef={bindSocket}
-                  />
+                  <div
+                    onMouseEnter={() => handleMouseEnter(output)}
+                    onMouseLeave={() => handleMouseLeave(output)}>
+                    <Socket
+                      type="output"
+                      socket={output.socket}
+                      io={output}
+                      innerRef={bindSocket}
+                    />
+                  </div>
                 </div>
               ))}
             </div>
@@ -121,7 +145,7 @@ export class MyNode extends Node {
             />
           ))}
         </div>
-      </div>
+      </div >
     );
   }
 }

--- a/packages/editor/src/components/Node/Node.tsx
+++ b/packages/editor/src/components/Node/Node.tsx
@@ -111,9 +111,7 @@ export class MyNode extends Node {
               ))}
             </div>
           )}
-        </div>
-        <div className={css['bottom-container']}>
-          {/* Controls */}
+
           {controls.map(control => (
             <Control
               className={css['control']}

--- a/packages/editor/src/contexts/ChatProvider.tsx
+++ b/packages/editor/src/contexts/ChatProvider.tsx
@@ -1,5 +1,5 @@
 import { LoadingScreen } from '@magickml/client-core'
-import { EditorContext, GraphData, MagickEditor, Spell } from '@magickml/core'
+import { EditorContext, GraphData, MagickEditor, SpellInterface } from '@magickml/core'
 import React, {
   createContext,
   useContext,
@@ -36,7 +36,7 @@ type EditorContextType = {
   buildEditor: (
     el: HTMLDivElement,
     // todo update this to use proper spell type
-    spell: Spell | undefined,
+    spell: SpellInterface | undefined,
     tab: MagickTab,
     reteInterface: EditorContext
   ) => void
@@ -79,8 +79,8 @@ const ChatProvider = ({ children }) => {
     const newEditor = await initEditor({
       container,
       pubSub,
+      context: magick,
       // calling magick during migration of screens
-      magick,
       tab,
       // MyNode is a custom default style for nodes
       node: MyNode,

--- a/packages/editor/src/contexts/InspectorProvider.tsx
+++ b/packages/editor/src/contexts/InspectorProvider.tsx
@@ -1,6 +1,6 @@
 // DOCUMENTED
 import { usePubSub } from '@magickml/client-core';
-import { InspectorData, SupportedLanguages } from '@magickml/core';
+import { ControlData, InspectorData, SupportedLanguages } from '@magickml/core';
 import { createContext, useContext, useEffect, useState } from 'react';
 
 /**
@@ -8,10 +8,10 @@ import { createContext, useContext, useEffect, useState } from 'react';
  */
 export type TextEditorData = {
   options?:
-    | Record<string, any>
-    | (undefined & {
-        language?: SupportedLanguages
-      })
+  | Record<string, any>
+  | (undefined & {
+    language?: SupportedLanguages
+  })
   data?: string
   control?: Record<string, any> | undefined
   name?: string
@@ -56,7 +56,7 @@ const InspectorProvider = ({ children, tab }) => {
       if (!data.dataControls) return
 
       // Handle components
-      Object.entries(data.dataControls).forEach(([, control]) => {
+      Object.entries(data.dataControls as ControlData[]).forEach(([, control]) => {
         if (control?.options?.editor) {
           // Relay data to the text editor
           const textData = {

--- a/packages/editor/src/design-globals/design-globals.css
+++ b/packages/editor/src/design-globals/design-globals.css
@@ -1,5 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap');
+
+@font-face {
+  font-family: 'BerkeleyMono-Regular';
+  src: url(https://lglrzlrsfxchbqsslvur.supabase.co/storage/v1/object/public/assets/BerkeleyMono-Regular.otf);
+}
+
 * {
   margin: 0;
 }
@@ -13,7 +19,8 @@ form,
 button,
 label,
 .flexlayout__tab_button_content {
-  font-family: 'IBM Plex Sans', 'IBM Plex Mono', sans-serif;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
+    sans-serif;
 }
 
 :root {
@@ -34,8 +41,8 @@ label,
   --blue: #1290ce;
   --purple: #7027dd;
   --glow-light: #b2fccd75;
-  --glow: #9d12a4;
-  --glow-dark: #570b5b;
+  --glow: #00e1ef;
+  --glow-dark: #00818a;
 
   --c1: 8px;
   --c2: 16px;

--- a/packages/editor/src/design-globals/design-globals.css
+++ b/packages/editor/src/design-globals/design-globals.css
@@ -39,6 +39,7 @@ label,
   --yellow: #fcbd03;
   --green: #21b534;
   --blue: #1290ce;
+  --deep-blue: #0e10a4;
   --purple: #7027dd;
   --glow-light: #b2fccd75;
   --glow: #00e1ef;

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -5,6 +5,7 @@ import gridimg from './grid.png'
 import CommentPlugin from './plugins/commentPlugin'
 import CommentManager from './plugins/commentPlugin/manager'
 import ContextMenuPlugin from './plugins/contextMenu'
+import HighlightPlugin from './plugins/highlightPlugin'
 import {
   CachePlugin,
   OnSubspellUpdated,
@@ -93,6 +94,8 @@ export const initEditor = function ({
   }
 
   editor.use(CachePlugin)
+
+  editor.use(HighlightPlugin)
 
   // History plugin for undo/redo
   editor.use(HistoryPlugin, { keyboard: false })

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -201,6 +201,14 @@ export const initEditor = function ({
     return source !== 'dblclick'
   })
 
+  // Unselect all nodes when clicking off nodes
+  editor.on('click', () => {
+    const list = [...editor.selected.list]
+
+    editor.selected.clear()
+    list.map(node => (node.update ? node.update() : null))
+  })
+
   editor.on(
     'multiselectnode',
     args => (args.accumulate = args.e.ctrlKey || args.e.metaKey)

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -1,11 +1,11 @@
 // DOCUMENTED
-import ConnectionPlugin from 'rete-connection-plugin'
 import { Plugin } from 'rete/types/core/plugin'
 import gridimg from './grid.png'
 import CommentPlugin from './plugins/commentPlugin'
 import CommentManager from './plugins/commentPlugin/manager'
 import ContextMenuPlugin from './plugins/contextMenu'
 import HighlightPlugin from './plugins/highlightPlugin'
+import ConnectionPlugin from './plugins/connectionPlugin'
 import {
   CachePlugin,
   OnSubspellUpdated,

--- a/packages/editor/src/layouts/MagickPageLayout/MagickPageLayout.tsx
+++ b/packages/editor/src/layouts/MagickPageLayout/MagickPageLayout.tsx
@@ -12,7 +12,7 @@ import css from './pagewrapper.module.css'
  * @function
  * @returns {JSX.Element} - The JSX element representing the wrapped pages.
  */
-const MagickPageWrapper = (): JSX.Element => {
+const MagickPageWrapper = () => {
   // Select the active tab from the Redux store.
   // const activeTab = useSelector(activeTabSelector)
 

--- a/packages/editor/src/plugins/areaPlugin/snap.ts
+++ b/packages/editor/src/plugins/areaPlugin/snap.ts
@@ -1,6 +1,11 @@
 import { PubSub, events } from '@magickml/client-core'
+import { MagickEditor } from '@magickml/core'
 
 export class SnapGrid {
+  editor: MagickEditor
+  size: number
+  active: boolean
+
   constructor(editor, { size = 16, dynamic = true }) {
     this.editor = editor
     this.size = size

--- a/packages/editor/src/plugins/commentPlugin/style.css
+++ b/packages/editor/src/plugins/commentPlugin/style.css
@@ -9,10 +9,15 @@
   border-radius: 16px;
 }
 
+.frame-comment,
+.inline-comment {
+  background: rgb(70 47 186 / 20%);
+}
+
 .frame-comment:focus,
 .inline-comment:focus {
   outline: none;
-  border-color: var(--glow);
+  border-color: rgba(88, 59, 234, 0.504);
 }
 
 .inline-comment {

--- a/packages/editor/src/plugins/commentPlugin/style.css
+++ b/packages/editor/src/plugins/commentPlugin/style.css
@@ -12,7 +12,7 @@
 .frame-comment:focus,
 .inline-comment:focus {
   outline: none;
-  border-color: #ffd92c;
+  border-color: var(--glow);
 }
 
 .inline-comment {

--- a/packages/editor/src/plugins/connectionPlugin/events.ts
+++ b/packages/editor/src/plugins/connectionPlugin/events.ts
@@ -1,0 +1,14 @@
+import { Connection, Input, Output } from 'rete';
+
+declare module 'rete/types/events' {
+    interface EventsTypes {
+        connectionpath: {
+            points: number[],
+            connection: Connection,
+            d: string
+        },
+        connectiondrop: Input | Output
+        connectionpick: Input | Output
+        resetconnection: void
+    }
+}

--- a/packages/editor/src/plugins/connectionPlugin/flow.ts
+++ b/packages/editor/src/plugins/connectionPlugin/flow.ts
@@ -1,0 +1,47 @@
+import { IO, Input, Output } from 'rete';
+import { Picker } from './picker';
+
+export type FlowParams = { input?: Input, output?: Output };
+
+export class Flow {
+
+    private picker: Picker;
+    private target?: IO | null;
+
+    constructor(picker: Picker) {
+        this.picker = picker;
+        this.target = null;
+    }
+
+    private act({ input, output }: FlowParams) {
+        if (this.unlock(input || output)) return
+
+        if (input)
+            this.picker.pickInput(input)
+        else if (output)
+            this.picker.pickOutput(output)
+        else
+            this.picker.reset();
+    }
+
+    public start(params: FlowParams, io?: IO) {
+        this.act(params);
+        this.target = io;
+    }
+
+    public complete(params: FlowParams = {}) {
+        this.act(params);
+    }
+
+    public hasTarget() {
+        return Boolean(this.target);
+    }
+
+    private unlock(io?: IO) {
+        const target = this.target;
+
+        this.target = null;
+
+        return target && target === io;
+    }
+}

--- a/packages/editor/src/plugins/connectionPlugin/index.css
+++ b/packages/editor/src/plugins/connectionPlugin/index.css
@@ -1,0 +1,15 @@
+.connection {
+  overflow: visible !important;
+  position: absolute;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.connection > * {
+  pointer-events: all;
+}
+.connection .main-path {
+  fill: none;
+  stroke-width: 5px;
+  stroke: steelblue;
+}

--- a/packages/editor/src/plugins/connectionPlugin/index.sass
+++ b/packages/editor/src/plugins/connectionPlugin/index.sass
@@ -1,0 +1,11 @@
+.connection
+  overflow: visible !important
+  position: absolute
+  z-index: -1
+  pointer-events: none
+  > *
+    pointer-events: all
+  .main-path
+    fill: none
+    stroke-width: 5px
+    stroke: steelblue

--- a/packages/editor/src/plugins/connectionPlugin/index.ts
+++ b/packages/editor/src/plugins/connectionPlugin/index.ts
@@ -1,0 +1,79 @@
+import { NodeEditor } from 'rete'
+import {
+  renderConnection,
+  renderPathData,
+  updateConnection,
+  getMapItemRecursively,
+} from './utils'
+import { Picker } from './picker'
+import { Flow, FlowParams } from './flow'
+import './events'
+import './index.sass'
+
+function install(editor: NodeEditor) {
+  editor.bind('connectionpath')
+  editor.bind('connectiondrop')
+  editor.bind('connectionpick')
+  editor.bind('resetconnection')
+
+  const picker = new Picker(editor)
+  const flow = new Flow(picker)
+  const socketsParams = new WeakMap<Element, FlowParams>()
+
+  function pointerDown(this: HTMLElement, e: PointerEvent) {
+    const flowParams = socketsParams.get(this)
+
+    if (flowParams) {
+      const { input, output } = flowParams
+
+      editor.view.container.dispatchEvent(new PointerEvent('pointermove', e))
+      e.preventDefault()
+      e.stopPropagation()
+      flow.start({ input, output }, input || output)
+    }
+  }
+
+  function pointerUp(this: Window, e: PointerEvent) {
+    const flowEl = document.elementFromPoint(e.clientX, e.clientY)
+
+    if (picker.io) {
+      editor.trigger('connectiondrop', picker.io)
+    }
+    if (flowEl) {
+      flow.complete(getMapItemRecursively(socketsParams, flowEl) || {})
+    }
+  }
+
+  editor.on('resetconnection', () => flow.complete())
+
+  editor.on('rendersocket', ({ el, input, output }) => {
+    socketsParams.set(el, { input, output })
+
+    el.removeEventListener('pointerdown', pointerDown)
+    el.addEventListener('pointerdown', pointerDown)
+  })
+
+  window.addEventListener('pointerup', pointerUp)
+
+  editor.on('renderconnection', ({ el, connection, points }) => {
+    const d = renderPathData(editor, points, connection)
+
+    renderConnection({ el, d, connection })
+  })
+
+  editor.on('updateconnection', ({ el, connection, points }) => {
+    const d = renderPathData(editor, points, connection)
+
+    updateConnection({ el, d })
+  })
+
+  editor.on('destroy', () => {
+    window.removeEventListener('pointerup', pointerUp)
+  })
+}
+
+export default {
+  name: 'connection',
+  install,
+}
+export { defaultPath } from './utils'

--- a/packages/editor/src/plugins/connectionPlugin/picker/index.ts
+++ b/packages/editor/src/plugins/connectionPlugin/picker/index.ts
@@ -1,0 +1,85 @@
+import { NodeEditor, Input, Output, Connection } from 'rete';
+import { PickerView } from './view';
+
+export class Picker {
+
+    private editor: NodeEditor;
+    private _io: Output | Input | null = null;
+    public view: PickerView;
+
+    constructor(editor: NodeEditor) {
+        this.editor = editor;
+        this.view = new PickerView(editor, editor.view);
+
+        editor.on('mousemove', () => this.io && this.view.updateConnection(this.io));
+    }
+
+    get io() : Output | Input | null {
+        return this._io;
+    }
+
+    set io(io: Output | Input | null) {
+        this._io = io;
+        this.view.updatePseudoConnection(io);
+    }
+
+    reset() {
+        this.io = null;
+    }
+
+    pickOutput(output: Output) {
+        if (!this.editor.trigger('connectionpick', output)) return;
+        
+        if (this.io instanceof Input) {
+            if(!output.multipleConnections && output.hasConnection())
+                this.editor.removeConnection(output.connections[0])
+    
+            this.editor.connect(output, this.io);
+            this.reset();
+            return;
+        }
+
+        if (this.io) this.reset();
+        this.io = output;
+    }
+
+    pickInput(input: Input) {
+        if (!this.editor.trigger('connectionpick', input)) return;
+
+        if (this.io === null) {
+            if (input.hasConnection()) {
+                this.io = input.connections[0].output;
+                this.editor.removeConnection(input.connections[0]);
+            } else {
+                this.io = input;
+            }
+            return true;
+        }
+
+        if (!input.multipleConnections && input.hasConnection())
+            this.editor.removeConnection(input.connections[0]);
+        
+        if (!this.io.multipleConnections && this.io.hasConnection())
+            this.editor.removeConnection(this.io.connections[0]);
+        
+        if (this.io instanceof Output && this.io.connectedTo(input)) {
+            let connection = input.connections.find(c => c.output === this.io);
+
+            if(connection) {
+                this.editor.removeConnection(connection);
+            }
+        }
+
+        if(this.io instanceof Output) {
+            this.editor.connect(this.io, input);
+            this.reset();
+        }
+    }
+
+    pickConnection(connection: Connection) {
+        const { output } = connection;
+
+        this.editor.removeConnection(connection);
+        this.io = output;
+    }
+}

--- a/packages/editor/src/plugins/connectionPlugin/picker/index.ts
+++ b/packages/editor/src/plugins/connectionPlugin/picker/index.ts
@@ -1,85 +1,84 @@
-import { NodeEditor, Input, Output, Connection } from 'rete';
-import { PickerView } from './view';
+import { NodeEditor, Input, Output, Connection } from 'rete'
+import { PickerView } from './view'
 
 export class Picker {
+  private editor: NodeEditor
+  private _io: Output | Input | null = null
+  public view: PickerView
 
-    private editor: NodeEditor;
-    private _io: Output | Input | null = null;
-    public view: PickerView;
+  constructor(editor: NodeEditor) {
+    this.editor = editor
+    this.view = new PickerView(editor, editor.view)
 
-    constructor(editor: NodeEditor) {
-        this.editor = editor;
-        this.view = new PickerView(editor, editor.view);
+    editor.on('mousemove', () => this.io && this.view.updateConnection(this.io))
+  }
 
-        editor.on('mousemove', () => this.io && this.view.updateConnection(this.io));
+  get io(): Output | Input | null {
+    return this._io
+  }
+
+  set io(io: Output | Input | null) {
+    this._io = io
+    this.view.updatePseudoConnection(io)
+  }
+
+  reset() {
+    this.io = null
+  }
+
+  pickOutput(output: Output) {
+    if (!this.editor.trigger('connectionpick', output)) return
+
+    if (this.io instanceof Input) {
+      if (!output.multipleConnections && output.hasConnection())
+        this.editor.removeConnection(output.connections[0])
+
+      this.editor.connect(output, this.io)
+      this.reset()
+      return
     }
 
-    get io() : Output | Input | null {
-        return this._io;
+    if (this.io) this.reset()
+    this.io = output
+  }
+
+  pickInput(input: Input) {
+    if (!this.editor.trigger('connectionpick', input)) return
+
+    if (this.io === null) {
+      if (input.hasConnection()) {
+        this.io = input.connections[0].output
+        this.editor.removeConnection(input.connections[0])
+      } else {
+        this.io = input
+      }
+      return true
     }
 
-    set io(io: Output | Input | null) {
-        this._io = io;
-        this.view.updatePseudoConnection(io);
+    if (!input.multipleConnections && input.hasConnection())
+      this.editor.removeConnection(input.connections[0])
+
+    if (!this.io.multipleConnections && this.io.hasConnection())
+      this.editor.removeConnection(this.io.connections[0])
+
+    if (this.io instanceof Output && this.io.connectedTo(input)) {
+      const connection = input.connections.find(c => c.output === this.io)
+
+      if (connection) {
+        this.editor.removeConnection(connection)
+      }
     }
 
-    reset() {
-        this.io = null;
+    if (this.io instanceof Output) {
+      this.editor.connect(this.io, input)
+      this.reset()
     }
+  }
 
-    pickOutput(output: Output) {
-        if (!this.editor.trigger('connectionpick', output)) return;
-        
-        if (this.io instanceof Input) {
-            if(!output.multipleConnections && output.hasConnection())
-                this.editor.removeConnection(output.connections[0])
-    
-            this.editor.connect(output, this.io);
-            this.reset();
-            return;
-        }
+  pickConnection(connection: Connection) {
+    const { output } = connection
 
-        if (this.io) this.reset();
-        this.io = output;
-    }
-
-    pickInput(input: Input) {
-        if (!this.editor.trigger('connectionpick', input)) return;
-
-        if (this.io === null) {
-            if (input.hasConnection()) {
-                this.io = input.connections[0].output;
-                this.editor.removeConnection(input.connections[0]);
-            } else {
-                this.io = input;
-            }
-            return true;
-        }
-
-        if (!input.multipleConnections && input.hasConnection())
-            this.editor.removeConnection(input.connections[0]);
-        
-        if (!this.io.multipleConnections && this.io.hasConnection())
-            this.editor.removeConnection(this.io.connections[0]);
-        
-        if (this.io instanceof Output && this.io.connectedTo(input)) {
-            let connection = input.connections.find(c => c.output === this.io);
-
-            if(connection) {
-                this.editor.removeConnection(connection);
-            }
-        }
-
-        if(this.io instanceof Output) {
-            this.editor.connect(this.io, input);
-            this.reset();
-        }
-    }
-
-    pickConnection(connection: Connection) {
-        const { output } = connection;
-
-        this.editor.removeConnection(connection);
-        this.io = output;
-    }
+    this.editor.removeConnection(connection)
+    this.io = output
+  }
 }

--- a/packages/editor/src/plugins/connectionPlugin/picker/view.ts
+++ b/packages/editor/src/plugins/connectionPlugin/picker/view.ts
@@ -1,0 +1,54 @@
+import { Output, Input, Emitter } from 'rete';
+import { EditorView } from 'rete/types/view/index';
+import { EventsTypes } from 'rete/types/events';
+import { renderConnection, renderPathData, updateConnection } from '../utils';
+
+export class PickerView {
+
+    private el: HTMLElement;
+
+    constructor(
+        private emitter: Emitter<EventsTypes>,
+        private editorView: EditorView
+    ) {
+        this.el = document.createElement('div');
+        this.el.style.position = 'absolute';
+        this.editorView.area.appendChild(this.el);
+    }
+
+    updatePseudoConnection(io: Output | Input | null) {
+        if (io !== null) {
+            this.renderConnection(io);
+        } else if (this.el.parentElement) {
+            this.el.innerHTML = '';
+        }
+    }
+
+    private getPoints(io: Output | Input): number[] {
+        const mouse = this.editorView.area.mouse;
+
+        if(!io.node) throw new Error('Node in output/input not found')
+    
+        const node = this.editorView.nodes.get(io.node);
+
+        if(!node) throw new Error('Node view not found')
+    
+        const [x1, y1] = node.getSocketPosition(io);
+
+        return io instanceof Output
+            ? [x1, y1, mouse.x, mouse.y]
+            : [mouse.x, mouse.y, x1, y1];
+    }
+
+    updateConnection(io: Output | Input) {
+        const d = renderPathData(this.emitter, this.getPoints(io));
+
+        updateConnection({ el: this.el, d });
+    }
+
+    renderConnection(io: Output | Input) {
+        const d = renderPathData(this.emitter, this.getPoints(io));
+
+        renderConnection({ el: this.el, d });
+    }
+}

--- a/packages/editor/src/plugins/connectionPlugin/utils.ts
+++ b/packages/editor/src/plugins/connectionPlugin/utils.ts
@@ -1,0 +1,152 @@
+import { documentResolver } from 'packages/core/server/src/services/documents/documents.schema'
+import { Emitter, Connection } from 'rete'
+import { EventsTypes } from 'rete/types/events'
+
+function toTrainCase(str: string) {
+  return str.toLowerCase().replace(/ /g, '-')
+}
+
+export function getMapItemRecursively<T extends any>(
+  map: WeakMap<Element, T>,
+  el: Element
+): T | null {
+  return (
+    map.get(el) ||
+    (el.parentElement ? getMapItemRecursively(map, el.parentElement) : null)
+  )
+}
+
+export function defaultPath(points: number[], curvature: number) {
+  const [x1, y1, x2, y2] = points
+  const hx1 = x1 + Math.abs(x2 - x1) * curvature
+  const hx2 = x2 - Math.abs(x2 - x1) * curvature
+
+  return `M ${x1} ${y1} C ${hx1} ${y1} ${hx2} ${y2} ${x2} ${y2}`
+}
+
+export function renderPathData(
+  emitter: Emitter<EventsTypes>,
+  points: number[],
+  connection?: Connection
+) {
+  const data = { points, connection, d: '' }
+
+  emitter.trigger('connectionpath', data)
+
+  return data.d || defaultPath(points, 0.4)
+}
+
+export function updateConnection({ el, d }: { el: HTMLElement; d: string }) {
+  const path = el.querySelector('.connection path')
+
+  if (!path) throw new Error('Path of connection was broken')
+
+  path.setAttribute('d', d)
+}
+
+export function renderConnection({
+  el,
+  d,
+  connection,
+}: {
+  el: HTMLElement
+  d: string
+  connection?: Connection
+}) {
+  const classed = !connection
+    ? []
+    : [
+        'input-' + toTrainCase(connection.input.name),
+        'output-' + toTrainCase(connection.output.name),
+        'socket-input-' + toTrainCase(connection.input.socket.name),
+        'socket-output-' + toTrainCase(connection.output.socket.name),
+      ]
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+
+  // Create SVG filter for the glow effect
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs')
+  const filter = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'filter'
+  )
+  filter.setAttribute('id', 'glow')
+  const feGaussianBlur = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feGaussianBlur'
+  )
+  feGaussianBlur.setAttribute('stdDeviation', '4')
+  feGaussianBlur.setAttribute('result', 'coloredBlur')
+  const feFlood = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feFlood'
+  )
+  feFlood.setAttribute('flood-color', 'white')
+  feFlood.setAttribute('flood-opacity', '0.75')
+  feFlood.setAttribute('result', 'glowColor')
+  const feComposite = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feComposite'
+  )
+  feComposite.setAttribute('in', 'glowColor')
+  feComposite.setAttribute('in2', 'coloredBlur')
+  feComposite.setAttribute('operator', 'in')
+  feComposite.setAttribute('result', 'glowComposite')
+  const feMerge = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feMerge'
+  )
+  const feMergeNode = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feMergeNode'
+  )
+  feMergeNode.setAttribute('in', 'glowComposite')
+  const feMergeNode2 = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'feMergeNode'
+  )
+  feMergeNode2.setAttribute('in', 'SourceGraphic')
+
+  feMerge.appendChild(feMergeNode)
+  feMerge.appendChild(feMergeNode2)
+  filter.appendChild(feGaussianBlur)
+  filter.appendChild(feFlood)
+  filter.appendChild(feComposite)
+  filter.appendChild(feMerge)
+  defs.appendChild(filter)
+  svg.appendChild(defs)
+
+  svg.classList.add('connection', ...classed)
+  path.classList.add('main-path')
+
+  path.setAttribute('d', d)
+
+  svg.appendChild(path)
+  el.appendChild(svg)
+
+  updateConnection({ el, d })
+
+  // const observer = new MutationObserver(mutations => {
+  //   mutations.forEach(mutation => {
+  //     console.log('CHANGES!')
+  //     if (
+  //       mutation.type === 'attributes' &&
+  //       mutation.attributeName === 'class'
+  //     ) {
+  //       const target = mutation.target as HTMLElement
+  //       const path = target.querySelector('.main-path')
+  //       if (target.classList.contains('selected')) {
+  //         if (path) path.setAttribute('filter', 'url(#glow)')
+  //       } else {
+  //         if (path) path.removeAttribute('filter')
+  //       }
+  //     }
+  //   })
+  // })
+
+  // // Call the observer with the right element selector.
+  // observer.observe(document.querySelector('.connection-wrapper'), {
+  //   attributes: true,
+  // })
+}

--- a/packages/editor/src/plugins/connectionPlugin/utils.ts
+++ b/packages/editor/src/plugins/connectionPlugin/utils.ts
@@ -1,4 +1,3 @@
-import { documentResolver } from 'packages/core/server/src/services/documents/documents.schema'
 import { Emitter, Connection } from 'rete'
 import { EventsTypes } from 'rete/types/events'
 
@@ -6,7 +5,7 @@ function toTrainCase(str: string) {
   return str.toLowerCase().replace(/ /g, '-')
 }
 
-export function getMapItemRecursively<T extends any>(
+export function getMapItemRecursively<T>(
   map: WeakMap<Element, T>,
   el: Element
 ): T | null {

--- a/packages/editor/src/plugins/contextMenu/menu.ts
+++ b/packages/editor/src/plugins/contextMenu/menu.ts
@@ -1,4 +1,4 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * The Menu class provides an abstract base class for menus in the editor.
  */
@@ -12,7 +12,7 @@ export default abstract class Menu {
     if (this.constructor === Menu) {
       throw new TypeError(
         'Abstract class "Menu" cannot be instantiated directly'
-      );
+      )
     }
   }
 
@@ -22,7 +22,9 @@ export default abstract class Menu {
    * @param onClick - The callback function to execute when the item is clicked
    * @param path - Optional parameter to specify the icon path
    */
-  addItem(title: string, onClick: () => void, path?: string): void {/* null */}
+  addItem(title: string, onClick: () => void, path?: string[]): void {
+    /* null */
+  }
 
   /**
    * Displays the menu at the specified x and y coordinates
@@ -30,10 +32,14 @@ export default abstract class Menu {
    * @param y - The y-coordinate to position the menu
    * @param args - Additional arguments to pass to the menu
    */
-  show(x: number, y: number, args: any): void {/* null */}
+  show(x: number, y: number, args: any): void {
+    /* null */
+  }
 
   /**
    * Hides the menu from view
    */
-  hide(): void {/* null */}
+  hide(): void {
+    /* null */
+  }
 }

--- a/packages/editor/src/plugins/contextMenu/node-menu.ts
+++ b/packages/editor/src/plugins/contextMenu/node-menu.ts
@@ -3,78 +3,76 @@ import { ReactMenu } from '.'
 import { createNode, traverse } from './utils'
 
 /**
+ * NodeMenu class that extends ReactMenu.
+ */
+class NodeMenu extends ReactMenu {
+  /**
+   * NodeMenu constructor.
+   * @param {object} editor - The editor instance
+   * @param {object} props - Additional properties for the NodeMenu
+   * @param {object} nodeItems - A set of key-value pairs for node items
+   */
+  constructor(editor: any, props: any, nodeItems: any) {
+    // Call parent constructor with modified props and node type
+    super(editor, { ...props, type: 'node' })
+
+    // Add 'Delete' menu item
+    this.addItem('Delete', ({ node }: { node: any }) => editor.removeNode(node))
+
+    // Add 'Clone' menu item
+    this.addItem('Clone', async (args: any) => {
+      const {
+        name,
+        position: [x, y],
+        ...params
+      } = args.node
+      const component = editor.components.get(name)
+
+      // New socketKey will be created at build since each node should have its unique socketKey
+      params.data.socketKey = null
+      const node = await createNode(component, {
+        ...params,
+        x: x + 10,
+        y: y + 10,
+      })
+
+      editor.addNode(node)
+    })
+
+    // Add 'Copy' menu item
+    this.addItem('Copy', () => {
+      const pubSub = editor.pubSub
+      const tabId = editor.tab.id
+      const event = pubSub.events.$MULTI_SELECT_COPY(tabId)
+      pubSub.publish(event)
+    })
+
+    // Add 'Paste' menu item
+    this.addItem('Paste', () => {
+      const pubSub = editor.pubSub
+      const tabId = editor.tab.id
+      const event = pubSub.events.$MULTI_SELECT_PASTE(tabId)
+      pubSub.publish(event)
+    })
+
+    // Add 'Comment' menu item
+    this.addItem('Wrap in comment \u21E7 f', () => {
+      const ids = editor.selected.list.map(node => node.id)
+      const nodes = ids.map(id => editor.nodes.find(n => n.id === id))
+      editor.trigger('addcomment', { type: 'frame', nodes })
+    })
+
+    // Add additional nodeItems, if any
+    traverse(nodeItems, (name: string, func: any, path: string[]) =>
+      this.addItem(name, func, path)
+    )
+  }
+}
+
+/**
  * Creates a new NodeMenu class.
  * @returns A NodeMenu class
  */
 export default function (): typeof NodeMenu {
-  /**
-   * NodeMenu class that extends ReactMenu.
-   */
-  class NodeMenu extends ReactMenu {
-    /**
-     * NodeMenu constructor.
-     * @param {object} editor - The editor instance
-     * @param {object} props - Additional properties for the NodeMenu
-     * @param {object} nodeItems - A set of key-value pairs for node items
-     */
-    constructor(editor: any, props: any, nodeItems: any) {
-      // Call parent constructor with modified props and node type
-      super(editor, { ...props, type: 'node' })
-
-      // Add 'Delete' menu item
-      this.addItem('Delete', ({ node }: { node: any }) =>
-        editor.removeNode(node)
-      )
-
-      // Add 'Clone' menu item
-      this.addItem('Clone', async (args: any) => {
-        const {
-          name,
-          position: [x, y],
-          ...params
-        } = args.node
-        const component = editor.components.get(name)
-
-        // New socketKey will be created at build since each node should have its unique socketKey
-        params.data.socketKey = null
-        const node = await createNode(component, {
-          ...params,
-          x: x + 10,
-          y: y + 10,
-        })
-
-        editor.addNode(node)
-      })
-
-      // Add 'Copy' menu item
-      this.addItem('Copy', (args: any) => {
-        const pubSub = editor.pubSub
-        const tabId = editor.tab.id
-        const event = pubSub.events.$MULTI_SELECT_COPY(tabId)
-        pubSub.publish(event)
-      })
-
-      // Add 'Paste' menu item
-      this.addItem('Paste', (args: any) => {
-        const pubSub = editor.pubSub
-        const tabId = editor.tab.id
-        const event = pubSub.events.$MULTI_SELECT_PASTE(tabId)
-        pubSub.publish(event)
-      })
-
-      // Add 'Comment' menu item
-      this.addItem('Wrap in comment \u21E7 f', (args: any) => {
-        const ids = editor.selected.list.map(node => node.id)
-        const nodes = ids.map(id => editor.nodes.find(n => n.id === id))
-        editor.trigger('addcomment', { type: 'frame', nodes })
-      })
-
-      // Add additional nodeItems, if any
-      traverse(nodeItems, (name: string, func: any, path: string[]) =>
-        this.addItem(name, func, path)
-      )
-    }
-  }
-
   return NodeMenu
 }

--- a/packages/editor/src/plugins/contextMenu/react-menu/Item.tsx
+++ b/packages/editor/src/plugins/contextMenu/react-menu/Item.tsx
@@ -19,12 +19,25 @@ import React, { Component } from 'react';
  * @property {boolean} visibleSubitems - Whether the subitems are visible.
  */
 
+type ItemType = {
+  title: string
+  onClick: (args) => void
+  subitems: ItemType[]
+}
+
+
+type State =
+  {
+    visibleSubitems: boolean
+  }
+
+type Props = { item: ItemType, search?: string }
 /**
  * Class representing an item with optional subitems.
  * @class Item
  * @extends {Component<ItemProps, ItemState>}
  */
-class Item extends Component {
+class Item extends Component<Props, State> {
   static contextType = Context;
 
   /**
@@ -35,7 +48,7 @@ class Item extends Component {
     super(props);
     this.state = {
       visibleSubitems: false,
-    };
+    }
   }
 
   /**
@@ -45,7 +58,7 @@ class Item extends Component {
   onClick = (e) => {
     const {
       item: { onClick },
-    } = this.props;
+    } = this.props
 
     // Doing this for now since we will be converting to functional components
     // @ts-ignore
@@ -80,7 +93,7 @@ class Item extends Component {
           <div className={styles['subitems']}>
             {subitems.map((subitem) =>
               search !== '' &&
-              !subitem.title.toLowerCase().includes(search.toLowerCase()) ? null : (
+                !subitem.title.toLowerCase().includes(search.toLowerCase()) ? null : (
                 <Item key={subitem.title} item={subitem} />
               )
             )}

--- a/packages/editor/src/plugins/contextMenu/react-menu/Menu.tsx
+++ b/packages/editor/src/plugins/contextMenu/react-menu/Menu.tsx
@@ -38,16 +38,16 @@ export default function ContextMenu({
    * This effect sets the focus on the search bar when the context menu is rendering.
    * It also clears the input value when the context menu is closed.
    */
-   
+
   useEffect(() => {
     if (visible) {
-      const searchbar = document?.querySelector('.context-menu-search-bar')
+      const searchbar = document?.querySelector('.context-menu-search-bar') as HTMLElement
       if (searchbar) searchbar.focus()
     } else {
       setSearch('')
     }
   }, [visible])
-  
+
   if (!visible) return null
 
   return (

--- a/packages/editor/src/plugins/contextMenu/react-menu/index.tsx
+++ b/packages/editor/src/plugins/contextMenu/react-menu/index.tsx
@@ -42,7 +42,7 @@ export default class CustomMenu extends Menu {
    * @param {function} onClick - The onClick function for the menu item
    * @param {Array} path - The path for the menu item, default is an empty array
    */
-  addItem(title, onClick, path = []) {
+  addItem(title: string, onClick: (args) => void, path: string[] = []) {
     injectItem(this.items, title, onClick, path);
     this.render();
   }

--- a/packages/editor/src/plugins/contextMenu/utils.ts
+++ b/packages/editor/src/plugins/contextMenu/utils.ts
@@ -1,10 +1,10 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * Returns a deep copy of an object using the JSON method.
  * @param obj The object to be copied.
  */
 export function deepCopy<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(JSON.stringify(obj))
 }
 
 /**
@@ -19,14 +19,19 @@ export function deepCopy<T>(obj: T): T {
  */
 export async function createNode(
   component: any,
-  { data = {}, meta = {}, x = 0, y = 0 }: { data?: any; meta?: any; x?: number; y?: number }
+  {
+    data = {},
+    meta = {},
+    x = 0,
+    y = 0,
+  }: { data?: any; meta?: any; x?: number; y?: number }
 ): Promise<any> {
-  const node = await component.createNode(deepCopy(data));
+  const node = await component.createNode(deepCopy(data))
 
-  node.meta = Object.assign(deepCopy(meta), node.meta);
-  node.position = [x, y];
+  node.meta = Object.assign(deepCopy(meta), node.meta)
+  node.position = [x, y]
 
-  return node;
+  return node
 }
 
 /**
@@ -40,12 +45,12 @@ export function traverse(
   callback: (key: string, value: any, path: string[]) => void,
   path: string[] = []
 ) {
-  if (typeof items !== "object") return;
+  if (typeof items !== 'object') return
 
-  Object.keys(items).forEach((key) => {
-    if (typeof items[key] === "function") callback(key, items[key], path);
-    else traverse(items[key], callback, [...path, key]);
-  });
+  Object.keys(items).forEach(key => {
+    if (typeof items[key] === 'function') callback(key, items[key], path)
+    else traverse(items[key], callback, [...path, key])
+  })
 }
 
 /**
@@ -58,7 +63,7 @@ export function fitViewport(coord: number[], element: HTMLElement): number[] {
   return [
     Math.min(coord[0], window.innerWidth - element.clientWidth),
     Math.min(coord[1], window.innerHeight - element.clientHeight),
-  ];
+  ]
 }
 
 /**
@@ -71,19 +76,19 @@ export function fitViewport(coord: number[], element: HTMLElement): number[] {
 export function injectItem(
   items: any[],
   title: string,
-  onClick: () => void,
+  onClick: (args) => void,
   path: string[]
 ) {
   for (const level of path) {
-    let exist = items.find((i) => i.title === level);
+    let exist = items.find(i => i.title === level)
 
     if (!exist) {
-      exist = { title: level, subitems: [] };
-      items.push(exist);
+      exist = { title: level, subitems: [] }
+      items.push(exist)
     }
 
-    items = exist.subitems || (exist.subitems = []);
+    items = exist.subitems || (exist.subitems = [])
   }
 
-  items.push({ title, onClick });
+  items.push({ title, onClick })
 }

--- a/packages/editor/src/plugins/highlightPlugin/index.ts
+++ b/packages/editor/src/plugins/highlightPlugin/index.ts
@@ -13,6 +13,12 @@ type DataType = {
 }
 
 function install(editor, params) {
+  // editor.on('rendersocket', ({ el, input, output, socket }) => {
+  //   console.log('Editor', editor)
+  //   console.log('SOCKET', socket)
+  //   console.log('INPUT', input?.connections)
+  // })
+
   editor.on('renderconnection', ({ connection, el }: DataType) => {
     const inputName = connection.input.socket.name
     const outputName = connection.output.socket.name

--- a/packages/editor/src/plugins/highlightPlugin/index.ts
+++ b/packages/editor/src/plugins/highlightPlugin/index.ts
@@ -1,8 +1,10 @@
 import { Connection } from 'rete'
 import {
+  addPathGlowToNode,
   makeAllConnectionsOpaque,
   makeAllConnectionsTransparent,
   makeNodeConnectionsOpaque,
+  removePathGlowFromAllConnections,
   selectNodeConnections,
   unselectAllConnections,
 } from './utils'
@@ -22,6 +24,8 @@ function install(editor, params) {
   editor.on('renderconnection', ({ connection, el }: DataType) => {
     const inputName = connection.input.socket.name
     const outputName = connection.output.socket.name
+
+    el.className += ' connection-wrapper'
 
     if (inputName === 'Any' && outputName === 'Any') {
       el.className += ' any'
@@ -60,17 +64,20 @@ function install(editor, params) {
     // unselect all connections first from connection Map
     unselectAllConnections(editor)
     makeAllConnectionsOpaque(editor)
+    removePathGlowFromAllConnections(editor)
 
     // select all connections from node
     selectNodeConnections(editor, node)
     makeAllConnectionsTransparent(editor)
     makeNodeConnectionsOpaque(editor, node)
+    addPathGlowToNode(editor, node)
   })
 
   // Make sure to unselect all connections when clicking on the editor
   editor.on('click', () => {
     unselectAllConnections(editor)
     makeAllConnectionsOpaque(editor)
+    removePathGlowFromAllConnections(editor)
   })
 }
 

--- a/packages/editor/src/plugins/highlightPlugin/index.ts
+++ b/packages/editor/src/plugins/highlightPlugin/index.ts
@@ -1,6 +1,70 @@
+import { Connection } from 'rete'
+import {
+  makeAllConnectionsOpaque,
+  makeAllConnectionsTransparent,
+  makeNodeConnectionsOpaque,
+  selectNodeConnections,
+  unselectAllConnections,
+} from './utils'
+
+type DataType = {
+  connection: Connection
+  el: HTMLElement
+}
+
 function install(editor, params) {
-  editor.on('renderconnection', data => {
-    console.log('RENDER CONNECTION', data)
+  editor.on('renderconnection', ({ connection, el }: DataType) => {
+    const inputName = connection.input.socket.name
+    const outputName = connection.output.socket.name
+
+    if (inputName === 'Any' && outputName === 'Any') {
+      el.className += ' any'
+    }
+
+    if (inputName === 'String' || outputName === 'String') {
+      el.className += ' string'
+    }
+
+    if (inputName === 'Number' || outputName === 'Number') {
+      el.className += ' number'
+    }
+
+    if (inputName === 'Boolean' || outputName === 'Boolean') {
+      el.className += ' boolean'
+    }
+
+    if (inputName === 'Object' || outputName === 'Object') {
+      el.className += ' object'
+    }
+
+    if (inputName === 'Array' || outputName === 'Array') {
+      el.className += ' array'
+    }
+
+    if (inputName === 'Trigger' || outputName === 'Trigger') {
+      el.className += ' trigger'
+    }
+
+    if (inputName === 'Event' || outputName === 'Event') {
+      el.className += ' event'
+    }
+  })
+
+  editor.on('nodeselect', node => {
+    // unselect all connections first from connection Map
+    unselectAllConnections(editor)
+    makeAllConnectionsOpaque(editor)
+
+    // select all connections from node
+    selectNodeConnections(editor, node)
+    makeAllConnectionsTransparent(editor)
+    makeNodeConnectionsOpaque(editor, node)
+  })
+
+  // Make sure to unselect all connections when clicking on the editor
+  editor.on('click', () => {
+    unselectAllConnections(editor)
+    makeAllConnectionsOpaque(editor)
   })
 }
 

--- a/packages/editor/src/plugins/highlightPlugin/index.ts
+++ b/packages/editor/src/plugins/highlightPlugin/index.ts
@@ -1,0 +1,12 @@
+function install(editor, params) {
+  editor.on('renderconnection', data => {
+    console.log('RENDER CONNECTION', data)
+  })
+}
+
+const plugin = {
+  name: 'HighlightPlugin',
+  install,
+}
+
+export default plugin

--- a/packages/editor/src/plugins/highlightPlugin/utils.ts
+++ b/packages/editor/src/plugins/highlightPlugin/utils.ts
@@ -55,6 +55,43 @@ export const addClassToNodeConnections = (
   })
 }
 
+export const addPathGlowToNode = (editor: MagickEditor, node: any) => {
+  const connections = node.getConnections()
+
+  connections.forEach((connection: Connection) => {
+    const connectionView = editor.view.connections.get(connection)
+
+    // get main path from inside connection el
+    const path = connectionView.el.querySelector('.main-path')
+
+    path.setAttribute('filter', 'url(#glow)')
+  })
+}
+
+export const removePathGlowFromNode = (editor: MagickEditor, node: any) => {
+  const connections = node.getConnections()
+
+  connections.forEach((connection: Connection) => {
+    const connectionView = editor.view.connections.get(connection)
+
+    // get main path from inside connection el
+    const path = connectionView.el.querySelector('.main-path')
+
+    path.setAttribute('filter', '')
+  })
+}
+
+export const removePathGlowFromAllConnections = (editor: MagickEditor) => {
+  const connections = editor.view.connections
+
+  connections.forEach((connection: any) => {
+    // get main path from inside connection el
+    const path = connection.el.querySelector('.main-path')
+
+    path.setAttribute('filter', '')
+  })
+}
+
 export const unselectAllConnections = (editor: MagickEditor) => {
   removeClassFromAllConnections(editor, 'selected')
 }

--- a/packages/editor/src/plugins/highlightPlugin/utils.ts
+++ b/packages/editor/src/plugins/highlightPlugin/utils.ts
@@ -1,0 +1,77 @@
+import { MagickEditor } from '@magickml/core'
+import { Connection } from 'rete'
+
+export const removeClassFromNodeConnections = (
+  editor: MagickEditor,
+  node: any,
+  className: string
+) => {
+  const connections = node.getConnections()
+
+  connections.forEach((connection: Connection) => {
+    const connectionView = editor.view.connections.get(connection)
+
+    connectionView.el.className = connectionView.el.className
+      .replace(className, '')
+      .trim()
+  })
+}
+
+export const removeClassFromAllConnections = (
+  editor: MagickEditor,
+  className: string
+) => {
+  const connections = editor.view.connections
+
+  connections.forEach((connection: any) => {
+    connection.el.className = connection.el.className
+      .replace(className, '')
+      .trim()
+  })
+}
+
+export const addClassToAllConnections = (
+  editor: MagickEditor,
+  className: string
+) => {
+  const connections = editor.view.connections
+
+  connections.forEach((connection: any) => {
+    connection.el.className += ` ${className}`
+  })
+}
+
+export const addClassToNodeConnections = (
+  editor: MagickEditor,
+  node: any,
+  className: string
+) => {
+  const connections = node.getConnections()
+
+  connections.forEach((connection: Connection) => {
+    const connectionView = editor.view.connections.get(connection)
+
+    connectionView.el.className += ` ${className}`
+  })
+}
+
+export const unselectAllConnections = (editor: MagickEditor) => {
+  removeClassFromAllConnections(editor, 'selected')
+}
+
+export const selectNodeConnections = (editor: MagickEditor, node: any) => {
+  unselectAllConnections(editor)
+  addClassToNodeConnections(editor, node, 'selected')
+}
+
+export const makeAllConnectionsOpaque = (editor: MagickEditor) => {
+  removeClassFromAllConnections(editor, 'transparent')
+}
+
+export const makeAllConnectionsTransparent = (editor: MagickEditor) => {
+  addClassToAllConnections(editor, 'transparent')
+}
+
+export const makeNodeConnectionsOpaque = (editor: MagickEditor, node: any) => {
+  removeClassFromNodeConnections(editor, node, 'transparent')
+}

--- a/packages/editor/src/plugins/reactRenderPlugin/Socket.tsx
+++ b/packages/editor/src/plugins/reactRenderPlugin/Socket.tsx
@@ -42,7 +42,9 @@ export class Socket extends React.Component<SocketProps> {
         className={`socket ${type} ${kebab(socket.name)}`}
         title={socket.name}
         ref={this.createRef} // force update for new IO with a same key
-      />
+      >
+        <div className={`expanding ${kebab(socket.name)}`}></div>
+      </div>
     );
   }
 }

--- a/packages/editor/src/plugins/reactRenderPlugin/styles.css
+++ b/packages/editor/src/plugins/reactRenderPlugin/styles.css
@@ -8,54 +8,60 @@
   padding-bottom: 6px;
   box-sizing: content-box;
   position: relative;
-  user-select: none; }
-  .node:hover {
-    background: rgba(130, 153, 255, 0.8); }
-  .node.selected {
-    background: #ffd92c;
-    border-color: #e3c000; }
-  .node .title {
-    color: white;
-    font-family: sans-serif;
-    font-size: 18px;
-    padding: 8px; }
-  .node .output {
-    text-align: right; }
-  .node .input {
-    text-align: left; }
-  .node .input-title, .node .output-title {
-    vertical-align: middle;
-    color: white;
-    display: inline-block;
-    font-family: sans-serif;
-    font-size: 14px;
-    margin: 6px;
-    line-height: 24px; }
-  .node .input-control {
-    z-index: 1;
-    width: calc(100% - 36px);
-    vertical-align: middle;
-    display: inline-block; }
-  .node .control {
-    padding: 6px 18px; }
+  user-select: none;
+}
+.node:hover {
+  background: rgba(130, 153, 255, 0.8);
+}
+.node.selected {
+  background: #ffd92c;
+  border-color: #e3c000;
+}
+.node .title {
+  color: white;
+  font-family: 'BerkeleyMono-Regular', sans-serif;
+  font-size: 18px;
+  padding: 8px;
+}
+.node .output {
+  text-align: right;
+}
+.node .input {
+  text-align: left;
+}
+.node .input-title,
+.node .output-title {
+  vertical-align: middle;
+  color: white;
+  display: inline-block;
+  font-family: 'BerkeleyMono-Regular', sans-serif;
+  font-size: 14px;
+  margin: 6px;
+  line-height: 24px;
+}
+.node .input-control {
+  z-index: 1;
+  width: calc(100% - 36px);
+  vertical-align: middle;
+  display: inline-block;
+}
+.node .control {
+  padding: 6px 18px;
+}
 
 .socket {
   display: inline-block;
   cursor: pointer;
-  border: 1px solid #ffffffaa;
   border-radius: 12px;
-  width: 24px;
-  height: 24px;
   margin: 6px;
   vertical-align: middle;
   background: #969696;
   z-index: 2;
-  box-sizing: border-box; }
-  .socket:hover {
-    border-width: 4px; }
-  .socket.multiple {
-    border-color: yellow; }
-  .socket.output {
-    margin-right: -12px; }
-  .socket.input {
-    margin-left: -12px; }
+  box-sizing: border-box;
+}
+.socket:hover {
+  border-width: 4px;
+}
+.socket.multiple {
+  border-color: yellow;
+}

--- a/packages/editor/src/screens/HomeScreen/CreateNew.tsx
+++ b/packages/editor/src/screens/HomeScreen/CreateNew.tsx
@@ -143,12 +143,12 @@ const CreateNew = () => {
           cancel
         </Button>
         <LoadingButton
-          className={`${!selectedTemplate ? 'disabled' : 'primary'} ${
-            css.button
-          }`}
+          className={`${!selectedTemplate ? 'disabled' : 'primary'} ${css.button
+            }`}
           loading={loading}
           onClick={onCreate}
           variant="outlined"
+          sx={{ color: "#fff !important" }}
         >
           CREATE
         </LoadingButton>

--- a/packages/editor/src/screens/Magick/magick.module.css
+++ b/packages/editor/src/screens/Magick/magick.module.css
@@ -50,7 +50,7 @@
   background-color: rgba(40, 40, 40, 0.95);
   color: rgba(150, 150, 150, 0.95);
   flex: 1;
-  font-family: 'IBM Plex Mono', 'mono';
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', 'mono';
   overflow-y: hidden;
   display: flex;
 }
@@ -82,7 +82,8 @@
   margin-top: var(--extraSmall);
 }
 
-.playtest-input input, .playtest-input textarea {
+.playtest-input input,
+.playtest-input textarea {
   color: #fff;
   width: 100%;
   border-radius: 4px;
@@ -131,7 +132,7 @@
 }
 
 .node-bottom-container {
-  font-family: 'IBM Plex Mono', monospace !important;
+  font-family: 'BerkeleyMono-Regular', 'IBM Plex Mono', monospace !important;
   padding: var(--extraSmall);
   display: flex;
   flex-direction: row;

--- a/packages/editor/src/windows/EditorWindow/editorwindow.module.css
+++ b/packages/editor/src/windows/EditorWindow/editorwindow.module.css
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   overflow: hidden;
+  background-color: var(--dark-0);
 }
 
 .deploy-shield {


### PR DESCRIPTION
## What Changed:

- restyled nodes
- Improved node selection highlight
- improved connection lines
  - unselected - medium thickness
  - select node - node connections appear bolder and glow
- added connection glow
- sockets get larger on hover
- connections connected to hovered socket highlight
- you can deselect nodes now by clicking on the editor
- modified styling of comments
- added our brand font Berkely mono as a remote font resource (can't check into repo due to licensing)

## How to test:

- Ensure nodes still turn green/red on run
- select a node and follow its connections
- hover over sockets to highlight a connection
- select a node and click on the editor area of deselect again

## Additional information:

- There are a few known bugs
  - when the connection is horizontal it disappears
  - the glow appears to be cut off at a bounding box around the connections
  - if you select a node and hover over its socket, the connection stops being high-lighted
- I suspect the first two bugs are related, and the SVG view box needs to be modified somehow.  I am not great with svg so figured I would submit this now and if someone else gets to it before me, awesome.
- 
