### PR TITLE
Fix plugin reloading by synchronously loading plugin imports

### DIFF
--- a/apps/agent/project.json
+++ b/apps/agent/project.json
@@ -6,9 +6,7 @@
   "implicitDependencies": [
     "@magickml/server-core",
     "@magickml/core",
-    "@magickml/agents",
-    "@magickml/plugin-twitter-server",
-    "@magickml/plugin-discord-server"
+    "@magickml/agents"
   ],
   "targets": {
     "build": {

--- a/apps/cloud-agent-worker/src/main.ts
+++ b/apps/cloud-agent-worker/src/main.ts
@@ -1,6 +1,7 @@
 import { CloudAgentWorker } from '@magickml/cloud-agent-worker'
 import { initLogger, getLogger } from '@magickml/core'
 import { initApp } from '@magickml/server-core'
+import pluginExports from './plugins'
 
 initLogger({ name: 'cloud-agent-worker' })
 const logger = getLogger()
@@ -9,9 +10,6 @@ await initApp()
 
 async function loadPlugins(): Promise<void> {
   logger.info('Loading plugins...')
-  // Import the plugins and get the default exports.
-  const pluginExports = (await import('./plugins')).default
-
   // Log the loaded plugin names.
   const pluginNames = Object.values(pluginExports)
     .map((p: any) => p.name)

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -3,7 +3,10 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/server/src",
   "projectType": "application",
-  "implicitDependencies": ["@magickml/server-core", "@magickml/core"],
+  "implicitDependencies": [
+    "@magickml/server-core",
+    "@magickml/core"
+],
   "targets": {
     "build": {
       "executor": "@nx/webpack:webpack",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { Context } from 'koa'
 import koaBody from 'koa-body'
 import compose from 'koa-compose'
 import 'regenerator-runtime/runtime'
+import plugins from './plugins'
 
 initLogger({ name: 'server' })
 const logger = getLogger()
@@ -56,7 +57,6 @@ async function init() {
   await initApp()
   // load plugins
   await (async () => {
-    const plugins = (await import('./plugins')).default
     logger.info(
       'loaded plugins on server %o',
       Object.values(plugins)


### PR DESCRIPTION
## What Changed:
Right now plugins are async loading into agent and server. The problem is that they don't rebuild on reload. This was fixed before by forcing the plugins to be implicit dependencies, however this would require all plugins to be added. Synchronous plugin loading fixes the rebuild.