### PR TITLE
Enable larger file uploads for larger projects

### DIFF
--- a/packages/core/server/src/app.ts
+++ b/packages/core/server/src/app.ts
@@ -66,7 +66,7 @@ export async function initApp() {
   app.use(cors({ origin: '*' }))
   app.use(errorHandler())
   app.use(parseAuthentication())
-  app.use(bodyParser())
+  app.use(bodyParser({ jsonLimit: '50mb', formLimit: '50mb', multipart: true }))
 
   // Initialize pubsub redis client
   const pubsub = new RedisPubSub()


### PR DESCRIPTION
## What Changed:
Right now the default form limit size is like, 5mb or 8mb or something. This updates it to 50mb which enables the importing of bigger projects.