### PR TITLE
Fix event recall

### DIFF
--- a/packages/core/server/src/services/events/events.class.ts
+++ b/packages/core/server/src/services/events/events.class.ts
@@ -95,8 +95,6 @@ export class EventService<
       // reverse the order of the events so that the newest events are last
       .then((res: any) => res.reverse())
 
-      console.log(res.map((r: any) => r.content))
-
     return { events: res as unknown as { data: Array<any> } }
   }
 


### PR DESCRIPTION
## What Changed:
Currently event recall is returning all events across all channels for any given type.

This PR cleans up the feathers find() call so that it handles both cases with and without embeddings well. These could be further consolidated in a later PR, for now this makes events work and not bleed across channels.