### PR TITLE
Modify the tooltip text position for the socket input and output

### DIFF
--- a/packages/editor/src/components/Node/Node.tsx
+++ b/packages/editor/src/components/Node/Node.tsx
@@ -1,32 +1,32 @@
-// DOCUMENTED 
-import { Node } from '../../plugins/reactRenderPlugin/Node';
-import { Socket } from '../../plugins/reactRenderPlugin/Socket';
-import { Control } from '../../plugins/reactRenderPlugin/Control';
-import { Upload } from '../../plugins/reactRenderPlugin/Upload';
-import { Tooltip } from '@mui/material';
-import { Icon, componentCategories } from '@magickml/client-core';
-import css from './Node.module.css';
+// DOCUMENTED
+import { Node } from '../../plugins/reactRenderPlugin/Node'
+import { Socket } from '../../plugins/reactRenderPlugin/Socket'
+import { Control } from '../../plugins/reactRenderPlugin/Control'
+import { Upload } from '../../plugins/reactRenderPlugin/Upload'
+import { Tooltip } from '@mui/material'
+import { Icon, componentCategories } from '@magickml/client-core'
+import css from './Node.module.css'
 
 /**
  * Custom Node component for rendering nodes with specific functionality.
  * Inherits from the base Node class.
  */
 export class MyNode extends Node {
-  declare props: any;
-  declare state: any;
+  declare props: any
+  declare state: any
 
   /**
    * Constructor for the MyNode component.
    * @param props - Properties that are passed to the component.
    */
   constructor(props) {
-    super(props);
+    super(props)
     this.state = {
       outputs: [],
       controls: [],
       inputs: [],
       selected: false,
-    };
+    }
   }
 
   /**
@@ -34,23 +34,23 @@ export class MyNode extends Node {
    * @returns The JSX representation of the component.
    */
   render() {
-    const { node, bindSocket, bindControl, editor } = this.props;
-    const { outputs, controls, inputs, selected } = this.state;
-    const name = node.displayName ? node.displayName : node.name;
-    const fullName = node.data.name ?? name;
-    const hasError = node.data.error;
-    const hasSuccess = node.data.success;
-    const img_url = node.data.image;
-    const html = node.data.func;
+    const { node, bindSocket, bindControl, editor } = this.props
+    const { outputs, controls, inputs, selected } = this.state
+    const name = node.displayName ? node.displayName : node.name
+    const fullName = node.data.name ?? name
+    const hasError = node.data.error
+    const hasSuccess = node.data.success
+    const img_url = node.data.image
+    const html = node.data.func
 
-    const handleMouseEnter = (socket) => {
+    const handleMouseEnter = socket => {
       socket.connections.forEach(connection => {
         const el = editor.view.connections.get(connection).el
         el.classList.add('selected')
       })
     }
 
-    const handleMouseLeave = (socket) => {
+    const handleMouseLeave = socket => {
       socket.connections.forEach(connection => {
         const el = editor.view.connections.get(connection).el
         el.classList.remove('selected')
@@ -59,12 +59,14 @@ export class MyNode extends Node {
 
     return (
       <div
-        className={`${css['node']} ${css[selected]} ${css[hasError ? 'error' : '']
-          } ${css[hasSuccess ? 'success' : '']}`}
+        className={`${css['node']} ${css[selected]} ${
+          css[hasError ? 'error' : '']
+        } ${css[hasSuccess ? 'success' : '']}`}
       >
         <div
-          className={`${css['node-id']} ${hasError ? css['error'] : ''} ${hasSuccess ? css['success'] : ''
-            }`}
+          className={`${css['node-id']} ${hasError ? css['error'] : ''} ${
+            hasSuccess ? css['success'] : ''
+          }`}
         >
           <p>{node.id}</p>
         </div>
@@ -87,32 +89,35 @@ export class MyNode extends Node {
           {inputs.length > 0 && (
             <div className={css['connection-container']}>
               {inputs.map(input => (
-                <Tooltip title={`Input:${input.name}`} placement="left" enterDelay={500}>
-
-                  <div className={css['input']} key={input.key}>
-                    <div
-                      onMouseEnter={() => handleMouseEnter(input)}
-                      onMouseLeave={() => handleMouseLeave(input)}>
-                      <Socket
-                        type="input"
-                        socket={input.socket}
-                        io={input}
-                        innerRef={bindSocket}
-                      />
-
-                    </div>
-                    {!input.showControl() && (
-                      <div className="input-title">{input.name}</div>
-                    )}
-                    {input.showControl() && (
-                      <Control
-                        className="input-control"
-                        control={input.control}
-                        innerRef={bindControl}
-                      />
-                    )}
+                <div className={css['input']} key={input.key}>
+                  <div
+                    onMouseEnter={() => handleMouseEnter(input)}
+                    onMouseLeave={() => handleMouseLeave(input)}
+                  >
+                    <Socket
+                      type="input"
+                      socket={input.socket}
+                      io={input}
+                      innerRef={bindSocket}
+                    />
                   </div>
-                </Tooltip>
+                  {!input.showControl() && (
+                    <Tooltip
+                      title={`Input:${input.name}`}
+                      placement="left"
+                      enterDelay={500}
+                    >
+                      <div className="input-title">{input.name}</div>
+                    </Tooltip>
+                  )}
+                  {input.showControl() && (
+                    <Control
+                      className="input-control"
+                      control={input.control}
+                      innerRef={bindControl}
+                    />
+                  )}
+                </div>
               ))}
             </div>
           )}
@@ -122,23 +127,27 @@ export class MyNode extends Node {
                 <div className={css['output']} key={output.key}>
                   {typeof output != 'undefined' &&
                     output.connections.forEach(element => {
-                      element.data = { ...element.data, hello: 'hello' };
+                      element.data = { ...element.data, hello: 'hello' }
                     })}
-                  <div className="output-title">{output.name}</div>
-                  <Tooltip title={`output: ${output.name}`} placement="right" 
-                  enterDelay={500}
+                  <Tooltip
+                    title={`output: ${output.name}`}
+                    placement="right"
+                    enterDelay={500}
                   >
-                    <div
-                      onMouseEnter={() => handleMouseEnter(output)}
-                      onMouseLeave={() => handleMouseLeave(output)}>
-                      <Socket
-                        type="output"
-                        socket={output.socket}
-                        io={output}
-                        innerRef={bindSocket}
-                      />
-                    </div>
+                    <div className="output-title">{output.name}</div>
                   </Tooltip>
+
+                  <div
+                    onMouseEnter={() => handleMouseEnter(output)}
+                    onMouseLeave={() => handleMouseLeave(output)}
+                  >
+                    <Socket
+                      type="output"
+                      socket={output.socket}
+                      io={output}
+                      innerRef={bindSocket}
+                    />
+                  </div>
                 </div>
               ))}
             </div>
@@ -153,7 +162,7 @@ export class MyNode extends Node {
             />
           ))}
         </div>
-      </div >
-    );
+      </div>
+    )
   }
 }


### PR DESCRIPTION
## What Changed:

Implemented this approach:

`We may also want to consider having the tooltip occur when hovering over the name of the socket rather than the connection itself.`

I have changed the tooltip occur when hovering over the  connection itself to be on the name of the socket.

## How to test:

- Navigate to the `tooltip_socket_modify` and hover on the input and output name to see the changes

## Additional information:


https://github.com/Oneirocom/Magick/assets/55635977/78cdcdac-0d20-4759-b155-f201e8294879

