### PR TITLE
Fix chat/text completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "Apache 2.0",
   "scripts": {
     "dev": "cross-env NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent --parallel --maxParallel=100",
+    "dev-nocache": "cross-env NX_NON_NATIVE_HASHER=true node scripts/check-install.js && node scripts/check-docker.js && npx nx run-many --watch --target=serve --projects=@magickml/server,@magickml/client,@magickml/agent --parallel --maxParallel=100 --skip-nx-cache",
     "start": "node scripts/start-server.js",
     "start-server": "node dist/apps/server/main.js",
     "start-agent": "node dist/apps/agent/main.js",

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -64,7 +64,7 @@ export async function makeTextCompletion(
   // Set up headers for the API request.
   const headers = {
     'Content-Type': 'application/json',
-    Authorization: 'Bearer ' + openaiKey ? openaiKey : DEFAULT_OPENAI_KEY,
+    Authorization: 'Bearer ' + (openaiKey ? openaiKey : DEFAULT_OPENAI_KEY),
   }
 
   // Make the API request and handle the response.

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -64,7 +64,7 @@ export async function makeTextCompletion(
   // Set up headers for the API request.
   const headers = {
     'Content-Type': 'application/json',
-    Authorization: 'Bearer ' + openaiKey ? DEFAULT_OPENAI_KEY : openaiKey,
+    Authorization: 'Bearer ' + openaiKey ? openaiKey : DEFAULT_OPENAI_KEY,
   }
 
   // Make the API request and handle the response.

--- a/packages/plugins/openai/shared/src/index.ts
+++ b/packages/plugins/openai/shared/src/index.ts
@@ -7,7 +7,7 @@ import {
   stringSocket,
 } from '@magickml/core'
 
-export const GPT4_MODELS = ['gpt4', 'gpt-4-0613']
+export const GPT4_MODELS = ['gpt-4', 'gpt-4-0613']
 
 /**
  * An array of PluginSecret objects containing information about API key secrets.
@@ -92,7 +92,7 @@ const completionProviders: CompletionProvider[] = [
         socket: 'function',
         name: 'Function',
         type: stringSocket,
-      }
+      },
     ],
     outputs: [
       {


### PR DESCRIPTION
- The OpenAI chat completion node was calling the wrong model name (gpt4 instead of gpt-4). It now uses the correct model name.
- The logic for getting the OpenAI chat completion API key is corrected, these models no longer throw a 401
- Added a NPM script to build without nx cach called "dev-nocache"
