### PR TITLE
Add connector to event destructure

### DIFF
--- a/packages/core/shared/src/nodes/events/EventDestructure.ts
+++ b/packages/core/shared/src/nodes/events/EventDestructure.ts
@@ -138,6 +138,7 @@ export class EventDestructureComponent extends MagickComponent<Promise<Event>> {
       projectId,
       entities,
       embedding,
+      connector,
       agentId,
     } = eventValue as Event
     return {
@@ -151,6 +152,7 @@ export class EventDestructureComponent extends MagickComponent<Promise<Event>> {
       projectId,
       entities,
       embedding,
+      connector,
       agentId,
       trigger: 'option',
     }


### PR DESCRIPTION
## What Changed:
This PR adds the connector field to the event destructure output. The socket was there, but it was undefined.