### PR TITLE
Scrub exported agent

### DIFF
--- a/packages/core/client/src/components/Drawer/ProjectWindow/index.tsx
+++ b/packages/core/client/src/components/Drawer/ProjectWindow/index.tsx
@@ -157,6 +157,16 @@ const ProjectWindow = ({ openDrawer }) => {
 
     const exportData = data
     exportData.agents.forEach((agent: any) => {
+      Object.keys(agent.data).forEach(key => {
+        if (
+          key.includes('api') ||
+          key.includes('token') ||
+          key.includes('secret') ||
+          key.includes('password')
+        ) {
+          delete agent.data[key]
+        }
+      })
       agent.secrets = {}
     })
 


### PR DESCRIPTION
## What Changed:
This PR adds some checks to remove secrets and API keys from exported agents, so users can share them without handing keys around.