### PR TITLE
cleans up doc flow a bit.  awaits on embedding creation

### DIFF
--- a/packages/core/server/src/customEmbeddings.ts
+++ b/packages/core/server/src/customEmbeddings.ts
@@ -135,7 +135,7 @@ export class PluginEmbeddings extends Embeddings {
       provider.models.includes(param.modelName)
     ) as CompletionProvider
     const handler = provider?.handler
-    let response
+    let response: any
     let retry = 0
     while (retry < 3) {
       try {

--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -37,24 +37,11 @@ export class DocumentService<
   async create(data: DocumentData): Promise<any> {
     const docdb = app.get('docdb')
     if (data.hasOwnProperty('secrets')) {
-      const {secrets, modelName, ...rest} = data as DocumentData & {secrets: string, modelName: string}
-      data = rest
-      /* const completionProviders = pluginManager.getCompletionProviders('text', ['embedding'])
-      const provider = completionProviders.find(provider =>
-        provider.models.includes(modelName)
-      ) as CompletionProvider
-      const handler = provider?.handler
-      
-      const {success, result, error} = await handler({
-        inputs: { input: context?.data?.content || "" },
-        node: { data: { model: modelName } } as unknown as WorkerData,
-        outputs: undefined,
-        context: { module: { secrets:JSON.parse(secrets) }, projectId: context.data.projectId },
-      })
-      embedding = result */
-      
-      app.get("docdb").fromString(data.content,data,{modelName, projectId: data?.projectId, secrets})
-      return data;
+      const {secrets, modelName, ...docData} = data as DocumentData & {secrets: string, modelName: string}
+
+      docdb.fromString(docData.content,docData,{modelName, projectId: docData?.projectId, secrets})
+
+      return docData;
     }
     await docdb.from('documents').insert(data)
     return data

--- a/packages/core/server/src/services/documents/documents.ts
+++ b/packages/core/server/src/services/documents/documents.ts
@@ -74,7 +74,6 @@ export const document = (app: Application) => {
             context.data.embedding = pgvector.toSql(nullArray)
             return context
           }
-          return
         },
       ],
       patch: [

--- a/packages/core/server/src/vectordb.ts
+++ b/packages/core/server/src/vectordb.ts
@@ -84,7 +84,7 @@ export class PostgresVectorStoreCustom extends SupabaseVectorStore {
         }
         metadata['id'] = uuidv4()
         metadata['content'] = split_docs[index]
-        this.addEvents({
+        await this.addEvents({
           array: [{ ...metadata, embedding: JSON.stringify(vector) }],
         })
       })
@@ -104,7 +104,7 @@ export class PostgresVectorStoreCustom extends SupabaseVectorStore {
         },
       },
     ]
-    this.addEvents({
+    await this.addEvents({
       array: [{ ...metadata, embedding: JSON.stringify(vector) }],
     })
     return insert_data


### PR DESCRIPTION
## What Changed:

Now awaits on embedding creation before returning from the create document endpoint

## How to test:

Create a document, observe that everything works normally

## Additional information:

this should resolve some weirdness when creating documents, since before the endpoint could return before the embedding creation promise resolved