### PR TITLE
fixing page autochange on events pages

### DIFF
--- a/packages/editor/src/screens/EventWindow/EventTable.tsx
+++ b/packages/editor/src/screens/EventWindow/EventTable.tsx
@@ -78,6 +78,7 @@ function EventTable({ events, updateCallback }) {
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedRow, setSelectedRow] = useState(null)
   const [selectedRows, setSelectedRows] = useState<string[]>([])
+  const [currentPage, setCurrentPage] = useState(0)
 
   const handleActionClick = (event, row) => {
     setAnchorEl(event.currentTarget)
@@ -177,6 +178,9 @@ function EventTable({ events, updateCallback }) {
       {
         columns: defaultColumns,
         data: events,
+        initialState : {
+          pageIndex: currentPage 
+        }
       },
       useFilters,
       useGlobalFilter,
@@ -212,6 +216,7 @@ function EventTable({ events, updateCallback }) {
   // // Handle pagination
   const handlePageChange = (page: number) => {
     const pageIndex = page - 1
+    setCurrentPage(pageIndex)
     gotoPage(pageIndex)
   }
 
@@ -246,6 +251,15 @@ function EventTable({ events, updateCallback }) {
     })
     if (isDeleted) enqueueSnackbar('Event deleted', { variant: 'success' })
     else enqueueSnackbar('Error deleting Event', { variant: 'error' })
+
+    //navigate user to previous page if rows are empty
+    if (page.length === 1) {
+      const pageIndex = currentPage - 1
+      setCurrentPage(pageIndex)
+      gotoPage(pageIndex)
+    }
+
+
     // close the action menu
     handleActionClose()
     updateCallback()
@@ -256,6 +270,8 @@ function EventTable({ events, updateCallback }) {
     () => flatRows.map(row => row.original),
     [flatRows]
   )
+
+  
 
   // Render the table with useMemo
   return (


### PR DESCRIPTION
## What Changed:

I added initial state on useTabel hook with contains pageIndex attribute which will help us to make sure that if we refresh our page after deleting items , that same page will be returned back , instead of loading the first page which causes items reorder 

## How to test:

1. Add many events on events table
2. go to any page other than the first one 
3. try deleting any item 


## Additional information:

[Screencast from 23.06.2023 16:15:36.webm](https://github.com/Oneirocom/Magick/assets/55635977/bd5debdd-3232-45bf-a00a-6eebe72b6a92)

