### PR TITLE
makes rootSpellId optional on agent creation

### DIFF
--- a/packages/core/shared/src/schemas.ts
+++ b/packages/core/shared/src/schemas.ts
@@ -55,7 +55,7 @@ export const agentSchema = Type.Object(
   {
     id: Type.String(),
     projectId: Type.String(),
-    rootSpellId: Type.String(),
+    rootSpellId: Type.Optional(Type.String()),
     name: Type.String(),
     enabled: Type.Optional(Type.Boolean()),
     runState: Type.Optional(Type.String()), // TODO: THe database restricts this to a set of values, but we don't have a way to express that in typebox afaik


### PR DESCRIPTION
This fixes some agent creation issues