### PR TITLE
Fix input switching

### DIFF
--- a/packages/core/shared/src/nodes/io/Input.ts
+++ b/packages/core/shared/src/nodes/io/Input.ts
@@ -62,9 +62,6 @@ export class InputComponent extends MagickComponent<InputReturn> {
    * @returns {MagickNode} - The configured node
    */
   builder(node: MagickNode) {
-    if (node.data.useData === undefined) {
-      node.data.useData = true
-    }
     // Setup dynamic controls
     const inputName = {
       type: InputControl,
@@ -74,17 +71,6 @@ export class InputComponent extends MagickComponent<InputReturn> {
       defaultValue: 'Default',
       onData: data => {
         node.data.name = `Input - ${data}`
-      },
-    }
-
-    const useData = {
-      type: SwitchControl,
-      name: 'Use Data',
-      label: 'Use Data',
-      dataKey: 'useData',
-      defaultValue: node.data.useData,
-      onData: data => {
-        configureNode()
       },
     }
 
@@ -103,7 +89,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
     const defaultInputTypes = [
       {
         name: 'Default',
-        inspectorControls: [inputName, useData],
+        inspectorControls: [inputName],
         sockets: [],
       },
       {
@@ -142,40 +128,60 @@ export class InputComponent extends MagickComponent<InputReturn> {
     let lastInspectorControls: any[] | undefined = []
     let lastSockets: CompletionSocket[] | undefined = []
 
-    const handleSockets = sockets => {
+    const handleSockets = async sockets => {
       const connections = node.getConnections()
+      const connectionCache = new Map()
+
       if (sockets !== lastSockets) {
-        lastSockets?.forEach(socket => {
+        lastSockets?.map(socket => {
           if (node.outputs.has(socket.socket)) {
-            if (socket.socket === 'trigger') return
+            if (socket.socket === 'trigger') return socket
             connections.forEach(c => {
               if (c.output.key === socket.socket) {
+                // Save connections in the cache before removing them
+                connectionCache.set(socket.socket, c)
                 this.editor?.removeConnection(c)
               }
             })
             node.outputs.delete(socket.socket)
           }
         })
-        sockets.forEach(socket => {
+        node.update()
+        this.editor?.view.updateConnections({ node })
+        sockets.map(async socket => {
           if (node.outputs.has(socket.socket)) return
           if (node.data.inputType === 'Default') {
             if (socket.socket === 'trigger') return
-            // if socket is output and useData is false, don't add
-            if (socket.socket === 'output' && node.data.useData !== true) return
           }
-          node.addOutput(
-            new Rete.Output(socket.socket, socket.name, socket.type)
-          )
-        })
 
+          // Add output socket
+          const output = new Rete.Output(
+            socket.socket,
+            socket.name,
+            socket.type
+          )
+          node.addOutput(output)
+          node.update()
+
+          // Restore connection if types match or either type is "any"
+          const oldConnection = connectionCache.get(socket.socket)
+          if (
+            oldConnection &&
+            (oldConnection.input.socket === socket.type ||
+              oldConnection.input.socket === anySocket ||
+              socket.type === anySocket)
+          ) {
+            this.editor?.connect(output, oldConnection.input)
+          }
+        })
+        node.update()
+        this.editor?.view.updateConnections({ node })
         lastSockets = sockets
       }
     }
 
     const configureNode = () => {
       const inputType = node.data.inputType ?? ('Default' as string)
-
-      const connections = node.getConnections()
 
       const inputTypeData = inputTypes.find(v => v.name === inputType) ?? {
         inspectorControls: [],
@@ -190,7 +196,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
         sockets.push(triggerOutput)
       }
 
-      if (inputType === 'Default' && node.data.useData === true) {
+      if (inputType === 'Default') {
         sockets.push(dataOutput)
       }
 
@@ -201,14 +207,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
         if (!node.outputs.has('trigger')) {
           node.addOutput(new Rete.Output('trigger', 'trigger', triggerSocket))
         }
-        if (!node.data.useData && node.outputs.has('output')) {
-          connections.forEach(c => {
-            if (c.output.key === 'output') {
-              this.editor?.removeConnection(c)
-            }
-          })
-          node.outputs.delete('output')
-        } else if (node.data.useData === true && !node.outputs.has('output')) {
+        if (!node.outputs.has('output')) {
           node.addOutput(new Rete.Output('output', 'output', anySocket))
         }
       }

--- a/packages/core/shared/src/nodes/io/Input.ts
+++ b/packages/core/shared/src/nodes/io/Input.ts
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { DropdownControl } from '../../dataControls/DropdownControl'
 import { InputControl } from '../../dataControls/InputControl'
-import { SwitchControl } from '../../dataControls/SwitchControl'
 import { MagickComponent } from '../../engine'
 import { PluginIOType, pluginManager } from '../../plugin'
 import { DataControl } from '../../plugins/inspectorPlugin'
@@ -145,6 +144,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
             })
             node.outputs.delete(socket.socket)
           }
+          return socket
         })
         node.update()
         this.editor?.view.updateConnections({ node })


### PR DESCRIPTION
## What Changed:
This PR fixes the input switching so that connections are maintained when the socket type is changed, as long as the key stays the same. Seems to work when switching between output types.