### PR TITLE
Hot patch: Disable delete key since it breaks graphs

### DIFF
--- a/packages/core/shared/src/plugins/keyCodePlugin/index.ts
+++ b/packages/core/shared/src/plugins/keyCodePlugin/index.ts
@@ -32,8 +32,10 @@ function install(editor: IRunContextEditor) {
     // If no node is currently selected, do nothing.
     if (!currentNode || editor.selected.list.length === 0) return
 
+    console.warn('The delete key has been temporary disabled')
+
     // Otherwise, remove the selected node from the editor.
-    editor.removeNode(currentNode)
+    // editor.removeNode(currentNode)
   })
 }
 


### PR DESCRIPTION
## What Changed:
For some reason, when I press Delete on a node it breaks my graph badly. However, when I delete a node from the context menu (right click) it is totally fine. This PR throws a warning and fixes this annoyance until we can dig into why exactly nodes break when called that way.

Maybe it's a plugin order issue? :-/