### PR TITLE
create network on compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,3 @@ volumes:
 networks:
   default:
     name: magick-network
-    external: true


### PR DESCRIPTION
## What Changed:

creates network on docker compose up

## How to test:

### if you have the network already running:
docker network rm magick-network
### then
docker compose up -d
### then
docker network ls