### PR TITLE
bubbles up agent errors to http api calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@feathersjs/authentication": "5.0.8",
         "@feathersjs/client": "5.0.8",
         "@feathersjs/configuration": "5.0.8",
-        "@feathersjs/errors": "5.0.8",
+        "@feathersjs/errors": "^5.0.8",
         "@feathersjs/express": "5.0.8",
         "@feathersjs/feathers": "5.0.8",
         "@feathersjs/knex": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@feathersjs/authentication": "5.0.8",
     "@feathersjs/client": "5.0.8",
     "@feathersjs/configuration": "5.0.8",
-    "@feathersjs/errors": "5.0.8",
+    "@feathersjs/errors": "^5.0.8",
     "@feathersjs/express": "5.0.8",
     "@feathersjs/feathers": "5.0.8",
     "@feathersjs/knex": "5.0.8",

--- a/packages/agents/src/lib/Agent.ts
+++ b/packages/agents/src/lib/Agent.ts
@@ -8,6 +8,7 @@ import {
   getLogger,
   MagickSpellInput,
   AGENT_RUN_RESULT,
+  AGENT_RUN_ERROR,
   AGENT_LOG,
   AGENT_WARN,
   AGENT_ERROR,
@@ -205,23 +206,35 @@ export class Agent implements AgentInterface {
 
     const spellRunner = await this.spellManager.loadById(data.spellId)
 
-    // Do we want a debug logger here?
-    const output = await spellRunner.runComponent({
-      agent: this,
-      secrets: this.secrets,
-      publicVariables: this.publicVariables,
-      runSubspell: data.runSubspell,
-      app,
-      ...data,
-    })
+    try {
+      this.logger.debug({ spellId: data.spellId, agent: { name: this.name, id: this.id } }, "Running agent's spell")
+      const output = await spellRunner.runComponent({
+        agent: this,
+        secrets: this.secrets,
+        publicVariables: this.publicVariables,
+        runSubspell: data.runSubspell,
+        app,
+        ...data,
+      })
 
-    this.publishEvent(AGENT_RUN_RESULT(this.id), {
-      jobId: job.data.jobId,
-      agentId: this.id,
-      projectId: this.projectId,
-      originalData: data,
-      result: output,
-    })
+      this.publishEvent(AGENT_RUN_RESULT(this.id), {
+        jobId: job.data.jobId,
+        agentId: this.id,
+        projectId: this.projectId,
+        originalData: data,
+        result: output,
+      })
+    } catch (err) {
+      this.logger.error({ spellId: data.spellId, agent: { name: this.name, id: this.id } }, 'Error running agent spell: %o', err)
+
+      this.publishEvent(AGENT_RUN_ERROR(this.id), {
+        jobId: job.data.jobId,
+        agentId: this.id,
+        projectId: this.projectId,
+        originalData: data,
+        result: { "error": err.message },
+      })
+    }
   }
 }
 

--- a/packages/core/shared/src/communication/agentEventTypes.ts
+++ b/packages/core/shared/src/communication/agentEventTypes.ts
@@ -1,3 +1,4 @@
+export const AGENT_RUN_ERROR = (agentId: string) => `agent:${agentId}:run:error`
 export const AGENT_RUN_RESULT = (agentId: string) => `agent:${agentId}:run:result`
 export const AGENT_LOG = (agentId: string) => `agent:${agentId}:log`
 export const AGENT_WARN = (agentId: string) => `agent:${agentId}:warn`

--- a/packages/core/shared/src/spellManager/SpellRunner.ts
+++ b/packages/core/shared/src/spellManager/SpellRunner.ts
@@ -325,15 +325,9 @@ class SpellRunner {
     // subscribe to a run pubsub and then we just use that.  This would treat running
     // from a trigger in node like any other data stream. Or even just pass in socket IO.
     //
+    await component.run(triggeredNode as unknown as MagickNode, inputs)
 
-    try {
-      await component.run(triggeredNode as unknown as MagickNode, inputs)
-      return this.outputData
-    } catch (err) {
-      this.logger.error('ERROR RUNNING SPELL, %o', err)
-
-      throw err
-    }
+    return this.outputData
   }
 }
 

--- a/packages/plugins/rest/server/src/services/api/api.class.ts
+++ b/packages/plugins/rest/server/src/services/api/api.class.ts
@@ -53,8 +53,8 @@ const getAgent = async (agentId: string, apiKey: string): Promise<Agent> => {
 
 export class ApiService<ServiceParams extends ApiParams = ApiParams>
   implements
-    ServiceInterface<ApiResponse | ApiError, ApiData, ServiceParams, ApiPatch>
-{
+ServiceInterface<ApiResponse | ApiError, ApiData, ServiceParams, ApiPatch>
+  {
   logger: pino.Logger = getLogger()
 
   // GET
@@ -87,55 +87,58 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
         }
       })
 
-        return {
-          result: result as object
-        }
-      } catch (err) {
-        this.logger.error("Error in ApiService.get: %s", err)
-        throw new GeneralError({
-          error: err
-        })
+      return {
+        result: result as object
       }
+    } catch (err) {
+      this.logger.error("Error in ApiService.get: %s", err)
+      throw new GeneralError({
+        error: err
+      })
     }
+  }
 
-    async create(data: ApiData, params: ServiceParams): Promise<ApiResponse | ApiError> {
-      const { spellId, content } = params.query as ApiData
+  async create(
+    data: ApiData,
+    params: ServiceParams
+  ): Promise<ApiResponse | ApiError> {
+    const { content } = data;
+    const spellId = data?.spellId
 
-      const agentCommander = app.get('agentCommander')
+    const agent = await getAgent(data.agentId, (params?.headers && params.headers['authorization']) as string)
 
-      // little hack since we dynamically add agents to the params in the hooks
-      const agent = (params as unknown as { agent: Agent }).agent
+    const agentCommander = app.get('agentCommander')
 
-      try {
-        const result = await agentCommander.runSpellWithResponse({
-          agent,
-          spellId,
-          inputs: {
-            [`Input - REST API (POST)`]: {
-              connector: "REST API (POST)",
-              content,
-              sender: 'api',
-              observer: agent.name,
-              client: 'rest',
-              channel: 'rest',
-              agentId: agent.id,
-              entities: ['api', agent.name],
-              channelType: 'POST',
-              rawData: "{}"
-            },
-            publicVariables: agent.publicVariables,
-            runSubspell: true
-          }
-        })
+    try {
+      const result = await agentCommander.runSpellWithResponse({
+        agent,
+        spellId,
+        inputs: {
+          [`Input - REST API (POST)`]: {
+            connector: 'REST API (POST)',
+            content,
+            sender: 'api',
+            observer: agent.name,
+            client: 'rest',
+            channel: 'rest',
+            agentId: agent.id,
+            entities: ['api', agent.name],
+            channelType: 'POST',
+            rawData: '{}',
+          },
+          publicVariables: agent.publicVariables,
+          runSubspell: true,
+        },
+      })
 
-        return {
-          result: result as object
-        }
-      } catch (err) {
-        this.logger.error("Error in ApiService.create: %s", err)
-        throw new GeneralError({
-          error: err
-        })
+      return {
+        result: result as object,
+      }
+    } catch (err) {
+      this.logger.error('Error in ApiService.create: %s', err)
+      throw new GeneralError({
+        error: err,
+      })
     }
   }
 

--- a/packages/plugins/rest/server/src/services/api/api.class.ts
+++ b/packages/plugins/rest/server/src/services/api/api.class.ts
@@ -6,8 +6,11 @@
 import { Application, app } from '@magickml/server-core'
 import type { Agent } from '@magickml/agents'
 import type { Params, ServiceInterface } from '@feathersjs/feathers'
+import { GeneralError } from '@feathersjs/errors'
 import type { Api, ApiData, ApiPatch, ApiQuery } from './api.schema'
 import { BadRequest, NotFound } from '@feathersjs/errors/lib'
+import { pino } from 'pino'
+import { getLogger } from '@magickml/core'
 
 export type { Api, ApiData, ApiPatch, ApiQuery }
 
@@ -52,6 +55,8 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
   implements
     ServiceInterface<ApiResponse | ApiError, ApiData, ServiceParams, ApiPatch>
 {
+  logger: pino.Logger = getLogger()
+
   // GET
   async get(agentId: string, params: ServiceParams): Promise<ApiResponse | ApiError> {
     const { spellId, content } = params.query as ApiData
@@ -60,29 +65,77 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
 
     const agentCommander = app.get('agentCommander')
 
-    const result = await agentCommander.runSpellWithResponse({
-      agent,
-      spellId,
-      inputs: {
-        [`Input - REST API (GET)`]: {
-          connector: 'REST API (GET)',
-          content,
-          sender: 'api',
-          observer: agent.name,
-          client: 'rest',
-          channel: 'rest',
-          agentId: agent.id,
-          entities: ['api', agent.name],
-          channelType: 'GET',
-          rawData: '{}',
-        },
-        publicVariables: agent.publicVariables,
-        runSubspell: true,
-      },
-    })
+    try {
+      const result = await agentCommander.runSpellWithResponse({
+        agent,
+        spellId,
+        inputs: {
+          [`Input - REST API (GET)`]: {
+            connector: "REST API (GET)",
+            content,
+            sender: 'api',
+            observer: agent.name,
+            client: 'rest',
+            channel: 'rest',
+            agentId: agent.id,
+            entities: ['api', agent.name],
+            channelType: 'GET',
+            rawData: "{}"
+          },
+          publicVariables: agent.publicVariables,
+          runSubspell: true
+        }
+      })
 
-    return {
-      result: result as object,
+        return {
+          result: result as object
+        }
+      } catch (err) {
+        this.logger.error("Error in ApiService.get: %s", err)
+        throw new GeneralError({
+          error: err
+        })
+      }
+    }
+
+    async create(data: ApiData, params: ServiceParams): Promise<ApiResponse | ApiError> {
+      const { spellId, content } = params.query as ApiData
+
+      const agentCommander = app.get('agentCommander')
+
+      // little hack since we dynamically add agents to the params in the hooks
+      const agent = (params as unknown as { agent: Agent }).agent
+
+      try {
+        const result = await agentCommander.runSpellWithResponse({
+          agent,
+          spellId,
+          inputs: {
+            [`Input - REST API (POST)`]: {
+              connector: "REST API (POST)",
+              content,
+              sender: 'api',
+              observer: agent.name,
+              client: 'rest',
+              channel: 'rest',
+              agentId: agent.id,
+              entities: ['api', agent.name],
+              channelType: 'POST',
+              rawData: "{}"
+            },
+            publicVariables: agent.publicVariables,
+            runSubspell: true
+          }
+        })
+
+        return {
+          result: result as object
+        }
+      } catch (err) {
+        this.logger.error("Error in ApiService.create: %s", err)
+        throw new GeneralError({
+          error: err
+        })
     }
   }
 
@@ -97,29 +150,36 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
 
     const agentCommander = app.get('agentCommander')
 
-    const result = await agentCommander.runSpellWithResponse({
-      agent,
-      spellId,
-      inputs: {
-        [`Input - REST API (POST)`]: {
-          connector: 'REST API (POST)',
-          content,
-          sender: 'api',
-          observer: agent.name,
-          client: 'rest',
-          channel: 'rest',
-          agentId: agent.id,
-          entities: ['api', agent.name],
-          channelType: 'POST',
-          rawData: '{}',
+    try {
+      const result = await agentCommander.runSpellWithResponse({
+        agent,
+        spellId,
+        inputs: {
+          [`Input - REST API (POST)`]: {
+            connector: 'REST API (POST)',
+            content,
+            sender: 'api',
+            observer: agent.name,
+            client: 'rest',
+            channel: 'rest',
+            agentId: agent.id,
+            entities: ['api', agent.name],
+            channelType: 'POST',
+            rawData: '{}',
+          },
+          publicVariables: agent.publicVariables,
+          runSubspell: true,
         },
-        publicVariables: agent.publicVariables,
-        runSubspell: true,
-      },
-    })
+      })
 
-    return {
-      result: result as object,
+      return {
+        result: result as object,
+      }
+    } catch (err) {
+      this.logger.error('Error in ApiService.create: %s', err)
+      throw new GeneralError({
+        error: err,
+      })
     }
   }
 
@@ -135,29 +195,36 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
 
     const agentCommander = app.get('agentCommander')
 
-    const result = await agentCommander.runSpellWithResponse({
-      agent,
-      spellId,
-      inputs: {
-        [`Input - REST API (UPDATE)`]: {
-          connector: 'REST API (UPDATE)',
-          content,
-          sender: 'api',
-          observer: agent.name,
-          client: 'rest',
-          channel: 'rest',
-          agentId: agent.id,
-          entities: ['api', agent.name],
-          channelType: 'UPDATE',
-          rawData: '{}',
+    try {
+      const result = await agentCommander.runSpellWithResponse({
+        agent,
+        spellId,
+        inputs: {
+          [`Input - REST API (UPDATE)`]: {
+            connector: 'REST API (UPDATE)',
+            content,
+            sender: 'api',
+            observer: agent.name,
+            client: 'rest',
+            channel: 'rest',
+            agentId: agent.id,
+            entities: ['api', agent.name],
+            channelType: 'UPDATE',
+            rawData: '{}',
+          },
+          publicVariables: agent.publicVariables,
+          runSubspell: true,
         },
-        publicVariables: agent.publicVariables,
-        runSubspell: true,
-      },
-    })
+      })
 
-    return {
-      result: result as object,
+      return {
+        result: result as object,
+      }
+    } catch (err) {
+      this.logger.error('Error in ApiService.update: %s', err)
+      throw new GeneralError({
+        error: err,
+      })
     }
   }
 
@@ -171,29 +238,36 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
 
     const agentCommander = app.get('agentCommander')
 
-    const result = await agentCommander.runSpellWithResponse({
-      agent,
-      spellId,
-      inputs: {
-        [`Input - REST API (DELETE)`]: {
-          connector: 'REST API (DELETE)',
-          content,
-          sender: 'api',
-          observer: agent.name,
-          client: 'rest',
-          channel: 'rest',
-          agentId: agent.id,
-          entities: ['api', agent.name],
-          channelType: 'DELETE',
-          rawData: '{}',
+    try {
+      const result = await agentCommander.runSpellWithResponse({
+        agent,
+        spellId,
+        inputs: {
+          [`Input - REST API (DELETE)`]: {
+            connector: 'REST API (DELETE)',
+            content,
+            sender: 'api',
+            observer: agent.name,
+            client: 'rest',
+            channel: 'rest',
+            agentId: agent.id,
+            entities: ['api', agent.name],
+            channelType: 'DELETE',
+            rawData: '{}',
+          },
+          publicVariables: agent.publicVariables,
+          runSubspell: true,
         },
-        publicVariables: agent.publicVariables,
-        runSubspell: true,
-      },
-    })
+      })
 
-    return {
-      result: result as object,
+      return {
+        result: result as object,
+      }
+    } catch (err) {
+      this.logger.error("Error in ApiService.remove: %s", err)
+      throw new GeneralError({
+        error: err,
+      })
     }
   }
   

--- a/packages/plugins/rest/server/src/services/api/api.class.ts
+++ b/packages/plugins/rest/server/src/services/api/api.class.ts
@@ -139,50 +139,6 @@ export class ApiService<ServiceParams extends ApiParams = ApiParams>
     }
   }
 
-  async create(
-    data: ApiData,
-    params: ServiceParams
-  ): Promise<ApiResponse | ApiError> {
-    const { content } = data;
-    const spellId = data?.spellId
-
-    const agent = await getAgent(data.agentId, (params?.headers && params.headers['authorization']) as string)
-
-    const agentCommander = app.get('agentCommander')
-
-    try {
-      const result = await agentCommander.runSpellWithResponse({
-        agent,
-        spellId,
-        inputs: {
-          [`Input - REST API (POST)`]: {
-            connector: 'REST API (POST)',
-            content,
-            sender: 'api',
-            observer: agent.name,
-            client: 'rest',
-            channel: 'rest',
-            agentId: agent.id,
-            entities: ['api', agent.name],
-            channelType: 'POST',
-            rawData: '{}',
-          },
-          publicVariables: agent.publicVariables,
-          runSubspell: true,
-        },
-      })
-
-      return {
-        result: result as object,
-      }
-    } catch (err) {
-      this.logger.error('Error in ApiService.create: %s', err)
-      throw new GeneralError({
-        error: err,
-      })
-    }
-  }
-
   async update(
     agentId: string,
     data: ApiData,


### PR DESCRIPTION
## What Changed:

Changed where we handled some errors, so we can listen to those errors from the http api

## How to test:

make a spell that always errors, use the rest api to run that spell, observe the error in the response