### PR TITLE
Adding Auto-save in Text Editor 

### DIFF
--- a/packages/editor/src/windows/TextEditorWindow/index.tsx
+++ b/packages/editor/src/windows/TextEditorWindow/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Window } from '@magickml/client-core';
+import { Window } from '@magickml/client-core';
 import Editor from '@monaco-editor/react';
 import { useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash';


### PR DESCRIPTION
## What Changed:

I added` debounce` function from the `lodash`  which is working with `useEffect` and it helps us to save data anytime something changes and it's done after 1 secs 

## How to test:

1. Add  Text Variable
2. Navigate to text-editor window 
3. type in any text 
4. refresh the page or visit a different node come back end see it the text is still there 

## Additional information:

Fixes: https://github.com/Oneirocom/Magick/issues/1210

[Screencast from 09.08.2023 14:26:38.webm](https://github.com/Oneirocom/Magick/assets/55635977/0b15c681-8e32-48ce-b31a-12f66c1cd5f4)
