### PR TITLE
Text editor

### DIFF
--- a/packages/core/server/src/api/index.ts
+++ b/packages/core/server/src/api/index.ts
@@ -1,48 +1,45 @@
-// DOCUMENTED 
-import { SpellInterface, SpellError } from '@magickml/core';
-import { app } from '../app';
-import Koa from 'koa';
-import otJson0 from 'ot-json0';
+// DOCUMENTED
+import { SpellInterface, SpellError } from '@magickml/core'
+import { app } from '../app'
+import Koa from 'koa'
+import otJson0 from 'ot-json0'
 
-import { Route } from '../config/types';
+import { Route } from '../config/types'
 
-import md5 from 'md5';
+import md5 from 'md5'
 
 /**
  * Saves a diff of a spell and updates it.
  * @param {Koa.Context} ctx - The Koa context of the request.
  */
 const saveDiffHandler = async (ctx: Koa.Context): Promise<void> => {
-  const { body } = ctx.request;
-  const { name, diff, projectId } = body as any;
+  const { body } = ctx.request
+  const { name, diff, projectId } = body as any
 
-  if (!body) throw new SpellError('input-failed', 'No parameters provided');
+  if (!body) throw new SpellError('input-failed', 'No parameters provided')
 
-  const spell = await app.service('spells').find({ query: { projectId, name } });
+  const spell = await app.service('spells').find({ query: { projectId, name } })
 
   if (!spell)
-    throw new SpellError('input-failed', `No spell with ${name} name found.`);
+    throw new SpellError('input-failed', `No spell with ${name} name found.`)
   if (!diff)
-    throw new SpellError('input-failed', 'No diff provided in request body');
+    throw new SpellError('input-failed', 'No diff provided in request body')
 
-  const spellUpdate = otJson0.type.apply(spell, diff);
+  const spellUpdate = otJson0.type.apply(spell, diff)
 
   if (Object.keys((spellUpdate as SpellInterface).graph.nodes).length === 0)
-    throw new SpellError(
-      'input-failed',
-      'Graph would be cleared.  Aborting.'
-    );
+    throw new SpellError('input-failed', 'Graph would be cleared.  Aborting.')
 
-  const hash = md5(JSON.stringify(spellUpdate.graph.nodes));
+  const hash = md5(JSON.stringify(spellUpdate.graph.nodes))
 
   // In feathers.js, get the spells service and update the spell with the name of 'name'.
   const updatedSpell = await app
     .service('spells')
-    .update(name, { ...spellUpdate, hash });
+    .update(name, { ...spellUpdate, hash })
 
-  ctx.response.status = 200;
-  ctx.body = updatedSpell;
-};
+  ctx.response.status = 200
+  ctx.body = updatedSpell
+}
 
 /**
  * Export the spells routes for use in other modules.
@@ -52,4 +49,4 @@ export const spells: Route[] = [
     path: '/spells/saveDiff',
     post: saveDiffHandler,
   },
-];
+]

--- a/packages/core/server/src/app.ts
+++ b/packages/core/server/src/app.ts
@@ -70,7 +70,9 @@ export async function initApp() {
   app.use(cors({ origin: '*' }))
   app.use(errorHandler())
   app.use(parseAuthentication())
-  app.use(bodyParser({ jsonLimit: '200mb', formLimit: '200mb', multipart: true }))
+  app.use(
+    bodyParser({ jsonLimit: '200mb', formLimit: '200mb', multipart: true })
+  )
 
   // Initialize pubsub redis client
   const pubsub = new RedisPubSub()
@@ -92,7 +94,7 @@ export async function initApp() {
 
   const redis = new Redis({
     ...bullMQConnection,
-    maxRetriesPerRequest: null
+    maxRetriesPerRequest: null,
   })
   app.set('redis', redis)
 

--- a/packages/core/shared/src/plugins/inspectorPlugin/index.ts
+++ b/packages/core/shared/src/plugins/inspectorPlugin/index.ts
@@ -1,68 +1,68 @@
-// DOCUMENTED 
-import { MagickComponent } from '../../engine';
-import { IRunContextEditor, MagickNode } from '../../types';
-import { HandleDataArgs, Inspector } from './Inspector';
+// DOCUMENTED
+import { MagickComponent } from '../../engine'
+import { IRunContextEditor, MagickNode } from '../../types'
+import { HandleDataArgs, Inspector } from './Inspector'
 
 /**
  * Install the inspector plugin to the editor
  * @param {IRunContextEditor} editor - The editor instance where the plugin will be installed
  */
 function install(editor: IRunContextEditor): void {
-  const { onInspector, sendToInspector, clearTextEditor } = editor.context;
+  const { onInspector, sendToInspector, clearTextEditor } = editor.context
 
   // Register a new component
   editor.on('componentregister', (component: MagickComponent<unknown>) => {
-    const builder = component.builder;
+    const builder = component.builder
 
     if (!component.info)
       return console.error(
         'All components must contain an info property describing the component to the end user.'
-      );
+      )
 
     // Override the default builder with a custom one, invoking the original builder inside it
     component.builder = (node: MagickNode) => {
       // Initialize an Inspector instance to handle registering data controls, serialization, etc.
-      node.inspector = new Inspector({ component, editor, node });
+      node.inspector = new Inspector({ component, editor, node })
 
       // Set node properties
-      node.category = component.category;
-      node.displayName = component.displayName;
-      node.info = component.info;
+      node.category = component.category
+      node.displayName = component.displayName
+      node.info = component.info
 
       // Attach the default info control to the component to display in the inspector
       if (onInspector) {
-        node.subscription = onInspector(node, (data) => {
-          node.inspector.handleData(data as HandleDataArgs);
-          editor.trigger('nodecreated', node);
-        });
+        node.subscription = onInspector(node, data => {
+          node.inspector.handleData(data as HandleDataArgs)
+          editor.trigger('nodecreated', node)
+        })
       }
 
       // Call the original builder
-      builder.call(component, node);
-    };
-  });
+      builder.call(component, node)
+    }
+  })
 
-  let currentNode: MagickNode | undefined;
+  let currentNode: MagickNode | undefined
 
   // Handle publishing and subscribing to the inspector
   editor.on('nodeselect', (node: MagickNode) => {
     // Do nothing if the selected node is the same as the current one
-    if (currentNode && node.id === currentNode.id) return;
-    if (!clearTextEditor || !sendToInspector) return;
+    if (currentNode && node.id === currentNode.id) return
+    if (!clearTextEditor || !sendToInspector) return
 
     // Update the current node and clear the text editor
-    currentNode = node;
-    clearTextEditor();
-    sendToInspector(node.inspector.data());
-  });
+    currentNode = node
+    clearTextEditor()
+    sendToInspector(node.inspector.data())
+  })
 }
 
-export { DataControl } from './DataControl';
+export { DataControl } from './DataControl'
 
 // Default export object
 const defaultExport = {
   name: 'inspector',
   install,
-};
+}
 
-export default defaultExport;
+export default defaultExport

--- a/packages/core/shared/src/plugins/keyCodePlugin/index.ts
+++ b/packages/core/shared/src/plugins/keyCodePlugin/index.ts
@@ -1,4 +1,4 @@
-// DOCUMENTED 
+// DOCUMENTED
 /**
  * The `IRunContextEditor` interface specifies the shape of objects that represent a magick editor context.
  * @interface

--- a/packages/editor/src/components/EventHandler.tsx
+++ b/packages/editor/src/components/EventHandler.tsx
@@ -7,7 +7,7 @@ import md5 from 'md5'
 
 import {
   useLazyGetSpellByIdQuery,
-  useSaveSpellMutation,
+  useSaveSpellMutation
 } from '../state/api/spells'
 import { useLayout } from '../contexts/LayoutProvider'
 import { useEditor } from '../contexts/EditorProvider'
@@ -29,6 +29,7 @@ const EventHandler = ({ pubSub, tab }) => {
   const { enqueueSnackbar } = useSnackbar()
 
   const [saveSpellMutation] = useSaveSpellMutation()
+
   // TODO: is this a bug?
   const [getSpell, { data: spell }] = useLazyGetSpellByIdQuery({
     spellName: tab.name.split('--')[0],
@@ -47,7 +48,7 @@ const EventHandler = ({ pubSub, tab }) => {
       id: tab.id,
       projectId: config.projectId,
     })
-  }, [config.projectId, getSpell, tab.id, tab.name])
+  }, [config.projectId, getSpell, tab.id, tab.name, tab])
 
   useEffect(() => {
     if (!spell) return

--- a/packages/editor/src/components/EventHandler.tsx
+++ b/packages/editor/src/components/EventHandler.tsx
@@ -48,7 +48,7 @@ const EventHandler = ({ pubSub, tab }) => {
       id: tab.id,
       projectId: config.projectId,
     })
-  }, [config.projectId, getSpell, tab.id, tab.name, tab])
+  }, [config.projectId, getSpell, tab])
 
   useEffect(() => {
     if (!spell) return

--- a/packages/editor/src/components/TabBar/TabBar.tsx
+++ b/packages/editor/src/components/TabBar/TabBar.tsx
@@ -10,7 +10,7 @@ import css from './tabBar.module.css'
 import { closeTab, selectAllTabs } from '../../state/tabs'
 import { changeActive } from '../../state/tabs'
 import { RootState } from '../../state/store'
-import { Icon } from '@magickml/client-core'
+import { Icon, usePubSub } from '@magickml/client-core'
 
 /**
  * Tab Component
@@ -22,6 +22,7 @@ const Tab = ({ tab, activeTab }) => {
   const navigate = useNavigate()
   const tabs = useSelector((state: RootState) => selectAllTabs(state.tabs))
   const active = tab.id === activeTab?.id
+  const { events, publish } = usePubSub()
 
   const title = `${tab.name.split('--')[0]}`
   const tabClass = classnames({
@@ -39,19 +40,20 @@ const Tab = ({ tab, activeTab }) => {
     const updatedTabs = tabs.map(t =>
       t.id === tab.id
         ? {
-            id: t.id,
-            changes: {
-              active: true,
-            },
-          }
+          id: t.id,
+          changes: {
+            active: true,
+          },
+        }
         : {
-            id: t.id,
-            changes: {
-              active: false,
-            },
-          }
+          id: t.id,
+          changes: {
+            active: false,
+          },
+        }
     )
     dispatch(changeActive(updatedTabs))
+    publish(events.$TEXT_EDITOR_CLEAR(tab.id))
     navigate(`/magick/${tab.URI}`)
   }
 

--- a/packages/editor/src/contexts/InspectorProvider.tsx
+++ b/packages/editor/src/contexts/InspectorProvider.tsx
@@ -2,6 +2,7 @@
 import { usePubSub } from '@magickml/client-core';
 import { InspectorData, SupportedLanguages } from '@magickml/core';
 import { createContext, useContext, useEffect, useState } from 'react';
+import { useEditor } from './EditorProvider';
 
 /**
  * TextEditorData represents the state and options for the text editor.
@@ -41,7 +42,7 @@ const InspectorProvider = ({ children, tab }) => {
 
   const [inspectorData, setInspectorData] = useState<InspectorData | null>(null)
   const [textEditorData, setTextEditorData] = useState({})
-
+  const { editor, serialize } = useEditor()
   const SET_INSPECTOR = events.$INSPECTOR_SET(tab.id)
 
   // Subscribe to inspector changes
@@ -54,7 +55,6 @@ const InspectorProvider = ({ children, tab }) => {
       setInspectorData(data)
 
       if (!data.dataControls) return
-
       // Handle components
       Object.entries(data.dataControls).forEach(([, control]) => {
         if (control?.options?.editor) {
@@ -66,6 +66,7 @@ const InspectorProvider = ({ children, tab }) => {
             control: control,
             options: control.options,
           }
+          console.log("}}}}}}}}}}}}}}}}}}}}}}}}", textData)
 
           setTextEditorData(textData)
         }
@@ -73,19 +74,20 @@ const InspectorProvider = ({ children, tab }) => {
     })
 
     return unsubscribe as () => void
-  }, [events, subscribe, publish])
+  }, [events, subscribe, publish, inspectorData])
 
   // Subscribe to text editor changes
   useEffect(() => {
     const unsubscribe = subscribe(
       events.$TEXT_EDITOR_SET(tab.id),
       (event, data) => {
+        console.log(":::::::::::::::::::::::::::", data)
         setTextEditorData(data)
       }
     )
 
     return unsubscribe as () => void
-  }, [events, subscribe, publish])
+  }, [events, subscribe, publish, inspectorData])
 
   // Subscribe to text editor clearing
   useEffect(() => {
@@ -113,6 +115,7 @@ const InspectorProvider = ({ children, tab }) => {
     }
 
     publish(events.$NODE_SET(tab.id, textData.nodeId), update)
+    publish(events.$SAVE_SPELL_DIFF(tab.id), { graph: serialize() })
     if (inspectorData) {
       setInspectorData(update)
     }

--- a/packages/editor/src/contexts/InspectorProvider.tsx
+++ b/packages/editor/src/contexts/InspectorProvider.tsx
@@ -42,7 +42,7 @@ const InspectorProvider = ({ children, tab }) => {
 
   const [inspectorData, setInspectorData] = useState<InspectorData | null>(null)
   const [textEditorData, setTextEditorData] = useState({})
-  const { editor, serialize } = useEditor()
+  const { serialize } = useEditor()
   const SET_INSPECTOR = events.$INSPECTOR_SET(tab.id)
 
   // Subscribe to inspector changes
@@ -66,25 +66,10 @@ const InspectorProvider = ({ children, tab }) => {
             control: control,
             options: control.options,
           }
-          console.log("}}}}}}}}}}}}}}}}}}}}}}}}", textData)
-
           setTextEditorData(textData)
         }
       })
     })
-
-    return unsubscribe as () => void
-  }, [events, subscribe, publish, inspectorData])
-
-  // Subscribe to text editor changes
-  useEffect(() => {
-    const unsubscribe = subscribe(
-      events.$TEXT_EDITOR_SET(tab.id),
-      (event, data) => {
-        console.log(":::::::::::::::::::::::::::", data)
-        setTextEditorData(data)
-      }
-    )
 
     return unsubscribe as () => void
   }, [events, subscribe, publish, inspectorData])

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -230,10 +230,10 @@ export const initEditor = function ({
 
   // Functions to load and run spells
   editor.loadSpell = async (spell: SpellInterface) => {
-    console.log('Loading spell in editor')
     if (!spell) return console.error('No spell to load')
     const _graph = spell.graph
     const graph = JSON.parse(JSON.stringify(_graph))
+    console.log('Loading spell in editor###########################', graph)
     await engine.abort()
     editor.fromJSON(graph)
 

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -233,7 +233,6 @@ export const initEditor = function ({
     if (!spell) return console.error('No spell to load')
     const _graph = spell.graph
     const graph = JSON.parse(JSON.stringify(_graph))
-    console.log('Loading spell in editor###########################', graph)
     await engine.abort()
     editor.fromJSON(graph)
 

--- a/packages/editor/src/windows/TextEditorWindow/index.tsx
+++ b/packages/editor/src/windows/TextEditorWindow/index.tsx
@@ -1,6 +1,6 @@
-import { Button, Window } from '@magickml/client-core'
+import { Window } from '@magickml/client-core'
 import Editor from '@monaco-editor/react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import '../../screens/Magick/magick.module.css'
 import WindowMessage from '../../components/WindowMessage'
 import { TextEditorData, useInspector } from '../../contexts/InspectorProvider'
@@ -13,7 +13,6 @@ const TextEditor = props => {
     wordWrap: 'on',
     minimap: { enabled: false },
   })
-  const [unSavedChanges, setUnSavedChanged] = useState<boolean>(false)
 
   const { textEditorData, saveTextEditor, inspectorData } = useInspector()
 
@@ -44,7 +43,6 @@ const TextEditor = props => {
   }, 1000); // Set the debounce delay as needed (in milliseconds)
 
   const updateCode = rawCode => {
-    if (!unSavedChanges) setUnSavedChanged(true)
     const code = rawCode.replace('\r\n', '\n')
     setCodeState(code)
     save(code); // Call the debounced save function

--- a/packages/editor/src/windows/TextEditorWindow/index.tsx
+++ b/packages/editor/src/windows/TextEditorWindow/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import '../../screens/Magick/magick.module.css'
 import WindowMessage from '../../components/WindowMessage'
 import { TextEditorData, useInspector } from '../../contexts/InspectorProvider'
+import { debounce } from '../../utils/debounce'
 
 const TextEditor = props => {
   const [code, setCodeState] = useState<string | undefined>(undefined)
@@ -13,7 +14,6 @@ const TextEditor = props => {
     minimap: { enabled: false },
   })
   const [unSavedChanges, setUnSavedChanged] = useState<boolean>(false)
-  const codeRef = useRef<string>()
 
   const { textEditorData, saveTextEditor, inspectorData } = useInspector()
 
@@ -31,66 +31,31 @@ const TextEditor = props => {
 
   useEffect(() => {
     setData(textEditorData)
-    setCode(textEditorData.data)
+    setCodeState(textEditorData?.data)
   }, [textEditorData])
 
-  const save = code => {
+  const save = debounce((code) => {
     const update = {
       ...data,
       data: code,
     }
     setData(update)
     saveTextEditor(update)
-  }
-
-  const onSave = () => {
-    setUnSavedChanged(false)
-    save(codeRef.current)
-  }
+  }, 1000); // Set the debounce delay as needed (in milliseconds)
 
   const updateCode = rawCode => {
     if (!unSavedChanges) setUnSavedChanged(true)
     const code = rawCode.replace('\r\n', '\n')
-    setCode(code)
-    const update = {
-      ...data,
-      data: code,
-    }
-    setData(update)
+    setCodeState(code)
+    save(code); // Call the debounced save function
   }
 
-  const setCode = update => {
-    setCodeState(update)
-    codeRef.current = update
-  }
-
-  const toolbar = (
-    <>
-      <div style={{ marginTop: 'var(--c1)' }}>
-        {textEditorData?.name && textEditorData?.name}
-      </div>
-      <Button onClick={onSave}>
-        SAVE
-        {unSavedChanges && (
-          <span
-            style={{
-              width: '6px',
-              height: '6px',
-              background: '#fff',
-              borderRadius: '50%',
-              marginLeft: '2px',
-            }}
-          />
-        )}
-      </Button>
-    </>
-  )
 
   if (!textEditorData?.control)
     return <WindowMessage content="Select a node with a text field" />
 
   return (
-    <Window key={inspectorData?.nodeId} toolbar={toolbar}>
+    <Window key={inspectorData?.nodeId}>
       <Editor
         theme="sds-dark"
         // height={height} // This seemed to have been causing issues.


### PR DESCRIPTION
## What Changed:

- Save spell difference when text editor data changed
- Publish text editor clear on tab change
- Auto save in text editor

## How to test:

- open more than one spells
- changed text editor data in one spell and keep switching between different spell tab to see if you lost data

## Additional information:

Any other information that might be useful while reviewing.
