### PR TITLE
Quiets logs and fixes agent startup on server cold start

### DIFF
--- a/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
+++ b/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
@@ -45,7 +45,7 @@ export class CloudAgentManager {
             this.logger.debug(`Adding agent ${agent.id} to cloud agent worker`)
             agentPromises.push(this.newQueue.addJob('agent:new', {
                 agentId: agent.id,
-            }, `agent-new-${agent.id}`))
+            }, `agent-new-${agent.id}-${new Date().getTime()}}`))
         }
 
         await Promise.all(agentPromises)
@@ -58,7 +58,6 @@ export class CloudAgentManager {
 
             this.logger.info(`Agent Updated: ${agent.id}`)
             const agentUpdatedAt = agent.updatedAt ? new Date(agent.updatedAt) : new Date()
-
 
             if (agent.enabled) {
                 this.logger.info(`Agent ${agent.id} enabled, adding to cloud agent worker`)
@@ -115,7 +114,7 @@ export class CloudAgentManager {
         })
 
         setInterval(async () => {
-            this.logger.info('Heartbeat')
+            this.logger.trace('Heartbeat')
             this.pubSub.publish('cloud-agent-manager:ping', "")
         }, 1000 * 60 * 5)
     }

--- a/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
+++ b/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
@@ -169,6 +169,7 @@ export class CloudAgentWorker extends AgentManager {
     new Worker(
       'agent:new',
       async (job: Job) => {
+        this.logger.info(`Starting agent ${job.data.agentId}`)
         this.agentUpdated(job.data.agentId)
       },
       {


### PR DESCRIPTION
## What Changed:

Changed the log level of heartbeats to "trace"

Agent startup messages on server cold start now contain timestamps. This ensures that we won't drop jobs if a job id matches a previous one.

## How to test:
Enable an agent then restart the server

Observe that the agent started

IMPORTANT: This will always work the first time, it's important to check a 2nd time so...

restart the server again and observe that the same enabled agent started up again.
