### PR TITLE
Add document distance to type and fix documentation

### DIFF
--- a/apps/docs/docs/nodes/document/GetDocuments.md
+++ b/apps/docs/docs/nodes/document/GetDocuments.md
@@ -1,3 +1,3 @@
 # Get Documents
 
-Gets Documents from the Documents store. The optional Type property will return only documents with the matching type, and the Max Count property will limit the number of documents returned. Documents are returned in order of embedding similarity.
+Gets Documents from the Documents store. The optional Type property will return only documents with the matching type, and the Max Count property will limit the number of documents returned. Documents are returned in order of embedding distance.

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -48,6 +48,7 @@ export type Document = {
   embedding?: number[]
   projectId?: string
   date?: string
+  distance?: number
 }
 
 export type CreateDocumentArgs = Document


### PR DESCRIPTION
## What Changed:
We are universally going with distance over similarity now. There is slight difference in the algorithm, but for normalized vectors (which most embeddings are) the distance and similarity are the same, and you can compute similarity as 1 - distance.

This simply changes the documentation and adds distance to the Document type.