### PR TITLE
Add descriptive tooltip text on the tasks and avatar left nav button left

### DIFF
--- a/packages/core/client/src/components/Drawer/index.tsx
+++ b/packages/core/client/src/components/Drawer/index.tsx
@@ -97,6 +97,7 @@ type DrawerItemProps = {
   Icon: React.ElementType
   open: boolean
   text: string
+  tooltip: string
   active: boolean
   onClick?: () => void
   tooltipText: string
@@ -179,7 +180,8 @@ const PluginDrawerItems: React.FC<PluginDrawerItemsProps> = ({
               open={open}
               onClick={onClick(item.path)}
               text={item.text}
-              tooltipText={`${item.text} are the basic unit of work in MagickML.`}
+              tooltip='Avatar and Tasks Tooltip'
+              tooltipText={item.tooltip}
             />
           </div>
         )
@@ -277,6 +279,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/magick')}
             text="Spells"
+            tooltip="Spells Tooltip"
             tooltipText={drawerTooltipText.spells}
             
           />
@@ -286,6 +289,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/agents')}
             text="Agents"
+            tooltip="Agents Tooltip"
             tooltipText={drawerTooltipText.agents}
           />
           <DrawerItem
@@ -294,6 +298,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/documents')}
             text="Documents"
+            tooltip="Documents Tooltip"
             tooltipText={drawerTooltipText.documents}
           />
           <DrawerItem
@@ -302,6 +307,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/events')}
             text="Events"
+            tooltip="Events Tooltip"
             tooltipText={drawerTooltipText.events}
           />
           <DrawerItem
@@ -310,6 +316,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/requests')}
             text="Requests"
+            tooltip="Requests Tooltip"
             tooltipText={drawerTooltipText.requests}
           />
           <Divider />
@@ -321,6 +328,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
             open={openDrawer}
             onClick={onClick('/settings')}
             text="Settings"
+            tooltip="Settings Tooltip"
             tooltipText={drawerTooltipText.settings}
           />
           {!isAPIKeysSet && <SetAPIKeys />}

--- a/packages/core/shared/src/plugin.ts
+++ b/packages/core/shared/src/plugin.ts
@@ -13,6 +13,7 @@ export type PluginDrawerItem = {
   path: string
   icon: FC
   text: string
+  tooltip: string
 }
 
 export type PluginClientRoute = {

--- a/packages/plugins/avatar/client/src/index.ts
+++ b/packages/plugins/avatar/client/src/index.ts
@@ -23,6 +23,7 @@ const AvatarPlugin = new ClientPlugin({
       path: '/avatar',
       icon: AvatarIcon,
       text: 'Avatar',
+      tooltip: 'Chat with your agents embodied with a 3D avatar'
     },
   ],
   clientRoutes: [

--- a/packages/plugins/task/client/src/index.ts
+++ b/packages/plugins/task/client/src/index.ts
@@ -39,6 +39,7 @@ class TaskPlugin extends ClientPlugin {
           path: '/tasks',
           icon: AssignmentTurnedInIcon,
           text: 'Tasks',
+          tooltip: 'Objectives for agents to iterate through and complete'
         },
       ],
       clientRoutes: [


### PR DESCRIPTION
## What Changed:

- I have added the descriptive tooltip text for the Tasks and Avatar navbar left menu

## How to test:

- Hover on the Tasks and Avatar menu to see the changes

## Additional information:

Any other information that might be useful while reviewing.
