### PR TITLE
agents in prod default to our prod openai key but still supports users adding their own key

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,8 @@ VITE_APP_POSTHOG_API_KEY=key
 
 # Settings for authentication
 PRODUCTION=false
+# This will be the default key for every openai api request
+DEFAULT_OPENAI_KEY=keytouseforprod
 VITE_APP_PRODUCTION=false
 VITE_APP_STANDALONE=true
 STANDALONE=true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "Apache 2.0",
   "scripts": {
-    "dev": "cross-env NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent,@magickml/docs --parallel --maxParallel=100",
+    "dev": "cross-env NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent,@magickml/docs --parallel --maxParallel=100 --skip-nx-cache",
     "start": "node scripts/start-server.js",
     "start-server": "node dist/apps/server/main.js",
     "start-agent": "node dist/apps/agent/main.js",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_USER_TOKEN =
   'eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..SUWUnYMxRTxIgGD1.lCzhMnTVeWOBFBzDs4_ft6UCZIVhfk9VSw18-SNzSJjXB4yqwi7z3XJEO9FwbSybFkAjSoFHwYnizYhDsrouDn1xLS7Dqzwnn4I-V1-L0mXcmKXRAS8D1PQzR88CDsk-LIqkcZkkxQ8aoGmyVcKwAmlnAdYpPUEbJ7E3DEBCvA4UbY1iqdYmCWdD7NWeR_IDsWFMKP3jEqp3HPMJbbTitCb1_W-G0gnZ6cokK_JH9tpgbjAoWe0KRQB2Dr3B22-1qa9cPV8W13she2q_RR6SeTAM9iqwzufvuIu2b3Lu0fypQpcV4JyrwCawkZcjsdGQqateftfAQNYzUeSXVzZdWSZJOwHtDHpIMKh_SugqS3ASNrN2gqUEwvY2SOe60h__2ljLsSc.9qWEv3VNEKFpc6zmJv4n0A'
 export const STANDALONE = getVarForEnvironment('STANDALONE') === 'true' || false
 export const PRODUCTION = getVarForEnvironment('PRODUCTION') === 'true'
+export const DEFAULT_OPENAI_KEY = getVarForEnvironment('DEFAULT_OPENAI_KEY')
 export const DONT_CRASH_ON_ERROR = getVarForEnvironment('DONT_CRASH_ON_ERROR') === 'true'
 export const SERVER_PORT = getVarForEnvironment('PORT') || '3030'
 export const SERVER_HOST = getVarForEnvironment('HOST') || 'localhost'

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -6,6 +6,7 @@ import {
 } from '@magickml/core'
 import axios from 'axios'
 import { OPENAI_ENDPOINT } from '../constants'
+import { DEFAULT_OPENAI_KEY } from '@magickml/config'
 
 /**
  * Generate a completion text based on prior chat conversation input.
@@ -71,10 +72,14 @@ export async function makeChatCompletion(
   // Update the settings messages
   settings.messages = messages
 
+  const openaiKey = context.module.secrets!['openai_api_key']
+
+  const finalKey = openaiKey ? openaiKey : DEFAULT_OPENAI_KEY
+
   // Create request headers
   const headers = {
     'Content-Type': 'application/json',
-    Authorization: 'Bearer ' + context.module.secrets!['openai_api_key'],
+    Authorization: 'Bearer ' + finalKey,
   }
 
   try {

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -2,6 +2,7 @@
 import { CompletionHandlerInputData, saveRequest } from '@magickml/core'
 import axios from 'axios'
 import { OPENAI_ENDPOINT } from '../constants'
+import { DEFAULT_OPENAI_KEY } from '@magickml/config'
 
 /**
  * Makes an API request to an AI text completion service.
@@ -50,11 +51,12 @@ export async function makeTextCompletion(
     throw new Error('ERROR: No secrets found')
   }
 
+  const openaiKey = context.module.secrets!['openai_api_key']
+
   // Set up headers for the API request.
   const headers = {
     'Content-Type': 'application/json',
-    Authorization:
-      'Bearer ' + (context.module.secrets['openai_api_key'] || null),
+    Authorization: 'Bearer ' + openaiKey ? DEFAULT_OPENAI_KEY : openaiKey,
   }
 
   // Make the API request and handle the response.

--- a/packages/plugins/openai/server/src/functions/makeTextEmbedding.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextEmbedding.ts
@@ -6,6 +6,7 @@ import {
 } from '@magickml/core'
 import axios from 'axios'
 import { OPENAI_ENDPOINT } from '../constants'
+import { DEFAULT_OPENAI_KEY } from '@magickml/config'
 
 /**
  * A function that makes a request to create a text embedding using OpenAI's
@@ -37,8 +38,7 @@ export async function makeTextEmbedding(
   }
 
   const apiKey =
-    (context?.module?.secrets && context?.module?.secrets['openai_api_key']) ||
-    null
+    (context?.module?.secrets && context?.module?.secrets['openai_api_key']) || DEFAULT_OPENAI_KEY
 
   if (!apiKey) {
     return {

--- a/packages/plugins/openai/shared/src/index.ts
+++ b/packages/plugins/openai/shared/src/index.ts
@@ -6,6 +6,7 @@ import {
   PluginSecret,
   stringSocket,
 } from '@magickml/core'
+import { PRODUCTION } from '@magickml/config'
 
 /**
  * An array of PluginSecret objects containing information about API key secrets.
@@ -46,7 +47,6 @@ const completionProviders: CompletionProvider[] = [
       'text-davinci-001',
       'text-curie-001',
       'text-babbage-001',
-      'text-ada-001',
     ],
   },
   {
@@ -66,7 +66,7 @@ const completionProviders: CompletionProvider[] = [
         type: embeddingSocket,
       },
     ],
-    models: ['text-embedding-ada-002', 'text-embedding-ada-001'],
+    models: ['text-embedding-ada-002'],
   },
   {
     type: 'text',
@@ -100,7 +100,7 @@ const completionProviders: CompletionProvider[] = [
         type: stringSocket,
       },
     ],
-    models: ['gpt-4', 'gpt-3.5-turbo'],
+    models: PRODUCTION ? ['gpt-3.5-turbo'] : ['gpt-3.5-turbo', 'gpt4'],
   },
 ]
 


### PR DESCRIPTION
## How to test:


When DEFAULT_OPENAI_KEY are both set, agents should work without needed to specify an open AI key in agent details, but when there is an open ai key in agent details, then the one provided is used (even if it's not valid)

When PRODUCTION is not set, nothing should change
