### PR TITLE
Fixing page auto-change on documents and requests windows

### DIFF
--- a/packages/editor/src/screens/DocumentWindow/DocumentTable.tsx
+++ b/packages/editor/src/screens/DocumentWindow/DocumentTable.tsx
@@ -85,6 +85,7 @@ function DocumentTable({ documents, updateCallback }) {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedRow, setSelectedRow] = useState(null)
+  const [currentPage, setCurrentPage] = useState(0)
 
   const handleActionClick = (document, row) => {
     setAnchorEl(document.currentTarget)
@@ -151,6 +152,9 @@ function DocumentTable({ documents, updateCallback }) {
       {
         columns: defaultColumns,
         data: documents,
+        initialState : {
+          pageIndex: currentPage 
+        }
       },
       useFilters,
       useGlobalFilter,
@@ -177,6 +181,7 @@ function DocumentTable({ documents, updateCallback }) {
   // // Handle pagination
   const handlePageChange = (page: number) => {
     const pageIndex = page - 1
+    setCurrentPage(pageIndex)
     gotoPage(pageIndex)
   }
 
@@ -196,6 +201,13 @@ function DocumentTable({ documents, updateCallback }) {
     })
     if (isDeleted) enqueueSnackbar('document deleted', { variant: 'success' })
     else enqueueSnackbar('Error deleting document', { variant: 'error' })
+
+    if (page.length === 1) {
+      const pageIndex = currentPage - 1
+      setCurrentPage(pageIndex)
+      gotoPage(pageIndex)
+    }
+
     // close the action menu
     handleActionClose()
     updateCallback()

--- a/packages/editor/src/screens/EventWindow/EventTable.tsx
+++ b/packages/editor/src/screens/EventWindow/EventTable.tsx
@@ -178,8 +178,8 @@ function EventTable({ events, updateCallback }) {
       {
         columns: defaultColumns,
         data: events,
-        initialState : {
-          pageIndex: currentPage 
+        initialState: {
+          pageIndex: currentPage
         }
       },
       useFilters,
@@ -227,19 +227,34 @@ function EventTable({ events, updateCallback }) {
 
   // Handle events deletion
   const handleDeleteMany = async (event: any) => {
-    const ids = selectedRows.join('&')
+    const ids = selectedRows.join('&');
     const isDeleted = await fetch(`${API_ROOT_URL}/events/${ids}`, {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    })
-    setSelectedRows([])
-    if (isDeleted) enqueueSnackbar('Events deleted', { variant: 'success' })
-    else enqueueSnackbar('Error deleting Event', { variant: 'error' })
-    // close the action menu
-    updateCallback()
-  }
+    });
+  
+    if (isDeleted) {
+      enqueueSnackbar('Events deleted', { variant: 'success' });
+      // Update the table data with the updated data from the server
+      updateCallback();
+      // Clear the selected rows
+      setSelectedRows([]);
+  
+      const updatedPageLength = page.length - selectedRows.length;
+      // Check if there are no more documents on the current page
+      if (updatedPageLength === 0 && currentPage > 0) {
+        const pageIndex = currentPage - 1;
+        setCurrentPage(pageIndex);
+        // Go to the previous page
+        gotoPage(pageIndex);
+      }
+    } else {
+      enqueueSnackbar('Error deleting Event', { variant: 'error' });
+    }
+  };
+  
 
   // Handle event deletion
   const handleEventDelete = async (event: any) => {
@@ -271,7 +286,7 @@ function EventTable({ events, updateCallback }) {
     [flatRows]
   )
 
-  
+  console.log(page.length)
 
   // Render the table with useMemo
   return (

--- a/packages/editor/src/screens/EventWindow/event.ts
+++ b/packages/editor/src/screens/EventWindow/event.ts
@@ -36,7 +36,7 @@ export interface EventData {
   content: string
   type: string
   channel: string
-  channelType: string
+  channelType?: string
   observer: string
   date: string
 }

--- a/packages/editor/src/screens/RequestWindow/RequestTable.tsx
+++ b/packages/editor/src/screens/RequestWindow/RequestTable.tsx
@@ -78,6 +78,7 @@ function RequestTable({ requests, updateCallback }) {
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedRow, setSelectedRow] = useState(null)
   const [selectedRows, setSelectedRows] = useState<string[]>([])
+  const [currentPage, setCurrentPage] = useState(0)
 
   const handleActionClick = (document, row) => {
     setAnchorEl(document.currentTarget)
@@ -107,6 +108,13 @@ function RequestTable({ requests, updateCallback }) {
 
     if (json) enqueueSnackbar('Request deleted', { variant: 'success' })
     else enqueueSnackbar('Error deleting Request', { variant: 'error' })
+
+    if (page.length === 1) {
+      const pageIndex = currentPage - 1
+      setCurrentPage(pageIndex)
+      gotoPage(pageIndex)
+    }
+
     // close the action menu
     handleActionClose()
     updateCallback()
@@ -114,24 +122,36 @@ function RequestTable({ requests, updateCallback }) {
   }
 
   // Handle events deletion
-  const handleDeleteMany = async (event: any) => {
-    const isDeleted: Array<unknown> = await client.service('request').remove(null, {
+  const handleDeleteMany = async (event) => {
+    const isDeleted = await client.service('request').remove(null, {
       query: {
         id: {
-          $in: selectedRows
-        }
-      }
-    })
+          $in: selectedRows,
+        },
+      },
+    });
+  
     if (isDeleted) {
       enqueueSnackbar('Requests deleted', { variant: 'success' });
+      // Update the table data with the updated data from the server
       updateCallback();
+      // Clear the selected rows
+      setSelectedRows([]);
+  
+      const updatedPageLength = page.length - selectedRows.length;
+      // Check if there are no more documents on the current page
+      if (updatedPageLength === 0 && currentPage > 0) {
+        const pageIndex = currentPage - 1;
+        setCurrentPage(pageIndex);
+        // Go to the previous page
+        gotoPage(pageIndex);
+      }
     } else {
       enqueueSnackbar('Error deleting Requests', { variant: 'error' });
     }
-
-    // Clear the selected rows
-    setSelectedRows([]);
-  }
+  };
+  
+  
 
 
   const defaultColumns = useMemo(
@@ -201,6 +221,9 @@ function RequestTable({ requests, updateCallback }) {
       {
         columns: defaultColumns,
         data: requests,
+        initialState : {
+          pageIndex: currentPage 
+        }
       },
       useFilters,
       useGlobalFilter,
@@ -211,6 +234,7 @@ function RequestTable({ requests, updateCallback }) {
   // Handle page change
   const handlePageChange = (page: number) => {
     const pageIndex = page - 1
+    setCurrentPage(pageIndex)
     gotoPage(pageIndex)
   }
 
@@ -292,6 +316,9 @@ function RequestTable({ requests, updateCallback }) {
 
     )
   })
+
+  
+      
 
 
   return (


### PR DESCRIPTION
## What Changed:

I added the initial state on useTable hook with contains pageIndex attribute which will help us to make sure that if we refresh our page after deleting items, that same page will be returned back, instead of loading the first page which causes items to reorder

## How to test:

1. Add many requests/documents on request or document table
2. Go to any page other than the first one
3. Try to delete any item

## Additional information:

[Screencast from 26.06.2023 17:57:42.webm](https://github.com/Oneirocom/Magick/assets/55635977/9e5733d5-0d70-403a-8d03-232bdddef336)

