### PR TITLE
add image col to agents table

### DIFF
--- a/apps/server/migrations/20230626020445_add-agent-image.ts
+++ b/apps/server/migrations/20230626020445_add-agent-image.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('agents', (table) => {
+    table.text('image').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('agents', (table) => {
+    table.dropColumn('image')
+  })
+}

--- a/packages/core/server/src/services/agents/agents.schema.ts
+++ b/packages/core/server/src/services/agents/agents.schema.ts
@@ -126,6 +126,7 @@ export const agentQueryProperties = Type.Pick(agentSchema, [
   'data',
   'publicVariables',
   'secrets',
+  'image',
 ]);
 
 /**

--- a/packages/core/shared/src/schemas.ts
+++ b/packages/core/shared/src/schemas.ts
@@ -50,6 +50,7 @@ export type SpellInterface = Static<typeof spellSchema>
  * @property {any} [data] - The data stored in the agent (optional).
  * @property {any} [publicVariables] - The public variables of the agent (optional).
  * @property {string} [secrets] - The secrets of the agent (optional).
+ * @property {string} [image] - The image of the agent (optional).
  */
 export const agentSchema = Type.Object(
   {
@@ -64,6 +65,7 @@ export const agentSchema = Type.Object(
     data: Type.Optional(Type.Any()),
     publicVariables: Type.Optional(Type.Any()),
     secrets: Type.Optional(Type.String()),
+    image: Type.Optional(Type.String()),
   },
   {
     $id: 'Agent',


### PR DESCRIPTION
## What Changed:

add migrations and feathers schema types for image in the agent

## How to test:

run migrate and see that the column is in the db
