### PR TITLE
[WIP] Fix plugin loading

### DIFF
--- a/apps/agent/project.json
+++ b/apps/agent/project.json
@@ -6,7 +6,9 @@
   "implicitDependencies": [
     "@magickml/server-core",
     "@magickml/core",
-    "@magickml/agents"
+    "@magickml/agents",
+    "@magickml/plugin-twitter-server",
+    "@magickml/plugin-discord-server"
   ],
   "targets": {
     "build": {

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -5,8 +5,11 @@
   "projectType": "application",
   "implicitDependencies": [
     "@magickml/server-core",
-    "@magickml/core"
-],
+    "@magickml/core",
+    "@magickml/plugin-twitter-server",
+    "@magickml/plugin-discord-server",
+    "@magickml/plugin-openai-server"
+  ],
   "targets": {
     "build": {
       "executor": "@nx/webpack:webpack",
@@ -20,7 +23,9 @@
         "inspect": true,
         "outputPath": "dist/apps/server",
         "main": "apps/server/src/index.ts",
-        "assets": ["apps/server/src/certs"],
+        "assets": [
+          "apps/server/src/certs"
+        ],
         "tsConfig": "apps/server/tsconfig.app.json",
         "webpackConfig": "apps/server/webpack.config.js"
       },


### PR DESCRIPTION
Currently plugin code doesn't update in the server or client unless they are explicitly marked as implicit dependencies in the tsconfig. This is at odds with our dynamic loading system. We can either generate a tsconfig with the plugins to load, or fix this behavior. What is weird is that we didn't need this before, it just worked.