### PR TITLE
adding tooltip on hover of labels in the inspector, show tooltip description of the field

### DIFF
--- a/packages/core/shared/src/dataControls/ArrayControl.ts
+++ b/packages/core/shared/src/dataControls/ArrayControl.ts
@@ -11,13 +11,14 @@ export class ArrayControl extends DataControl {
    * @param {string} data.name - The name of the control
    * @param {string} [data.icon = 'hand'] - The icon of the control
    */
-  constructor({ dataKey, name, icon = 'hand' }) {
+  constructor({ dataKey, name, icon = 'hand' ,tooltip}) {
     const options = {
       dataKey,
       name,
       component: 'input',
       icon,
       type: 'array',
+      tooltip: tooltip,
     }
 
     super(options)

--- a/packages/core/shared/src/dataControls/BooleanControl.ts
+++ b/packages/core/shared/src/dataControls/BooleanControl.ts
@@ -25,6 +25,7 @@ export class BooleanControl extends DataControl {
       icon: config.icon || 'hand', // Assign the icon property from the configuration object or default to 'hand'.
       type: 'boolean', // Set the control type to 'boolean'.
       defaultValue: config.defaultValue || false, // Assign the defaultValue property from the configuration object or default to 'false'.
+      tooltip: ''
     };
 
     super(options); // Call the super constructor with the options object.

--- a/packages/core/shared/src/dataControls/BooleanControl.ts
+++ b/packages/core/shared/src/dataControls/BooleanControl.ts
@@ -15,6 +15,7 @@ export class BooleanControl extends DataControl {
    *      @param {string} name - The name of the control to be shown in the inspector UI.
    *      @param {string} icon - The icon of the control to be shown in the inspector UI. Defaults to 'hand'.
    *      @param {string} component - The type of control to be rendered in the inspector UI. Defaults to 'switch'.
+   *      @param {string} tooltip   - The type of control to show the quick overview to the users
    *      @param {boolean} defaultValue - The initial value of the controlled data. Defaults to 'false'.
    */
   constructor(config) {
@@ -25,7 +26,7 @@ export class BooleanControl extends DataControl {
       icon: config.icon || 'hand', // Assign the icon property from the configuration object or default to 'hand'.
       type: 'boolean', // Set the control type to 'boolean'.
       defaultValue: config.defaultValue || false, // Assign the defaultValue property from the configuration object or default to 'false'.
-      tooltip: ''
+      tooltip: config.tooltip
     };
 
     super(options); // Call the super constructor with the options object.

--- a/packages/core/shared/src/dataControls/CodeControl.ts
+++ b/packages/core/shared/src/dataControls/CodeControl.ts
@@ -16,12 +16,14 @@ export class CodeControl extends DataControl {
     dataKey,
     name,
     icon = 'feathers',
-    language = 'javascript'
+    language = 'javascript',
+    tooltip= ''
   }: {
     dataKey: string,
     name: string,
     icon?: string,
     language?: string
+    tooltip?: string
   }) {
     const options = {
       dataKey,
@@ -31,7 +33,8 @@ export class CodeControl extends DataControl {
       options: {
         editor: true,
         language
-      }
+      },
+      tooltip: tooltip,
     }
 
     super(options)

--- a/packages/core/shared/src/dataControls/DropdownControl.ts
+++ b/packages/core/shared/src/dataControls/DropdownControl.ts
@@ -27,6 +27,7 @@ export class DropdownControl extends DataControl {
     icon = 'properties',
     write = true,
     ignored = [],
+    tooltip = '',
   }: {
     name: string
     dataKey: string
@@ -35,6 +36,7 @@ export class DropdownControl extends DataControl {
     icon?: string
     write?: boolean
     ignored?: string[]
+    tooltip?: string;
   }) {
     const options = {
       dataKey,
@@ -47,6 +49,7 @@ export class DropdownControl extends DataControl {
         values,
         ignored,
       },
+      tooltip: tooltip
     }
 
     super(options)

--- a/packages/core/shared/src/dataControls/EmptyControl.ts
+++ b/packages/core/shared/src/dataControls/EmptyControl.ts
@@ -12,7 +12,7 @@ export class EmptyControl extends DataControl {
    * @param {string} dataKey - The key of the data that the control will interact with.
    * @param {array} ignored - The list of ignored values by the control.
    */
-  constructor({ dataKey, ignored = [] }) {
+  constructor({ dataKey, ignored = [],tooltip }) {
     const options = {
       dataKey: dataKey,
       name: 'empty',
@@ -20,6 +20,7 @@ export class EmptyControl extends DataControl {
       data: {
         ignored,
       },
+      tooltip: tooltip,
     }
 
     super(options)

--- a/packages/core/shared/src/dataControls/FewshotControl.ts
+++ b/packages/core/shared/src/dataControls/FewshotControl.ts
@@ -21,6 +21,7 @@ export class FewshotControl extends DataControl {
     dataKey = 'fewshot',
     name = 'fewshot',
     defaultValue = '',
+    tooltip=''
   }) {
     const options = {
       dataKey,
@@ -32,7 +33,8 @@ export class FewshotControl extends DataControl {
         language,
         wordWrap: true
       },
-      defaultValue
+      defaultValue,
+      tooltip: tooltip,
     }
 
     // Calls the constructor of parent class and passes the options object to it.

--- a/packages/core/shared/src/dataControls/InputControl.ts
+++ b/packages/core/shared/src/dataControls/InputControl.ts
@@ -23,6 +23,7 @@ export class InputControl extends DataControl {
     dataKey = '',
     name = '',
     icon = 'hand',
+    tooltip = '',
     defaultValue,
     placeholder,
   }: {
@@ -31,6 +32,7 @@ export class InputControl extends DataControl {
     icon?: string;
     defaultValue?: unknown;
     placeholder?: string;
+    tooltip?: string;
   }) {
     // Call super constructor with options and 'input' as the type of control
     super({
@@ -40,6 +42,7 @@ export class InputControl extends DataControl {
       defaultValue: defaultValue,
       icon: icon,
       placeholder: placeholder,
+      tooltip: tooltip,
     });
   }
 }

--- a/packages/core/shared/src/dataControls/ModelControl.ts
+++ b/packages/core/shared/src/dataControls/ModelControl.ts
@@ -20,12 +20,14 @@ export class ModelControl extends DataControl {
     defaultValue,
     icon = 'properties',
     write = true,
+    tooltip = '',
   }: {
     name: string;
     dataKey: string;
     defaultValue: string;
     icon?: string;
     write?: boolean;
+    tooltip?: string;
   }) {
     const options = {
       dataKey,
@@ -36,6 +38,7 @@ export class ModelControl extends DataControl {
       data: {
         defaultValue,
       },
+      tooltip: tooltip,
     };
 
     super(options);

--- a/packages/core/shared/src/dataControls/MultiSocketGenerator.ts
+++ b/packages/core/shared/src/dataControls/MultiSocketGenerator.ts
@@ -28,6 +28,7 @@ export class MultiSocketGeneratorControl extends DataControl {
     icon = 'properties',
     connectionType,
     name: nameInput,
+    tooltip = '',
   }: {
     socketTypes: string[];
     taskTypes: string[];
@@ -35,6 +36,7 @@ export class MultiSocketGeneratorControl extends DataControl {
     icon?: string;
     connectionType: 'input' | 'output';
     name: string;
+    tooltip?: string;
   }) {
     const name = nameInput || `${socketTypes.join('|')} ${connectionType}s`;
 
@@ -49,6 +51,7 @@ export class MultiSocketGeneratorControl extends DataControl {
         taskTypes,
         connectionType,
       },
+      tooltip: tooltip,
     };
 
     super(options);

--- a/packages/core/shared/src/dataControls/NumberControl.ts
+++ b/packages/core/shared/src/dataControls/NumberControl.ts
@@ -12,7 +12,7 @@ export class NumberControl extends DataControl {
    * @param {Object} params - An object containing the key, name, icon,
    * defaultValue of the control.
    */
-  constructor({ dataKey, name, icon = 'hand', defaultValue = -1 }) {
+  constructor({ dataKey, name, icon = 'hand', defaultValue = -1, tooltip }) {
 
     super({
       dataKey: dataKey,
@@ -21,6 +21,7 @@ export class NumberControl extends DataControl {
       icon,
       type: 'number',
       defaultValue,
+      tooltip: tooltip,
     });
   }
 

--- a/packages/core/shared/src/dataControls/PlaytestControl.ts
+++ b/packages/core/shared/src/dataControls/PlaytestControl.ts
@@ -23,6 +23,7 @@ export class PlaytestControl extends DataControl {
     label = 'Toggle',
     defaultValue = {},
     ignored = [],
+    tooltip=''
   }) {
     const options = {
       dataKey, // shorthand object property assignment
@@ -34,6 +35,7 @@ export class PlaytestControl extends DataControl {
         label,
         ignored,
       },
+      tooltip: tooltip,
     };
 
     super(options); // call super constructor

--- a/packages/core/shared/src/dataControls/SocketGenerator.ts
+++ b/packages/core/shared/src/dataControls/SocketGenerator.ts
@@ -31,6 +31,7 @@ export class SocketGeneratorControl extends DataControl {
     icon = 'properties',
     connectionType,
     name: nameInput,
+    tooltip = '',
   }: {
     socketType?: SocketType,
     taskType?: TaskType,
@@ -38,6 +39,7 @@ export class SocketGeneratorControl extends DataControl {
     icon?: string,
     connectionType: 'input' | 'output',
     name: string
+    tooltip?: string,
   }) {
     super({
       dataKey: connectionType + 's',
@@ -50,6 +52,7 @@ export class SocketGeneratorControl extends DataControl {
         taskType,
         connectionType,
       },
+      tooltip: tooltip,
     });
 
     if(!connectionType || !(connectionType === 'input' || connectionType === 'output')) {

--- a/packages/core/shared/src/dataControls/SpellControl.ts
+++ b/packages/core/shared/src/dataControls/SpellControl.ts
@@ -20,6 +20,7 @@ export class SpellControl extends DataControl {
     icon?: string
     write: boolean
     defaultValue?: string
+    tooltip?: string
   }) {
     const optionsWithDefaults = {
       dataKey: 'spell',
@@ -28,6 +29,7 @@ export class SpellControl extends DataControl {
       defaultValue: options.defaultValue || '',
       write: options.write,
       icon: options.icon || 'sieve',
+      tooltip: options.tooltip || '',
     }
     super(optionsWithDefaults);
   }

--- a/packages/core/shared/src/dataControls/SwitchControl.ts
+++ b/packages/core/shared/src/dataControls/SwitchControl.ts
@@ -32,12 +32,14 @@ export class SwitchControl extends DataControl {
     icon = 'hand',
     label = 'Toggle',
     defaultValue = {},
+    tooltip = '',
   }: {
     dataKey: string
     name: string
     icon?: string
     label: string
     defaultValue?: unknown
+    tooltip?: string
   }) {
     super({
       dataKey: dataKey,
@@ -48,6 +50,7 @@ export class SwitchControl extends DataControl {
       data: {
         label,
       },
+      tooltip: tooltip,
     })
   }
 

--- a/packages/core/shared/src/nodes/array/ArrayVariable.ts
+++ b/packages/core/shared/src/nodes/array/ArrayVariable.ts
@@ -49,21 +49,25 @@ export class ArrayVariable extends MagickComponent<InputReturn> {
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      tooltip: 'This is an input for name',
     })
     const _var = new InputControl({
       dataKey: '_var',
       name: 'Value',
       icon: 'moon',
+      tooltip: 'This is an input value',
     })
     const splitter = new InputControl({
       dataKey: 'splitter',
       name: 'Splitter',
       icon: 'moon',
+      tooltip: 'This is an input splitter',
     })
     const keepEmpty = new BooleanControl({
       dataKey: 'keepEmpty',
       name: 'Keep Empty Values',
       icon: 'moon',
+      tooltip: 'This is an toggle to keep empty values',
     })
     node.inspector.add(name).add(_var).add(splitter).add(keepEmpty)
     return node.addOutput(out)

--- a/packages/core/shared/src/nodes/array/ExtractFromArray.ts
+++ b/packages/core/shared/src/nodes/array/ExtractFromArray.ts
@@ -48,6 +48,7 @@ export class ExtractFromArray extends MagickComponent<Promise<WorkerReturn>> {
     const values = new InputControl({
       dataKey: 'value',
       name: 'Value to Extract',
+      tooltip: 'This is a tooltip for value',
     })
 
     node.inspector.add(values)

--- a/packages/core/shared/src/nodes/array/GetValueFromArray.ts
+++ b/packages/core/shared/src/nodes/array/GetValueFromArray.ts
@@ -49,6 +49,7 @@ export class GetValueFromArray extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'element',
       name: 'Element',
       defaultValue: 0,
+      tooltip: 'this is a element input',
     })
 
     node.inspector.add(element)

--- a/packages/core/shared/src/nodes/array/JoinList.ts
+++ b/packages/core/shared/src/nodes/array/JoinList.ts
@@ -51,6 +51,7 @@ export class JoinListComponent extends MagickComponent<WorkerReturn> {
       name: 'Separator',
       dataKey: 'separator',
       defaultValue: separator,
+      tooltip: 'this is a separator input ',
     })
     node.inspector.add(input)
 

--- a/packages/core/shared/src/nodes/array/RemapArray.ts
+++ b/packages/core/shared/src/nodes/array/RemapArray.ts
@@ -48,6 +48,7 @@ export class RemapArray extends MagickComponent<Promise<WorkerReturn>> {
     const values = new InputControl({
       dataKey: 'values',
       name: 'Values (, separated)',
+      tooltip:"this is an input for value"
     })
 
     node.inspector.add(values)

--- a/packages/core/shared/src/nodes/boolean/BooleanVariable.ts
+++ b/packages/core/shared/src/nodes/boolean/BooleanVariable.ts
@@ -52,15 +52,18 @@ export class BooleanVariable extends MagickComponent<InputReturn> {
       name: 'Value',
       icon: 'moon',
       component: 'switch',
+      tooltip:"This is a toggle for value property"
     })
     const name = new InputControl({
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      tooltip: 'Tooltip text for Input Name',
     })
     const _public = new BooleanControl({
       dataKey: 'isPublic',
       name: 'isPublic',
+      tooltip: 'Make your variable public and globally accessible',
     })
 
     node.inspector.add(name).add(_var).add(_public)

--- a/packages/core/shared/src/nodes/boolean/LogicalOperator.ts
+++ b/packages/core/shared/src/nodes/boolean/LogicalOperator.ts
@@ -55,12 +55,14 @@ export class LogicalOperator extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'operationType',
       values: operationTypes,
       defaultValue: operationTypes[0],
+      tooltip:"this is an operation type dropdown"
     })
 
     const testt = new NumberControl({
       dataKey: 'testt',
       name: 'testt Type',
       icon: 'moon',
+      tooltip:"This is a number control"
     })
 
     node.inspector.add(operationType).add(testt)

--- a/packages/core/shared/src/nodes/code/Javascript.ts
+++ b/packages/core/shared/src/nodes/code/Javascript.ts
@@ -68,23 +68,27 @@ export class Javascript extends MagickComponent<unknown> {
       connectionType: 'output',
       ignored: ['trigger'],
       name: 'Output Sockets',
+      tooltip: 'Add output sockets'
     })
 
     const inputGenerator = new SocketGeneratorControl({
       connectionType: 'input',
       ignored: ['trigger'],
       name: 'Input Sockets',
+      tooltip: 'Add input sockets'
     })
 
     const codeControl = new CodeControl({
       dataKey: 'code',
       name: 'Code',
       language: 'javascript',
+      tooltip: 'Open code editor'
     })
 
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Component Name',
+      tooltip: 'Enter component name'
     })
 
     node.addOutput(dataOutput).addInput(dataInput)

--- a/packages/core/shared/src/nodes/code/Python.ts
+++ b/packages/core/shared/src/nodes/code/Python.ts
@@ -68,23 +68,27 @@ export class Python extends MagickComponent<unknown> {
       connectionType: 'output',
       ignored: ['trigger'],
       name: 'Output Sockets',
+      tooltip: 'Add output sockets'
     })
 
     const inputGenerator = new SocketGeneratorControl({
       connectionType: 'input',
       ignored: ['trigger'],
       name: 'Input Sockets',
+      tooltip: 'Add input sockets'
     })
 
     const codeControl = new CodeControl({
       dataKey: 'code',
       name: 'Code',
       language: 'python',
+      tooltip: 'Open code editor'
     })
 
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Component Name',
+      tooltip: 'Enter component name'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/database/Delete.ts
+++ b/packages/core/shared/src/nodes/database/Delete.ts
@@ -66,6 +66,7 @@ export class Delete extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'db_provider',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the database provider'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/database/Insert.ts
+++ b/packages/core/shared/src/nodes/database/Insert.ts
@@ -66,6 +66,7 @@ export class Insert extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'db_provider',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the database provider'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/database/Select.ts
+++ b/packages/core/shared/src/nodes/database/Select.ts
@@ -66,6 +66,7 @@ export class Select extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'db_provider',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the database provider'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/database/Update.ts
+++ b/packages/core/shared/src/nodes/database/Update.ts
@@ -66,6 +66,7 @@ export class Update extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'db_provider',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the database provider'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/database/Upsert.ts
+++ b/packages/core/shared/src/nodes/database/Upsert.ts
@@ -66,6 +66,7 @@ export class Upsert extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'db_provider',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the database provider'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/document/GetDocuments.ts
+++ b/packages/core/shared/src/nodes/document/GetDocuments.ts
@@ -65,6 +65,7 @@ export class GetDocuments extends MagickComponent<Promise<InputReturn>> {
       name: 'Type',
       icon: 'moon',
       placeholder: 'document',
+      tooltip: 'Enter document type'
     })
 
     const max_count = new InputControl({
@@ -72,6 +73,7 @@ export class GetDocuments extends MagickComponent<Promise<InputReturn>> {
       name: 'Max Count',
       icon: 'moon',
       defaultValue: '6',
+      tooltip: 'Enter max count'
     })
 
     // Save controls as inspector data for easy reference

--- a/packages/core/shared/src/nodes/document/StoreDocument.ts
+++ b/packages/core/shared/src/nodes/document/StoreDocument.ts
@@ -41,6 +41,7 @@ export class StoreDocument extends MagickComponent<Promise<void>> {
       dataKey: 'name',
       name: 'Input name',
       placeholder: 'Conversation',
+      tooltip: 'Enter input name'
     })
 
     const type = new InputControl({
@@ -48,6 +49,7 @@ export class StoreDocument extends MagickComponent<Promise<void>> {
       name: 'Type',
       icon: 'moon',
       placeholder: 'conversation',
+      tooltip: 'Enter input type'
     })
 
     const contentInput = new Rete.Input('content', 'Content', stringSocket)

--- a/packages/core/shared/src/nodes/embedding/CreateTextEmbedding.ts
+++ b/packages/core/shared/src/nodes/embedding/CreateTextEmbedding.ts
@@ -63,6 +63,7 @@ export class CreateTextEmbedding extends MagickComponent<Promise<InputReturn>> {
       dataKey: 'model',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose the model name'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/events/EventRecall.ts
+++ b/packages/core/shared/src/nodes/events/EventRecall.ts
@@ -77,6 +77,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       dataKey: 'name',
       name: 'Name',
       placeholder: 'Event Recall',
+      tooltip: "Event input name"
     })
 
     const type = new InputControl({
@@ -84,6 +85,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       name: 'Type',
       icon: 'moon',
       placeholder: 'conversation',
+      tooltip: "Event input type"
     })
 
     const max_count = new InputControl({
@@ -91,6 +93,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       name: 'Max Count',
       icon: 'moon',
       defaultValue: '6',
+      tooltip: "Event max count value"
     })
 
     // FilterTypes is an enum, so we can use Object.values to get the values
@@ -102,6 +105,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       dataKey: 'mode',
       values: recallModes,
       defaultValue: recallModes[0],
+      tooltip: "Choose Event Mode name"
     })
 
     const filterBy = new DropdownControl({
@@ -109,6 +113,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       dataKey: 'filterBy',
       values: filterTypes,
       defaultValue: filterTypes[0],
+      tooltip: "Filter Event type name"
     })
 
     const lastMode = node.data.mode

--- a/packages/core/shared/src/nodes/events/EventStore.ts
+++ b/packages/core/shared/src/nodes/events/EventStore.ts
@@ -45,6 +45,7 @@ export class EventStore extends MagickComponent<Promise<void>> {
       dataKey: 'name',
       name: 'Name',
       placeholder: 'Store Event',
+      tooltip: "Store Event input name"
     })
 
     const type = new InputControl({
@@ -52,6 +53,7 @@ export class EventStore extends MagickComponent<Promise<void>> {
       name: 'Type',
       icon: 'moon',
       placeholder: 'conversation',
+      tooltip: "Store Event input type"
     })
 
     const contentInput = new Rete.Input('content', 'Content', stringSocket)
@@ -71,6 +73,7 @@ export class EventStore extends MagickComponent<Promise<void>> {
       dataKey: 'storeEventFor',
       values: storeEventForTypes,
       defaultValue: storeEventForTypes[0],
+      tooltip: "Choose Store Event For"
     })
 
     node.inspector.add(storeEventFor)

--- a/packages/core/shared/src/nodes/flow/ExclusiveGate.ts
+++ b/packages/core/shared/src/nodes/flow/ExclusiveGate.ts
@@ -46,6 +46,7 @@ export class ExclusiveGate extends MagickComponent<void> {
       socketTypes: ['triggerSocket', 'anySocket'],
       taskTypes: ['option', 'output'],
       name: 'Triggers',
+      tooltip: 'Add socket triggers'
     })
 
     const triggerOutput = new Rete.Output('trigger', 'Trigger', triggerSocket)

--- a/packages/core/shared/src/nodes/flow/SwitchGate.ts
+++ b/packages/core/shared/src/nodes/flow/SwitchGate.ts
@@ -47,6 +47,7 @@ export class SwitchGate extends MagickComponent<void> {
       socketType: 'triggerSocket',
       taskType: 'option',
       name: 'Output Sockets',
+      tooltip: 'Add output sockets'
     })
 
     const input = new Rete.Input('input', 'Input', anySocket)

--- a/packages/core/shared/src/nodes/flow/WaitForAll.ts
+++ b/packages/core/shared/src/nodes/flow/WaitForAll.ts
@@ -40,6 +40,7 @@ export class WaitForAll extends MagickComponent<void> {
       connectionType: 'input',
       socketType: 'triggerSocket',
       name: 'Input Sockets',
+      tooltip: 'Add socket triggers'
     })
 
     node.inspector.add(inputGenerator)

--- a/packages/core/shared/src/nodes/io/Input.ts
+++ b/packages/core/shared/src/nodes/io/Input.ts
@@ -20,7 +20,6 @@ import {
 
 /** Information about the InputComponent functionality */
 const info = `The input component allows you to pass a single value to your graph and outputs an Event. The playtest window will pass values into your Input for easy testing.`
-
 type InputReturn = {
   output: unknown
 }
@@ -42,7 +41,8 @@ export class InputComponent extends MagickComponent<InputReturn> {
         },
       },
       'I/O',
-      info
+      info,
+    
     )
 
     this.module = {
@@ -71,6 +71,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
       onData: data => {
         node.data.name = `Input - ${data}`
       },
+      tooltip: 'Tooltip text for Input Name',
     }
 
     const dataOutput = {
@@ -115,10 +116,11 @@ export class InputComponent extends MagickComponent<InputReturn> {
 
     // Setup default controls
     const inputType = new DropdownControl({
-      name: 'Input Type',
+      name: 'Input Types',
       dataKey: 'inputType',
       values: inputTypes.map(v => v.name),
       defaultValue: inputTypes[0].name,
+      tooltip: 'Tooltip text for Input Types',
     })
 
     node.inspector.add(inputType)

--- a/packages/core/shared/src/nodes/io/JupyterNotebook.ts
+++ b/packages/core/shared/src/nodes/io/JupyterNotebook.ts
@@ -73,12 +73,14 @@ export class JupyterNotebook extends MagickComponent<Promise<{ output: string }>
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Component Name',
+      tooltip: 'Enter component name'
     });
 
     const inputGenerator = new SocketGeneratorControl({
       connectionType: 'input',
       name: 'Input Sockets',
       ignored: ['trigger'],
+      tooltip: 'Add Input Socket'
     });
 
     // The URL of the Jupyter Server
@@ -86,6 +88,7 @@ export class JupyterNotebook extends MagickComponent<Promise<{ output: string }>
       dataKey: 'url',
       name: 'Base URL',
       icon: 'moon',
+      tooltip: 'Enter Base url'
     });
 
     // To be supplied if Authorization is turned on on the server
@@ -93,6 +96,7 @@ export class JupyterNotebook extends MagickComponent<Promise<{ output: string }>
       dataKey: 'Authorization',
       name: 'Authorization Header',
       icon: 'moon',
+      tooltip: 'Enter Authorization Header'
     });
 
     // Exact file name including the extension
@@ -100,6 +104,7 @@ export class JupyterNotebook extends MagickComponent<Promise<{ output: string }>
       dataKey: 'file_name',
       name: 'File Name',
       icon: 'moon',
+      tooltip: 'Enter file name'
     });
 
     node

--- a/packages/core/shared/src/nodes/io/Output.ts
+++ b/packages/core/shared/src/nodes/io/Output.ts
@@ -82,6 +82,7 @@ export class Output extends MagickComponent<void> {
       dataKey: 'outputType',
       values: values.map(v => v.name),
       defaultValue: values[0].name || 'Default',
+      tooltip: "Choose Output type"
     })
 
     outputType.onData = data => {

--- a/packages/core/shared/src/nodes/io/Request.ts
+++ b/packages/core/shared/src/nodes/io/Request.ts
@@ -54,18 +54,21 @@ export class Request extends MagickComponent<Promise<WorkerReturn>> {
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Component Name',
+      tooltip: 'Enter Component name'
     })
-    const headers = new InputControl({ dataKey: 'headers', name: 'Headers' })
+    const headers = new InputControl({ dataKey: 'headers', name: 'Headers', tooltip: 'Headers for the input request' })
     const inputGenerator = new SocketGeneratorControl({
       connectionType: 'input',
       name: 'Body Inputs',
       ignored: ['trigger'],
+      tooltip: 'Add body inputs for the request'
     })
-    const url = new InputControl({ dataKey: 'url', name: 'URL', icon: 'moon' })
+    const url = new InputControl({ dataKey: 'url', name: 'URL', icon: 'moon', tooltip: 'url for the input request'})
     const method = new InputControl({
       dataKey: 'method',
       name: 'method',
       icon: 'moon',
+      tooltip: 'Method for the input request'
     })
 
     // Add inputs and outputs to the node and configure node inspector

--- a/packages/core/shared/src/nodes/io/Spell.ts
+++ b/packages/core/shared/src/nodes/io/Spell.ts
@@ -119,6 +119,7 @@ export class SpellComponent extends MagickComponent<
       name: 'Spell Select',
       write: false,
       defaultValue: (node.data.spell as string) || '',
+      tooltip: 'Select/Choose the created spell'
     })
 
     node.inspector.add(spellControl)
@@ -144,6 +145,7 @@ export class SpellComponent extends MagickComponent<
             dataKey: data.name,
             language: 'plaintext',
             defaultValue: publicVar || data.value || '',
+            tooltip: 'Directive for the spell'
           })
           if (!node.inspector.dataControls.has(fewshotInputControl.dataKey)) {
             node.inspector.add(fewshotInputControl)

--- a/packages/core/shared/src/nodes/io/Spell.ts
+++ b/packages/core/shared/src/nodes/io/Spell.ts
@@ -178,6 +178,7 @@ export class SpellComponent extends MagickComponent<
             name: data.name,
             dataKey: data.name,
             defaultValue: data.value,
+            tooltip:""
           })
           if (!node.inspector.dataControls.has(numberInputControl.dataKey)) {
             node.inspector.add(numberInputControl)

--- a/packages/core/shared/src/nodes/number/Add.ts
+++ b/packages/core/shared/src/nodes/number/Add.ts
@@ -50,12 +50,14 @@ export class Add extends MagickComponent<WorkerOutputs> {
       dataKey: 'firstNumber',
       name: 'First Number',
       defaultValue: 1,
+      tooltip: 'Enter First Number'
     })
 
     const inspectorEndNumSocket = new InputControl({
       dataKey: 'secondNumber',
       name: 'Second Number',
       defaultValue: 1,
+      tooltip: 'Enter Second Number'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/Divide.ts
+++ b/packages/core/shared/src/nodes/number/Divide.ts
@@ -50,12 +50,14 @@ export class Divide extends MagickComponent<WorkerOutputs> {
       dataKey: 'firstNumber',
       name: 'First Number',
       defaultValue: 1,
+      tooltip: 'Enter First Number'
     })
 
     const inspectorEndNumSocket = new InputControl({
       dataKey: 'secondNumber',
       name: 'Second Number',
       defaultValue: 1,
+      tooltip: 'Enter Second Number'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/Equal.ts
+++ b/packages/core/shared/src/nodes/number/Equal.ts
@@ -35,6 +35,7 @@ export class Equal extends MagickComponent<void> {
       dataKey: 'value',
       name: 'Value',
       defaultValue: 0,
+      tooltip: 'Display default value'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/GreaterThan.ts
+++ b/packages/core/shared/src/nodes/number/GreaterThan.ts
@@ -35,6 +35,7 @@ export class GreaterThan extends MagickComponent<void> {
       dataKey: 'value',
       name: 'Value',
       defaultValue: 0,
+      tooltip: 'Display default value'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/GreaterThanOrEqual.ts
+++ b/packages/core/shared/src/nodes/number/GreaterThanOrEqual.ts
@@ -35,6 +35,7 @@ export class GreaterThanOrEqual extends MagickComponent<void> {
       dataKey: 'value',
       name: 'Value',
       defaultValue: 0,
+      tooltip: 'Display default value'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/InRange.ts
+++ b/packages/core/shared/src/nodes/number/InRange.ts
@@ -47,12 +47,14 @@ export class InRange extends MagickComponent<void> {
       dataKey: 'startNumber',
       name: 'Start Number',
       defaultValue: 10,
+      tooltip: 'Enter the start number'
     })
 
     const inspectorEndNumSocket = new InputControl({
       dataKey: 'endNumber',
       name: 'End Number',
       defaultValue: 100,
+      tooltip: 'Enter an end number'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/LessThan.ts
+++ b/packages/core/shared/src/nodes/number/LessThan.ts
@@ -35,6 +35,7 @@ export class LessThan extends MagickComponent<void> {
       dataKey: 'value',
       name: 'Value',
       defaultValue: 0,
+      tooltip: 'Display the default value'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/LessThanOrEqual.ts
+++ b/packages/core/shared/src/nodes/number/LessThanOrEqual.ts
@@ -35,6 +35,7 @@ export class LessThanOrEqual extends MagickComponent<void> {
       dataKey: 'value',
       name: 'Value',
       defaultValue: 0,
+      tooltip: 'Display the default value'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/Multiply.ts
+++ b/packages/core/shared/src/nodes/number/Multiply.ts
@@ -50,12 +50,14 @@ export class Multiply extends MagickComponent<WorkerOutputs> {
       dataKey: 'firstNumber',
       name: 'First Number',
       defaultValue: 1,
+      tooltip: 'Enter the first number'
     })
 
     const inspectorEndNumSocket = new InputControl({
       dataKey: 'secondNumber',
       name: 'Second Number',
       defaultValue: 1,
+      tooltip: 'Enter the second number'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/number/NumberVariable.ts
+++ b/packages/core/shared/src/nodes/number/NumberVariable.ts
@@ -47,11 +47,13 @@ export class NumberVariable extends MagickComponent<InputReturn> {
       dataKey: '_var',
       name: 'Value',
       icon: 'moon',
+      tooltip:""
     })
     const name = new InputControl({
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      
     })
 
     const _public = new BooleanControl({

--- a/packages/core/shared/src/nodes/number/NumberVariable.ts
+++ b/packages/core/shared/src/nodes/number/NumberVariable.ts
@@ -47,18 +47,19 @@ export class NumberVariable extends MagickComponent<InputReturn> {
       dataKey: '_var',
       name: 'Value',
       icon: 'moon',
-      tooltip:""
+      tooltip: 'Value for variable number'
     })
     const name = new InputControl({
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
-      
+      tooltip: 'Name for variable number'
     })
 
     const _public = new BooleanControl({
       dataKey: 'isPublic',
       name: 'isPublic',
+      tooltip: 'Switch isPublic'
     })
 
     node.inspector.add(name).add(_var).add(_public)

--- a/packages/core/shared/src/nodes/number/Subtract.ts
+++ b/packages/core/shared/src/nodes/number/Subtract.ts
@@ -50,12 +50,14 @@ export class Subtract extends MagickComponent<WorkerOutputs> {
       dataKey: 'firstNumber',
       name: 'First Number',
       defaultValue: 1,
+      tooltip: 'Enter the first number'
     })
 
     const inspectorEndNumSocket = new InputControl({
       dataKey: 'secondNumber',
       name: 'Second Number',
       defaultValue: 1,
+      tooltip: 'Enter the second number'
     })
 
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)

--- a/packages/core/shared/src/nodes/object/ComposeObject.ts
+++ b/packages/core/shared/src/nodes/object/ComposeObject.ts
@@ -50,6 +50,7 @@ export class ComposeObject extends MagickComponent<Promise<WorkerReturn>> {
       connectionType: 'input',
       name: 'Input Sockets',
       ignored: ['trigger'],
+      tooltip: 'Add input sockets'
     })
 
     node.addInput(dataInput).addOutput(dataOutput).addOutput(outp)

--- a/packages/core/shared/src/nodes/object/GetValuesFromObject.ts
+++ b/packages/core/shared/src/nodes/object/GetValuesFromObject.ts
@@ -45,6 +45,7 @@ export class GetValuesFromObject extends MagickComponent<void> {
       connectionType: 'output',
       name: 'Property Name',
       ignored: ['trigger'],
+      tooltip: 'Add property name'
     })
 
     node.addInput(dataInput).addInput(objectInput).addOutput(outputTrigger)

--- a/packages/core/shared/src/nodes/object/MergeObjects.ts
+++ b/packages/core/shared/src/nodes/object/MergeObjects.ts
@@ -50,12 +50,14 @@ export class Merge extends MagickComponent<void> {
     const nameInput = new InputControl({
       dataKey: 'name',
       name: 'Node name',
+      tooltip: 'Enter node name'
     })
 
     const socketGenerator = new SocketGeneratorControl({
       connectionType: 'input',
       ignored: ['trigger', 'object'],
       name: 'Property Name',
+      tooltip: 'Add property name'
     })
 
     node

--- a/packages/core/shared/src/nodes/text/CombineText.ts
+++ b/packages/core/shared/src/nodes/text/CombineText.ts
@@ -49,12 +49,14 @@ export class CombineText extends MagickComponent<Promise<WorkerReturn>> {
       connectionType: 'input',
       name: 'Input Sockets',
       ignored: ['trigger'],
+      tooltip: 'Add your socket input'
     })
 
     const delimiter = new InputControl({
       dataKey: 'delimiter',
       name: 'Delimiter',
       icon: 'moon',
+      tooltip: 'Enter Delimiter'
     })
 
     node.addInput(dataInput).addOutput(dataOutput).addOutput(outp)

--- a/packages/core/shared/src/nodes/text/EvaluateText.ts
+++ b/packages/core/shared/src/nodes/text/EvaluateText.ts
@@ -60,9 +60,10 @@ export class EvaluateText extends MagickComponent<Promise<void>> {
       dataKey: 'operationType',
       values: operationTypes,
       defaultValue: operationTypes[0],
+      tooltip: 'Choose operation type'
     })
 
-    const fewshotControl = new FewshotControl({})
+    const fewshotControl = new FewshotControl({tooltip: 'Open fewshot'})
 
     node.inspector.add(fewshotControl).add(operationType)
 

--- a/packages/core/shared/src/nodes/text/GenerateText.ts
+++ b/packages/core/shared/src/nodes/text/GenerateText.ts
@@ -66,6 +66,7 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'model',
       values: models,
       defaultValue: models[0],
+      tooltip: 'Choose model name'
     })
 
     node.inspector.add(modelName)

--- a/packages/core/shared/src/nodes/text/ReplaceText.ts
+++ b/packages/core/shared/src/nodes/text/ReplaceText.ts
@@ -59,16 +59,19 @@ export class ReplaceText extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      tooltip: 'Enter Replace Text name'
     })
     const match = new InputControl({
       dataKey: 'match',
       name: 'Match',
       icon: 'moon',
+      tooltip: 'Enter Replace Text match'
     })
     const replace = new InputControl({
       dataKey: 'replace',
       name: 'Replace',
       icon: 'moon',
+      tooltip: 'Enter Replace Text replace'
     })
 
     node.inspector.add(name).add(match).add(replace)

--- a/packages/core/shared/src/nodes/text/SplitBySentence.ts
+++ b/packages/core/shared/src/nodes/text/SplitBySentence.ts
@@ -93,6 +93,7 @@ export class SplitBySentence extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'stringMaxLength',
       name: 'Maximum String Length',
       defaultValue: 280,
+      tooltip:"The maximum length of each string."
     })
 
     node.inspector.add(stringMaxLength)

--- a/packages/core/shared/src/nodes/text/SplitBySentence.ts
+++ b/packages/core/shared/src/nodes/text/SplitBySentence.ts
@@ -93,7 +93,7 @@ export class SplitBySentence extends MagickComponent<Promise<WorkerReturn>> {
       dataKey: 'stringMaxLength',
       name: 'Maximum String Length',
       defaultValue: 280,
-      tooltip:"The maximum length of each string."
+      tooltip:"Enter The maximum length of each string."
     })
 
     node.inspector.add(stringMaxLength)

--- a/packages/core/shared/src/nodes/text/StringVariable.ts
+++ b/packages/core/shared/src/nodes/text/StringVariable.ts
@@ -47,16 +47,19 @@ export class StringVariable extends MagickComponent<InputReturn> {
       dataKey: '_var',
       name: 'Value',
       icon: 'moon',
+      tooltip: 'Enter value'
     })
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      tooltip: 'Enter name'
     })
 
     const _public = new BooleanControl({
       dataKey: 'isPublic',
       name: 'isPublic',
+      tooltip: 'Switch isPublic'
     })
 
     node.inspector.add(nameControl).add(_var).add(_public)

--- a/packages/core/shared/src/nodes/text/TextTemplate.ts
+++ b/packages/core/shared/src/nodes/text/TextTemplate.ts
@@ -55,11 +55,13 @@ export class TextTemplate extends MagickComponent<Promise<WorkerReturn>> {
       connectionType: 'input',
       ignored: ['trigger'],
       name: 'Input Sockets',
+      tooltip: 'Add input sockets'
     })
 
     const fewshotControl = new FewshotControl({
       name: 'Prompt Template',
       language: 'handlebars',
+      tooltip: 'Open prompt template'
     })
 
     node.inspector.add(inputGenerator).add(fewshotControl)

--- a/packages/core/shared/src/nodes/text/TextVariable.ts
+++ b/packages/core/shared/src/nodes/text/TextVariable.ts
@@ -64,14 +64,16 @@ export class TextVariable extends MagickComponent<InputReturn> {
       dataKey: 'name',
       name: 'Name',
       icon: 'moon',
+      tooltip: 'Enter name'
     })
 
     const _public = new BooleanControl({
       dataKey: 'isPublic',
       name: 'isPublic',
+      tooltip: 'Switch isPublic'
     })
 
-    const fewshotControl = new FewshotControl({})
+    const fewshotControl = new FewshotControl({tooltip: 'Open fewshot'})
 
     node.inspector.add(fewshotControl).add(name).add(_public)
 

--- a/packages/core/shared/src/nodes/utility/Log.ts
+++ b/packages/core/shared/src/nodes/utility/Log.ts
@@ -44,6 +44,7 @@ export class Log extends MagickComponent<void> {
     const nameControl = new InputControl({
       dataKey: 'name',
       name: 'Log Name',
+      tooltip: 'Enter Log Name'
     })
 
     node.inspector.add(nameControl)

--- a/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
@@ -55,6 +55,7 @@ export abstract class DataControl {
     defaultValue = null,
     type = 'string',
     placeholder = '',
+    tooltip = '',
   }: {
     dataKey: string
     name: string
@@ -66,6 +67,7 @@ export abstract class DataControl {
     defaultValue?: unknown
     type?: string
     placeholder?: string
+    tooltip?: string
   }) {
     if (!dataKey) throw new Error('Data key is required')
     if (!name) throw new Error('Name is required')
@@ -82,6 +84,7 @@ export abstract class DataControl {
     this.type = type
     this.placeholder = placeholder
     this.data = data
+    this.tooltip = tooltip
   }
 
   // Add TSDoc comment to the method.
@@ -99,6 +102,7 @@ export abstract class DataControl {
       icon: this.icon,
       type: this.type,
       placeholder: this.placeholder,
+      tooltip: this.tooltip
     }
   }
 

--- a/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/DataControl.ts
@@ -5,6 +5,7 @@ import { MagickComponent } from '../../engine'
 import { ComponentData, ControlData, MagickNode } from '../../types'
 import { Inspector } from './Inspector'
 
+
 // Add TSDoc comment to the class.
 /**
  * A general class for the data controls.
@@ -27,6 +28,7 @@ export abstract class DataControl {
   placeholder: string
   data: ComponentData
   expanded?: boolean
+  tooltip?: string;
 
   // Add TSDoc comment to the constructor.
   /**

--- a/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
@@ -79,7 +79,7 @@ export class Inspector {
       this.node.data[control.dataKey] = control.defaultValue
 
     // add tooltip to the control
-    control.tooltip = control.tooltip || control.name 
+    control.tooltip = control.tooltip || ''
 
     list.set(control.dataKey, control)
   }

--- a/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
@@ -58,7 +58,7 @@ export class Inspector {
     this.info = component.info
   }
   // addede DataControl[]
-  _add(list: Map<string, DataControl>, control: DataControl , tooltip?: string) {
+  _add(list: Map<string, DataControl>, control: DataControl) {
     if (list.has(control.dataKey))
       return console.error(
         `Item with dataKey '${control.dataKey}' already been added to the inspector`

--- a/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/Inspector.ts
@@ -58,7 +58,7 @@ export class Inspector {
     this.info = component.info
   }
   // addede DataControl[]
-  _add(list: Map<string, DataControl>, control: DataControl) {
+  _add(list: Map<string, DataControl>, control: DataControl , tooltip?: string) {
     if (list.has(control.dataKey))
       return console.error(
         `Item with dataKey '${control.dataKey}' already been added to the inspector`
@@ -77,6 +77,9 @@ export class Inspector {
     // If we gave a default value and there isnt already one on the node, add it.
     if (control.defaultValue !== null && !this.node.data[control.dataKey])
       this.node.data[control.dataKey] = control.defaultValue
+
+    // add tooltip to the control
+    control.tooltip = control.tooltip || control.name 
 
     list.set(control.dataKey, control)
   }

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -143,6 +143,7 @@ export type ControlData = {
   icon: string
   type: string
   placeholder: string
+  tooltip?: string
 }
 
 export class MagickEditor extends NodeEditor<EventsTypes> {

--- a/packages/editor/src/DataControls/DataControls.tsx
+++ b/packages/editor/src/DataControls/DataControls.tsx
@@ -123,7 +123,7 @@ const DataControls = ({
               borderRadius: '5px',
             }}
           >
-            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top" >
+            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top-start" arrow>
 
             <p style={{ margin: 0, marginBottom: '10px' }}>
               {control.name || key}

--- a/packages/editor/src/DataControls/DataControls.tsx
+++ b/packages/editor/src/DataControls/DataControls.tsx
@@ -16,6 +16,8 @@ import CheckBoxControl from './CheckBox'
 import { ControlData } from '@magickml/core'
 import {Tooltip } from '@mui/material'
 
+
+
 /**
  * Stub component for unknown control types.
  * @param props - The properties for the stub component.
@@ -96,6 +98,7 @@ const DataControls = ({
     <>
       {Object.entries(dataControls).map(([key, control]) => {
         // Default props to pass through to every data control
+
         const controlProps = {
           nodeId,
           width,
@@ -112,7 +115,6 @@ const DataControls = ({
         if (!Component) return null
 
         if (control.component === 'info' && !control?.data?.info) return null
-
         return (
           <div
             key={control.name + nodeId + key}
@@ -121,7 +123,7 @@ const DataControls = ({
               borderRadius: '5px',
             }}
           >
-            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top">
+            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top" >
 
             <p style={{ margin: 0, marginBottom: '10px' }}>
               {control.name || key}

--- a/packages/editor/src/DataControls/DataControls.tsx
+++ b/packages/editor/src/DataControls/DataControls.tsx
@@ -14,6 +14,7 @@ import SwitchControl from './SwitchControl'
 import SpellSelect from './SpellSelect'
 import CheckBoxControl from './CheckBox'
 import { ControlData } from '@magickml/core'
+import {Tooltip } from '@mui/material'
 
 /**
  * Stub component for unknown control types.
@@ -120,9 +121,12 @@ const DataControls = ({
               borderRadius: '5px',
             }}
           >
+            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top">
+
             <p style={{ margin: 0, marginBottom: '10px' }}>
               {control.name || key}
             </p>
+            </Tooltip>
             <Component key={nodeId + control.name} {...controlProps} />
           </div>
         )

--- a/packages/editor/src/windows/InspectorWindow.tsx
+++ b/packages/editor/src/windows/InspectorWindow.tsx
@@ -66,7 +66,7 @@ const Inspector = (props) => {
 
   const toolbar = (
     <>
-    <Tooltip title={inspectorData?.name} placement="top"> 
+    <Tooltip title={inspectorData?.name} placement="top-start"> 
       <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
         <Icon
           name={componentCategories[inspectorData?.category || 0]}

--- a/packages/editor/src/windows/InspectorWindow.tsx
+++ b/packages/editor/src/windows/InspectorWindow.tsx
@@ -66,6 +66,7 @@ const Inspector = (props) => {
 
   const toolbar = (
     <>
+    <Tooltip title={inspectorData?.name} placement="top"> 
       <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
         <Icon
           name={componentCategories[inspectorData?.category || 0]}
@@ -73,6 +74,7 @@ const Inspector = (props) => {
         />
         {inspectorData?.name}
       </div>
+      </Tooltip>
       {inspectorData?.info && (
         <Tooltip title="Help" placement="bottom">
           <IconButton

--- a/packages/plugins/database/client/src/index.ts
+++ b/packages/plugins/database/client/src/index.ts
@@ -18,6 +18,7 @@ const selectControls = [
     name: 'Table',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter table here'
   },
 ]
 
@@ -28,6 +29,7 @@ const insertControls = [
     name: 'Table',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter table here'
   },
 ]
 
@@ -38,6 +40,7 @@ const updateControls = [
     name: 'Table',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter table here'
   },
 ]
 
@@ -48,6 +51,7 @@ const upsertControls = [
     name: 'Table',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter table here'
   },
   {
     type: InputControl,
@@ -55,6 +59,7 @@ const upsertControls = [
     name: 'On Conflict',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter On conflict'
   },
 ]
 
@@ -65,6 +70,7 @@ const deleteControls = [
     name: 'Table',
     icon: 'database',
     defaultValue: '',
+    tooltip: 'Enter table here'
   },
 ]
 

--- a/packages/plugins/googleai/client/src/index.ts
+++ b/packages/plugins/googleai/client/src/index.ts
@@ -17,6 +17,7 @@ const textCompletionControls = [
     name: 'Temperature (0-1.0)',
     icon: 'moon',
     defaultValue: 0.5,
+    tooltip: 'Change the Temperature'
   },
   {
     type: InputControl,
@@ -24,6 +25,7 @@ const textCompletionControls = [
     name: 'Top K (0-100)',
     icon: 'moon',
     defaultValue: 50,
+    tooltip: 'Change the top_k '
   },
   {
     type: InputControl,
@@ -31,6 +33,7 @@ const textCompletionControls = [
     name: 'Top P (0-1.0)',
     icon: 'moon',
     defaultValue: 1,
+    tooltip: 'Change the top_p'
   },
   {
     type: InputControl,
@@ -38,6 +41,7 @@ const textCompletionControls = [
     name: 'Stop Sequences (comma separated)',
     icon: 'moon',
     defaultValue: '',
+    tooltip: 'Add Stop Sequence'
   },
 ]
 

--- a/packages/plugins/task/shared/src/nodes/CreateTask.ts
+++ b/packages/plugins/task/shared/src/nodes/CreateTask.ts
@@ -45,6 +45,7 @@ export class CreateTask extends MagickComponent<Promise<{ task: AgentTask }>> {
       name: 'Type',
       icon: 'moon',
       placeholder: 'task',
+      tooltip: 'Add Task type'
     })
 
     const objective = new Rete.Input('objective', 'Objective', stringSocket)


### PR DESCRIPTION
## What Changed:

- I added a tooltip on the labels of the inspector
- Show the tooltip short description of the field

## How to test:

- Create a spell and navigate to the inspector view and try to hover on each to see the short description
- Change or click on  a node from the spell view and check on the inspector too while you are hovering.

## Additional information:

[Screencast from 11.07.2023 20:22:08.webm](https://github.com/Oneirocom/Magick/assets/55635977/a0ff43ac-d37c-4d4a-a7c6-b4d8391ccdf3)

