### PR TITLE
Fix autosave on Text editor

### DIFF
--- a/packages/editor/src/windows/TextEditorWindow/index.tsx
+++ b/packages/editor/src/windows/TextEditorWindow/index.tsx
@@ -14,7 +14,6 @@ const TextEditor = props => {
     minimap: { enabled: false },
   })
   const [unSavedChanges, setUnSavedChanged] = useState<boolean>(false)
-  const codeRef = useRef<string>()
 
   const { textEditorData, saveTextEditor, inspectorData } = useInspector()
 
@@ -48,13 +47,11 @@ const TextEditor = props => {
     if (!unSavedChanges) setUnSavedChanged(true)
     const code = rawCode.replace('\r\n', '\n')
     setCode(code)
-    codeRef.current = code; // Update codeRef immediately
     save(code); // Call the debounced save function
   }
 
   const setCode = update => {
     setCodeState(update)
-    codeRef.current = update
   }
 
   if (!textEditorData?.control)


### PR DESCRIPTION
## What Changed:

Use custom debounce instead of the one i had used before from lodash 

## How to test:

1. open any spell
2. add multiple Text variable nodes
3. add text to each Text variable Node using Text Editor
4.  try playing with the spell and see if the text still get saved there

## Additional information:


https://github.com/Oneirocom/Magick/assets/55635977/f7c87a86-afcc-423d-815f-50b79e61ccfd


