### PR TITLE
change asc to desc for document order

### DIFF
--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -98,7 +98,7 @@ export class DocumentService<
             )}') AS similarity`
           )
         )
-        .orderBy('similarity', 'asc')
+        .orderBy('similarity', 'desc')
         .limit(param.maxCount)
       return { data: querys }
     }


### PR DESCRIPTION
## What Changed:
Change asc to desc to fix the document search, currently it's sorted by opposite of what we want, this fixes that!