### PR TITLE
Fixing node name extending beyond the node

### DIFF
--- a/packages/editor/src/components/Node/Node.module.css
+++ b/packages/editor/src/components/Node/Node.module.css
@@ -69,6 +69,7 @@
   background: var(--dark-0);
   border-radius: var(--extraSmall) var(--extraSmall) 0px 0px;
   display: flex;
+  word-break: break-word;
 }
 .input,
 .output {

--- a/packages/editor/src/components/Node/Node.module.css
+++ b/packages/editor/src/components/Node/Node.module.css
@@ -47,7 +47,7 @@
 }
 .node-id {
   position: absolute;
-  top: 5px;
+  top: 8px;
   right: 10px;
   color: var(--dark-4);
 }
@@ -57,6 +57,10 @@
 .node-id.success {
   color: var(--green);
 }
+.node-title-container {
+  background: var(--dark-0);
+  border-bottom: 1px solid var(--dark-2);
+}
 .node-title {
   font-family: 'BerkeleyMono-Regular', 'IBM Plex Sans', 'IBM Plex Mono',
     sans-serif;
@@ -64,11 +68,10 @@
   letter-spacing: 0.1em;
   font-weight: 900;
   padding: var(--extraSmall);
-  border-bottom: 1px solid var(--dark-2);
   color: var(--glow);
-  background: var(--dark-0);
   border-radius: var(--extraSmall) var(--extraSmall) 0px 0px;
   display: flex;
+  width: 83%;
   word-break: break-word;
 }
 .input,

--- a/packages/editor/src/components/Node/Node.tsx
+++ b/packages/editor/src/components/Node/Node.tsx
@@ -68,12 +68,14 @@ export class MyNode extends Node {
         >
           <p>{node.id}</p>
         </div>
-        <div className={css['node-title']}>
-          <Icon
-            name={componentCategories[node.category]}
-            style={{ marginRight: 'var(--extraSmall)' }}
-          />
-          {fullName}
+        <div className={css['node-title-container']}>
+          <div className={css['node-title']}>
+            <Icon
+              name={componentCategories[node.category]}
+              style={{ marginRight: 'var(--extraSmall)' }}
+            />
+            {fullName}
+          </div>
         </div>
         <div className={css['connections-container']}>
           {html !== undefined && (


### PR DESCRIPTION
## What Changed:

I fixed the default node name so that it won't ever overlap the node when it's set to a long text

## How to test:

1. Create an input node
2. change the default name of that node and set it to a long text

## Additional information:
![Screenshot from 2023-06-27 11-06-11](https://github.com/Oneirocom/Magick/assets/55635977/8e33f44f-ef22-4fe8-852c-701274fbceb8)

