### PR TITLE
adding collapse icon on all window tables

### DIFF
--- a/packages/core/client/src/components/Table/index.module.scss
+++ b/packages/core/client/src/components/Table/index.module.scss
@@ -31,6 +31,7 @@
   box-shadow: none !important;
   height: 2rem !important;
   width: 2rem !important;
+  padding: 1.4rem !important;
 }
 
 .tableCellBody {

--- a/packages/core/client/src/components/Table/index.tsx
+++ b/packages/core/client/src/components/Table/index.tsx
@@ -328,9 +328,12 @@ export const TableComponent = ({
                         ) : column.id === 'collapse' ? (
                           <IconButton
                             aria-label={isExpanded ? 'Collapse' : 'Expand'}
-                            size="small"
+                              size="medium"
                             className={styles.expandCollapse}
-                            onClick={() => handleRowClick(row.id || row.row.id)}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                handleRowClick(row.id || row.row.id)
+                              }}
                           >
                             {isExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
                           </IconButton>

--- a/packages/editor/src/screens/EventWindow/event.ts
+++ b/packages/editor/src/screens/EventWindow/event.ts
@@ -2,6 +2,7 @@ export interface Column {
   id:
     | 'action'
     | 'checkbox'
+    | 'collapse'
     | 'client'
     | 'sender'
     | 'content'
@@ -18,6 +19,7 @@ export interface Column {
 export const columns: Column[] = [
   { id: 'action', label: 'Actions', minWidth: 10 },
   { id: 'checkbox', label: '', minWidth: 10 },
+  { id: 'collapse', label: '', minWidth: 10 },
   { id: 'client', label: 'Client', minWidth: 65 },
   { id: 'sender', label: 'Sender', minWidth: 65 },
   { id: 'content', label: 'Content', minWidth: 65 },

--- a/packages/editor/src/screens/RequestWindow/requests.ts
+++ b/packages/editor/src/screens/RequestWindow/requests.ts
@@ -1,27 +1,29 @@
 export interface Column {
-    id:
-      | 'action'
-      | 'checkbox'
-      | 'provider'
-      | 'type'
-      | 'nodeId'
-      | 'cost'
-      | 'duration'
-      | 'status'
-      | 'statusCode'
-      | 'model'
-      | 'requestData'
-      | 'responseData'
-      | 'parameters'
-      | 'spell'
-    label: string
-    minWidth?: number
-    align?: 'right'
-  }
+  id:
+    | 'action'
+    | 'checkbox'
+    | 'collapse'
+    | 'provider'
+    | 'type'
+    | 'nodeId'
+    | 'cost'
+    | 'duration'
+    | 'status'
+    | 'statusCode'
+    | 'model'
+    | 'requestData'
+    | 'responseData'
+    | 'parameters'
+    | 'spell'
+  label: string
+  minWidth?: number
+  align?: 'right'
+}
   
   export const columns: Column[] = [
     { id: 'action', label: 'Actions', minWidth: 10 },
     { id: 'checkbox', label: '', minWidth: 10 },
+    { id: 'collapse', label: '', minWidth: 10 },
     { id: 'provider', label: 'Provider', minWidth: 65 },
     { id: 'type', label: 'Type', minWidth: 65 },
     { id: 'nodeId', label: 'Node ID', minWidth: 65 },
@@ -33,7 +35,7 @@ export interface Column {
     { id: 'requestData', label: 'Request Data', minWidth: 65 },
     { id: 'responseData', label: 'Response Data', minWidth: 65 },
     { id: 'parameters', label: 'Parameters', minWidth: 65 },
-    { id: 'spell', label: 'Spell', minWidth: 65  },
+    { id: 'spell', label: 'Spell', minWidth: 65 },
   ]
   
   export interface DocumentData {


### PR DESCRIPTION
## What Changed:

I added collapse functionality  to all tables column type file 

## How to test:

Navigate to any table to event , request or documents window and make sure there is some data available in them and the try click on collapse icon to view data in full form  

## Additional information:

[Screencast from 02.08.2023 18:33:01.webm](https://github.com/Oneirocom/Magick/assets/55635977/09aa2410-73db-4e49-b631-62427a0dc52a)

