### PR TITLE
Pino logger.error can't be called implicitly

### DIFF
--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -45,9 +45,13 @@ async function initializeAgent(): Promise<void> {
 initLogger({ name: 'agent' })
 const logger = getLogger()
 
-process.on('uncaughtException', logger.error)
+process.on('uncaughtException', (e, o) => {
+  logger.error('Uncaught exception: %o\n From: %s', e, o)
+})
 
-process.on('unhandledRejection', logger.error)
+process.on('unhandledRejection', (e, o) => {
+  logger.error('Unhandled rejection: %o\n From: %s', e, o)
+})
 
 await initApp()
 initializeAgent()


### PR DESCRIPTION
## What Changed:

Pino loggers can't be called implicitly (because it uses some magic)

Some errors were bubbling up in dev and we were getting crashes trying to call pino in this way

## How to test:

run server locally without redis being online
observe a TON of ERRCONNREFUSED errors, but the agent doesn't crash instantly
