### PR TITLE
add command parser node

### DIFF
--- a/packages/core/shared/src/nodes/flow/CommandParser.ts
+++ b/packages/core/shared/src/nodes/flow/CommandParser.ts
@@ -73,7 +73,6 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
     )
 
     const triggerOutput = new Rete.Output('trigger', 'Trigger', triggerSocket)
-    // const output = new Rete.Output('result', 'Result', stringSocket)
     const commandOutput = new Rete.Output('command', 'Command', stringSocket)
     const argsOutput = new Rete.Output('args', 'Arguments', arraySocket)
     const isCommandOutput = new Rete.Output(
@@ -147,7 +146,7 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
     outputs: MagickWorkerOutputs
   ) {
     const input = inputs.command[0] as string
-    const commandList = inputs.commandList as string[]
+    const commandList = inputs.commandList[0] as string[]
 
     const useCheckList = (node?.data?.useCheckList as boolean) ?? false
 

--- a/packages/core/shared/src/nodes/flow/CommandParser.ts
+++ b/packages/core/shared/src/nodes/flow/CommandParser.ts
@@ -1,0 +1,156 @@
+// UNDOCUMENTED
+import Rete from 'rete'
+import { MagickComponent } from '../../engine'
+import {
+  arraySocket,
+  booleanSocket,
+  stringSocket,
+  triggerSocket,
+} from '../../sockets'
+import {
+  MagickNode,
+  MagickWorkerInputs,
+  MagickWorkerOutputs,
+  WorkerData,
+} from '../../types'
+import { BooleanControl } from '../../dataControls/BooleanControl'
+
+/** Information related to the CommandParser */
+const info =
+  'Takes a string input and an optional string array of commands and parses it into a command, arguments and boolean indicating if it is a command.'
+
+/** Type definition for the worker return */
+type WorkerReturn = {
+  command?: string
+  args?: string[]
+  isCommand?: boolean
+}
+
+/**  Type definition for the parsed command */
+type ParsedCommand = {
+  command: string
+  args: string[]
+  isCommand: boolean
+}
+
+/**
+ * CommandParser component for parsing commands.
+ */
+export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
+  constructor() {
+    super(
+      'Command Parser',
+      {
+        outputs: {
+          trigger: 'option',
+          command: 'output',
+          args: 'output',
+          isCommand: 'output',
+        },
+      },
+      'Flow',
+      info
+    )
+  }
+
+  /**
+   * Builder for CommandParser.
+   * @param node - the MagickNode instance.
+   * @returns a configured node with sockets.
+   */
+  builder(node: MagickNode) {
+    const triggerInput = new Rete.Input(
+      'trigger',
+      'Trigger',
+      triggerSocket,
+      true
+    )
+    const command = new Rete.Input('command', 'Command', stringSocket)
+    const commandList = new Rete.Input(
+      'commandList',
+      'Command List',
+      arraySocket
+    )
+
+    const triggerOutput = new Rete.Output('trigger', 'Trigger', triggerSocket)
+    // const output = new Rete.Output('result', 'Result', stringSocket)
+    const commandOutput = new Rete.Output('command', 'Command', stringSocket)
+    const argsOutput = new Rete.Output('args', 'Arguments', arraySocket)
+    const isCommandOutput = new Rete.Output(
+      'isCommand',
+      'Is Command',
+      booleanSocket
+    )
+
+    node
+      .addInput(triggerInput)
+      .addInput(command)
+      .addInput(commandList)
+      .addOutput(triggerOutput)
+      .addOutput(commandOutput)
+      .addOutput(argsOutput)
+      .addOutput(isCommandOutput)
+
+    const useCheckList = new BooleanControl({
+      dataKey: 'useCheckList',
+      name: 'Use Check List',
+      icon: 'moon',
+      tooltip: 'Use the command list to check if the command is valid.',
+      defaultValue: true,
+    })
+
+    node.inspector.add(useCheckList)
+
+    return node
+  }
+
+  /**
+   * Parser for
+   * @param input - the user input.
+   * @param checkList - an array of strings of commands to check against.
+   * @param useCheckList - a boolean indicating whether to use the check list.
+   * @returns an object with isCommand, command, and args.
+   */
+  parseCommand(
+    input: string,
+    checkList: string[],
+    useCheckList: boolean
+  ): ParsedCommand {
+    let isCommand = false
+    let command = ''
+    let args: string[] = []
+
+    if (input.startsWith('/')) {
+      const inputArray = input.split(' ')
+      command = inputArray[0].substring(1)
+      args = inputArray.slice(1)
+      isCommand = useCheckList ? checkList.includes(command) : true
+    }
+
+    return {
+      isCommand,
+      command,
+      args,
+    }
+  }
+
+  /**
+   * Worker for processing the generated text.
+   * @param node - the worker data.
+   * @param inputs - worker inputs.
+   * @param outputs - worker outputs.
+   * @returns an object with the success status and result or error message.
+   */
+  async worker(
+    node: WorkerData,
+    inputs: MagickWorkerInputs,
+    outputs: MagickWorkerOutputs
+  ) {
+    const input = inputs.command[0] as string
+    const commandList = inputs.commandList as string[]
+
+    const useCheckList = (node?.data?.useCheckList as boolean) ?? false
+
+    return this.parseCommand(input, commandList, useCheckList)
+  }
+}

--- a/packages/core/shared/src/nodes/flow/CommandParser.ts
+++ b/packages/core/shared/src/nodes/flow/CommandParser.ts
@@ -14,6 +14,7 @@ import {
   WorkerData,
 } from '../../types'
 import { BooleanControl } from '../../dataControls/BooleanControl'
+import { InputControl } from '../../dataControls/InputControl'
 
 /** Information related to the CommandParser */
 const info =
@@ -97,8 +98,15 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
       tooltip: 'Use the command list to check if the command is valid.',
       defaultValue: true,
     })
+    const commandStarter = new InputControl({
+      dataKey: 'commandStarter',
+      name: 'Command Starter',
+      icon: 'moon',
+      tooltip: 'What characters to start your command with.',
+      defaultValue: '/',
+    })
 
-    node.inspector.add(useCheckList)
+    node.inspector.add(useCheckList).add(commandStarter)
 
     return node
   }
@@ -113,13 +121,14 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
   parseCommand(
     input: string,
     checkList: string[],
-    useCheckList: boolean
+    useCheckList: boolean,
+    commandStarter: string
   ): ParsedCommand {
     let isCommand = false
     let command = ''
     let args: string[] = []
 
-    if (input.startsWith('/')) {
+    if (input.startsWith(commandStarter)) {
       const inputArray = input.split(' ')
       command = inputArray[0].substring(1)
       args = inputArray.slice(1)
@@ -148,7 +157,8 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
     const input = inputs.command[0] as string
     const commandList = inputs?.commandList?.[0] as string[]
     const useCheckList = (node?.data?.useCheckList as boolean) ?? false
+    const commandStarter = (node?.data?.commandStarter as string) ?? '/'
 
-    return this.parseCommand(input, commandList, useCheckList)
+    return this.parseCommand(input, commandList, useCheckList, commandStarter)
   }
 }

--- a/packages/core/shared/src/nodes/flow/CommandParser.ts
+++ b/packages/core/shared/src/nodes/flow/CommandParser.ts
@@ -146,8 +146,7 @@ export class CommandParser extends MagickComponent<Promise<WorkerReturn>> {
     outputs: MagickWorkerOutputs
   ) {
     const input = inputs.command[0] as string
-    const commandList = inputs.commandList[0] as string[]
-
+    const commandList = inputs?.commandList?.[0] as string[]
     const useCheckList = (node?.data?.useCheckList as boolean) ?? false
 
     return this.parseCommand(input, commandList, useCheckList)

--- a/packages/core/shared/src/nodes/index.ts
+++ b/packages/core/shared/src/nodes/index.ts
@@ -84,6 +84,7 @@ import { Trim } from './text/Trim'
 import { GetLength } from './text/GetLength'
 import { UUIDGenerator } from './text/GenerateUUID'
 import { TypeChat } from './text/TypeChat'
+import { CommandParser } from './flow/CommandParser'
 
 export const components: Record<string, () => MagickComponent<unknown>> = {
   booleanGate: () => new BooleanGate(),
@@ -169,6 +170,7 @@ export const components: Record<string, () => MagickComponent<unknown>> = {
   jsonToArray: () => new JSONToArray(),
   generateUUID: () => new UUIDGenerator(),
   typeChat: () => new TypeChat(),
+  commandParser: () => new CommandParser(),
 }
 
 /**


### PR DESCRIPTION
## What Changed:

Adds a Command Parser that parses commands such with an optional string array of valid commands.
/command arg1 arg2
into outputs:
command: 'command'
args: ['arg1','arg2']
isCommand: boolean

## How to test:

Use the node