### PR TITLE
Remove query limit hardcode

### DIFF
--- a/packages/core/server/src/services/documents/documents.ts
+++ b/packages/core/server/src/services/documents/documents.ts
@@ -46,7 +46,7 @@ export const document = (app: Application) => {
         (context: HookContext) => {
           const { getEmbedding } = context.params.query
           if (getEmbedding) {
-            context.params.query.$limit = 1
+            // context.params.query.$limit = 1
             context.params.query.embedding = { $ne: pgvector.toSql(nullArray) }
           }
           return context

--- a/packages/core/server/src/services/events/events.ts
+++ b/packages/core/server/src/services/events/events.ts
@@ -53,7 +53,7 @@ export const event = (app: Application) => {
         (context: HookContext) => {
           const { getEmbedding } = context.params.query
           if (getEmbedding) {
-            context.params.query.$limit = 1
+            // context.params.query.$limit = 1
             context.params.query.embedding = { $ne: pgvector.toSql(nullArray) }
           }
           return context


### PR DESCRIPTION
## What Changed:
Right now embedding searches are limited to a single returned document, but there are many cases where this isn't what we want. This just comments out the hard limit.