### PR TITLE
Slow down zoom in/out

### DIFF
--- a/packages/core/client/src/components/Drawer/ProjectWindow/index.tsx
+++ b/packages/core/client/src/components/Drawer/ProjectWindow/index.tsx
@@ -98,6 +98,47 @@ const ProjectWindow = ({ openDrawer }) => {
   }
 
   /**
+   * Replace all files with the uploaded project
+   *
+   * @param {File} selectedFile - Selected file object
+   */
+    const loadFileReplace = selectedFile => {
+      if (!token && PRODUCTION) {
+        enqueueSnackbar('You must be logged in to create a project', {
+          variant: 'error',
+        })
+        return
+      }
+      const fileReader = new FileReader()
+      fileReader.readAsText(selectedFile)
+      fileReader.onload = event => {
+        const data = JSON.parse(event?.target?.result as string)
+  
+        delete data['id']
+        axios({
+          url: `${globalConfig.apiUrl}/projects`,
+          method: 'POST',
+          data: { ...data, projectId: globalConfig.projectId, replace: true },
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+          .then(async res => {
+            const res2 = await fetch(
+              `${globalConfig.apiUrl}/projects?projectId=${globalConfig.projectId}`,
+              { headers: { Authorization: `Bearer ${token}` } }
+            )
+            const json = await res2.json()
+            setData(json)
+          })
+          .catch(err => {
+            console.error('error is', err)
+          })
+      }
+      handleClose()
+    }
+
+  /**
    * Export the project data as a .project.json file.
    */
   const exportProject = () => {
@@ -236,7 +277,33 @@ const ProjectWindow = ({ openDrawer }) => {
                       }}
                     />
                   }
-                  innerText={'Import'}
+                  innerText={'Import (Add)'}
+                />
+              </MenuItem>
+              <MenuItem>
+                <FileInput
+                  loadFile={loadFileReplace}
+                  sx={{
+                    display: 'inline-block',
+                    minWidth: '0',
+                    padding: 0,
+                    margin: 0,
+                    color: 'rgba(255,255,255,.5)',
+                    backgroundColor: 'rgba(0,0,0,0)',
+                    boxShadow: 'none',
+                    border: 0,
+                  }}
+                  Icon={
+                    <FileUpload
+                      style={{
+                        height: '1em',
+                        width: '1em',
+                        position: 'relative',
+                        top: '.25em',
+                      }}
+                    />
+                  }
+                  innerText={'Import (Replace)'}
                 />
               </MenuItem>
               <MenuItem>

--- a/packages/core/server/src/services/agents/agents.class.ts
+++ b/packages/core/server/src/services/agents/agents.class.ts
@@ -65,5 +65,6 @@ export const getOptions = (app: Application): KnexAdapterOptions => {
     paginate: app.get('paginate'),
     Model: app.get('dbClient'),
     name: 'agents',
+    multi: ['remove'],
   }
 }

--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -127,5 +127,6 @@ export const getOptions = (app: Application): KnexAdapterOptions => {
     },
     Model: app.get('dbClient'),
     name: 'documents',
+    multi: ['remove'],
   }
 }

--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -65,8 +65,14 @@ export class DocumentService<
    * @param id {string} The document ID to remove
    * @return {Promise<any>} The removed document
    */
-  async remove(id: string): Promise<any> {
+  async remove(id: string, params): Promise<any> {
     const db = app.get('dbClient')
+
+    if(!id && params.projectId) {
+      // delete all documents of a project
+      return await db('documents').where('projectId', params.projectId).del()
+    }
+
     return await db('documents').where('id', id).del()
   }
 

--- a/packages/core/server/src/services/projects/projects.class.ts
+++ b/packages/core/server/src/services/projects/projects.class.ts
@@ -75,6 +75,28 @@ export class ProjectsService {
   }> {
     const { agents, documents, spells, projectId } = data
 
+    // If replace is true, delete all agents, documents, and spells for this projectId
+    if ((data as any).replace) {
+      await Promise.all([
+        app.service('agents').remove(null, {
+          query: {
+            projectId,
+          },
+        }),
+        app.service('spells').remove(null, {
+          query: {
+            projectId,
+          },
+        }),
+        app.service('documents').remove(null, {
+          query: {
+            projectId,
+          },
+        }),
+      ])
+    }
+
+
     // Map agents, documents, and spells with updated information for the new project
     const mappedAgents = agents.map(agent => {
       delete agent.id

--- a/packages/core/server/src/services/spells/spells.class.ts
+++ b/packages/core/server/src/services/spells/spells.class.ts
@@ -77,5 +77,6 @@ export const getOptions = (app: Application): KnexAdapterOptions => {
     },
     Model: app.get('dbClient'),
     name: 'spells',
+    multi: ['remove'],
   }
 }

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -146,7 +146,7 @@ export const initEditor = function ({
 
   // Configure Area plugin
   editor.use(AreaPlugin, {
-    scaleExtent: { min: 0.1, max: 1.5 },
+    scaleExtent: { min: 0.05, max: 2.0 },
     background,
     tab,
     snap: true,

--- a/packages/editor/src/plugins/areaPlugin/restrictor.js
+++ b/packages/editor/src/plugins/areaPlugin/restrictor.js
@@ -4,29 +4,26 @@ export class Restrictor {
     this.scaleExtent = scaleExtent
     this.zoomLerpFactor = zoomLerpFactor
     this.translateExtent = translateExtent
-
+    this.lastZoom = 2.0
     if (scaleExtent) editor.on('zoom', this.restrictZoom.bind(this))
     if (translateExtent)
       editor.on('translate', this.restrictTranslate.bind(this))
   }
   lastZoom = null
   restrictZoom(data) {
-    if(!this.lastZoom) {
-      this.lastZoom = data.zoom
-    }
-
-    // lerp from lastZoom to zoom, weighted 1/3 toward zoom
-    const avgZoom = (data.zoom * this.zoomLerpFactor) + (this.lastZoom * (1 - this.zoomLerpFactor))
-
-    this.lastZoom = data.zoom
-    data.zoom = avgZoom
-
-
     const se =
       typeof this.scaleExtent === 'boolean'
         ? { min: 0.1, max: 1 }
         : this.scaleExtent
-    // const tr = data.transform;
+
+    if (this.lastZoom < se.min) this.lastZoom = se.min
+    else if (this.lastZoom > se.max) this.lastZoom = se.max
+
+    // lerp from lastZoom to zoom, weighted 1/3 toward zoom
+    const avgZoom = (data.zoom * this.zoomLerpFactor) + (this.lastZoom * (1 - this.zoomLerpFactor))
+
+    this.lastZoom = avgZoom
+    data.zoom = avgZoom
 
     if (data.zoom < se.min) data.zoom = se.min
     else if (data.zoom > se.max) data.zoom = se.max

--- a/packages/editor/src/plugins/areaPlugin/restrictor.js
+++ b/packages/editor/src/plugins/areaPlugin/restrictor.js
@@ -1,3 +1,6 @@
+// detect Mac OSX
+const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+
 export class Restrictor {
   constructor(editor, scaleExtent, translateExtent, zoomLerpFactor = 0.25) {
     this.editor = editor
@@ -16,14 +19,16 @@ export class Restrictor {
         ? { min: 0.1, max: 1 }
         : this.scaleExtent
 
-    if (this.lastZoom < se.min) this.lastZoom = se.min
-    else if (this.lastZoom > se.max) this.lastZoom = se.max
+    if (isMac) {
+      if (this.lastZoom < se.min) this.lastZoom = se.min
+      else if (this.lastZoom > se.max) this.lastZoom = se.max
 
-    // lerp from lastZoom to zoom, weighted 1/3 toward zoom
-    const avgZoom = (data.zoom * this.zoomLerpFactor) + (this.lastZoom * (1 - this.zoomLerpFactor))
+      // lerp from lastZoom to zoom, weighted 1/3 toward zoom
+      const avgZoom = (data.zoom * this.zoomLerpFactor) + (this.lastZoom * (1 - this.zoomLerpFactor))
 
-    this.lastZoom = avgZoom
-    data.zoom = avgZoom
+      this.lastZoom = avgZoom
+      data.zoom = avgZoom
+    }
 
     if (data.zoom < se.min) data.zoom = se.min
     else if (data.zoom > se.max) data.zoom = se.max

--- a/packages/editor/src/plugins/areaPlugin/restrictor.js
+++ b/packages/editor/src/plugins/areaPlugin/restrictor.js
@@ -1,15 +1,27 @@
 export class Restrictor {
-  constructor(editor, scaleExtent, translateExtent) {
+  constructor(editor, scaleExtent, translateExtent, zoomLerpFactor = 0.25) {
     this.editor = editor
     this.scaleExtent = scaleExtent
+    this.zoomLerpFactor = zoomLerpFactor
     this.translateExtent = translateExtent
 
     if (scaleExtent) editor.on('zoom', this.restrictZoom.bind(this))
     if (translateExtent)
       editor.on('translate', this.restrictTranslate.bind(this))
   }
-
+  lastZoom = null
   restrictZoom(data) {
+    if(!this.lastZoom) {
+      this.lastZoom = data.zoom
+    }
+
+    // lerp from lastZoom to zoom, weighted 1/3 toward zoom
+    const avgZoom = (data.zoom * this.zoomLerpFactor) + (this.lastZoom * (1 - this.zoomLerpFactor))
+
+    this.lastZoom = data.zoom
+    data.zoom = avgZoom
+
+
     const se =
       typeof this.scaleExtent === 'boolean'
         ? { min: 0.1, max: 1 }


### PR DESCRIPTION
## What Changed:
This introduces a "zoom lerp factor" which slows down zoom by 1/4th. This is a temporary fix for an impossible zoom experience on Macbooks.

- Macbook only, so someone with a Mac will need to test. Shouldn't do anything on a PC.

- There is a little glitch at the beginning. To fix this, we would need to update the Oneirocom rete.js fork and handle this zoom internally, seems to be fixed?

- Ideally could control zoom sensitivity from UI, but this sets it on constructor.

- Ideally isn't in the zoom restrictor, although that nicely handles the background etc as well for now.