### PR TITLE
Get Embedding should only get one (limit 1), not from documents

### DIFF
--- a/packages/core/server/src/services/documents/documents.ts
+++ b/packages/core/server/src/services/documents/documents.ts
@@ -42,16 +42,7 @@ export const document = (app: Application) => {
         schemaHooks.resolveQuery(documentQueryResolver),
       ],
       find: [],
-      get: [
-        (context: HookContext) => {
-          const { getEmbedding } = context.params.query
-          if (getEmbedding) {
-            // context.params.query.$limit = 1
-            context.params.query.embedding = { $ne: pgvector.toSql(nullArray) }
-          }
-          return context
-        },
-      ],
+      get: [],
       // Optimize the create operation
       create: [
         // feathers hook to get the 'embedding' field from the request and make sure it is a valid pgvector (cast all to floats)

--- a/packages/core/server/src/services/events/events.ts
+++ b/packages/core/server/src/services/events/events.ts
@@ -53,7 +53,7 @@ export const event = (app: Application) => {
         (context: HookContext) => {
           const { getEmbedding } = context.params.query
           if (getEmbedding) {
-            // context.params.query.$limit = 1
+            context.params.query.$limit = 1
             context.params.query.embedding = { $ne: pgvector.toSql(nullArray) }
           }
           return context


### PR DESCRIPTION
## What Changed:
Re-add the limit and fix it, this is only for getting the cached embedding so we only need the first one