### PR TITLE
Fixing Public variable's name overlaps

### DIFF
--- a/packages/editor/src/screens/agents/AgentWindow/AgentPubVariables.tsx
+++ b/packages/editor/src/screens/agents/AgentWindow/AgentPubVariables.tsx
@@ -66,7 +66,7 @@ const AgentPubVariables = ({
               }}
             >
               <Grid item xs={1}>
-                <p style={{ marginRight: '20px' }}>{`${variable.name}: `}</p>
+                <p style={{  wordBreak: "break-all",whiteSpace: "normal", marginRight: '2px' }}>{`${variable.name}: `}</p>
               </Grid>
               <Grid item xs={8}>
                 {variable?.type?.includes('Boolean') ? (


### PR DESCRIPTION
## What Changed:

I have the variable name styling and made sure that no matter how long they can be , that they don't overlap into the input area

## How to test:

- Create a spell 
- add text variable node 
- rename that text variable node to eg: AgentPersonality  
- mark that variable as Public
- navigate to Agent settings tab
- set your Root spell to the one you created 
You will see the public variable displayed 

## Additional information:
![Screenshot from 2023-06-20 14-15-44](https://github.com/Oneirocom/Magick/assets/55635977/6e72375f-3992-4088-8989-de968786c7ea)
![Screenshot from 2023-06-20 14-16-38](https://github.com/Oneirocom/Magick/assets/55635977/8754265b-6410-4c20-93f6-810efacdb4e3)

