### PR TITLE
changes server proc name to web as per heroku's requirements

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-server: npm run start-server
+web: npm run start-server
 worker: npm run start-cloud-agent-worker
 manager: npm run start-cloud-agent-manager


### PR DESCRIPTION
Heroku wants the service recieving HTTP traffic to be named "web" instead of "server"

This just changes that.

https://devcenter.heroku.com/articles/procfile#the-release-process-type