### PR TITLE
Fixing deleting a spell while the spell is open and active

### DIFF
--- a/packages/editor/src/screens/HomeScreen/AllProjects.tsx
+++ b/packages/editor/src/screens/HomeScreen/AllProjects.tsx
@@ -137,7 +137,7 @@ const AllProjects: React.FC<AllProjectsProps> = ({
         <FileInput loadFile={loadFile} />
         <Button
           onClick={() => {
-            console.log('selectedSpell', selectedSpell)
+            // console.log('selectedSpell', selectedSpell)
             openSpell(selectedSpell)
           }}
           className={!selectedSpell ? 'disabled' : 'primary'}

--- a/packages/editor/src/screens/HomeScreen/AllProjects.tsx
+++ b/packages/editor/src/screens/HomeScreen/AllProjects.tsx
@@ -7,6 +7,7 @@ import ProjectRow from '../../components/ProjectRow'
 import css from './homeScreen.module.css'
 import SearchIcon from '@mui/icons-material/Search'
 import { IconButton } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
 
 /**
  * @description AllProjects component props
@@ -54,6 +55,7 @@ const AllProjects: React.FC<AllProjectsProps> = ({
     }
   }, [])
 
+  const navigate = useNavigate()
   return (
     <Panel shadow>
       <div className={css.searchContainer}>
@@ -127,7 +129,7 @@ const AllProjects: React.FC<AllProjectsProps> = ({
       <div className={css['button-row']}>
         <Button
           onClick={() => {
-            window.history.back()
+            navigate('/magick')
           }}
         >
           back

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -81,25 +81,26 @@ const StartScreen = (): JSX.Element => {
    * Handles spell deletion.
    * @param spellName - The name of the spell to delete
    */
-  const onDelete = async (spellName): Promise<void> => {
+  const onDelete = async (spellName: string): Promise<void> => {
     try {
-      const [tab] = tabs.filter(tab => tab.id === spellName)
+      const tab = tabs.find(tab => tab.id === spellName);
 
       if (tab) {
-        await dispatch(closeTab(tab.id))
-        await deleteSpell({ spellName, projectId: config.projectId })
-        window.localStorage.removeItem(`zoomValues-${tab.id}`)
-        setSelectedSpell("")
-        return
+        await Promise.all([
+          dispatch(closeTab(tab.id)),
+          deleteSpell({ spellName, projectId: config.projectId }),
+          window.localStorage.removeItem(`zoomValues-${tab.id}`)
+        ]);
       } else {
-        await deleteSpell({ spellName, projectId: config.projectId })
-        return 
+        await deleteSpell({ spellName, projectId: config.projectId });
       }
 
+      setSelectedSpell("");
     } catch (err) {
-      console.error('Error deleting spell', err)
+      console.error('Error deleting spell', err);
     }
-  }
+  };
+
 
   /**
    * Opens a spell

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -83,24 +83,17 @@ const StartScreen = (): JSX.Element => {
    */
   const onDelete = async (spellName: string): Promise<void> => {
     try {
-      const tab = tabs.find(tab => tab.id === spellName);
-
+      await deleteSpell({ spellName, projectId: config.projectId })
+      const tab = tabs.find(tab => tab.id === spellName)
       if (tab) {
-        await Promise.all([
-          dispatch(closeTab(tab.id)),
-          deleteSpell({ spellName, projectId: config.projectId }),
-          window.localStorage.removeItem(`zoomValues-${tab.id}`)
-        ]);
-      } else {
-        await deleteSpell({ spellName, projectId: config.projectId });
+        dispatch(closeTab(tab.id))
+        window.localStorage.removeItem(`zoomValues-${tab.id}`)
       }
-
-      setSelectedSpell("");
+      setSelectedSpell("")
     } catch (err) {
-      console.error('Error deleting spell', err);
+      console.error('Error deleting spell', err)
     }
-  };
-
+  }
 
   /**
    * Opens a spell

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -90,6 +90,10 @@ const StartScreen = (): JSX.Element => {
         await deleteSpell({ spellName, projectId: config.projectId })
         window.localStorage.removeItem(`zoomValues-${tab.id}`)
         setSelectedSpell("")
+        return
+      } else {
+        await deleteSpell({ spellName, projectId: config.projectId })
+        return 
       }
 
     } catch (err) {

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
   useNewSpellMutation,
 } from '../../state/api/spells'
 import { RootState } from '../../state/store'
-import { closeTab, openTab, selectAllTabs } from '../../state/tabs'
+import { closeTab, openTab, selectAllTabs, activeTabSelector, changeActive } from '../../state/tabs'
 import AllProjects from './AllProjects'
 import CreateNew from './CreateNew'
 import css from './homeScreen.module.css'
@@ -26,7 +26,7 @@ const StartScreen = (): JSX.Element => {
   const config = useConfig()
 
   const dispatch = useDispatch()
-
+  const activeTab = useSelector(activeTabSelector)
   const navigate = useNavigate()
   const [deleteSpell] = useDeleteSpellMutation()
   const { data: spells } = useGetSpellsQuery({
@@ -84,12 +84,15 @@ const StartScreen = (): JSX.Element => {
    */
   const onDelete = async (spellName): Promise<void> => {
     try {
-      await deleteSpell({ spellName, projectId: config.projectId })
       const [tab] = tabs.filter(tab => tab.id === spellName)
+
       if (tab) {
-        dispatch(closeTab(tab.id))
+        await dispatch(closeTab(tab.id))
+        await deleteSpell({ spellName, projectId: config.projectId })
         window.localStorage.removeItem(`zoomValues-${tab.id}`)
+        setSelectedSpell("")
       }
+
     } catch (err) {
       console.error('Error deleting spell', err)
     }

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
   useNewSpellMutation,
 } from '../../state/api/spells'
 import { RootState } from '../../state/store'
-import { closeTab, openTab, selectAllTabs, activeTabSelector } from '../../state/tabs'
+import { closeTab, openTab, selectAllTabs } from '../../state/tabs'
 import AllProjects from './AllProjects'
 import CreateNew from './CreateNew'
 import css from './homeScreen.module.css'

--- a/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
+++ b/packages/editor/src/screens/HomeScreen/HomeScreen.tsx
@@ -11,7 +11,7 @@ import {
   useNewSpellMutation,
 } from '../../state/api/spells'
 import { RootState } from '../../state/store'
-import { closeTab, openTab, selectAllTabs, activeTabSelector, changeActive } from '../../state/tabs'
+import { closeTab, openTab, selectAllTabs, activeTabSelector } from '../../state/tabs'
 import AllProjects from './AllProjects'
 import CreateNew from './CreateNew'
 import css from './homeScreen.module.css'
@@ -26,7 +26,6 @@ const StartScreen = (): JSX.Element => {
   const config = useConfig()
 
   const dispatch = useDispatch()
-  const activeTab = useSelector(activeTabSelector)
   const navigate = useNavigate()
   const [deleteSpell] = useDeleteSpellMutation()
   const { data: spells } = useGetSpellsQuery({


### PR DESCRIPTION
## What Changed:

I made few changes on the onDelete function which handles spell delete , I first made sure that I close the spell before deleting it and I also made changes on the back button which is on open project form and I made sure that we don't use the browser history to navigate back , insead i navigate the user back to `/magic` page

## How to test:

- Create a spell
- Have that spell as your currently active spell tab in the spell editor
- Delete the spell (via the Open spell dialog)
- Confirm the deletion
- check if  the spell is still open in your editor
