### PR TITLE
reverting Knowledge nodes text back to Documents

### DIFF
--- a/packages/core/client/src/components/Drawer/OldSidebar/index.tsx
+++ b/packages/core/client/src/components/Drawer/OldSidebar/index.tsx
@@ -292,8 +292,8 @@ export function OldSidebar({ children }: DrawerProps): JSX.Element {
             Icon={ArticleIcon}
             open={openDrawer}
             onClick={onClick('/documents')}
-            text="Knowledge"
-            tooltip="Knowledge Tooltip"
+            text="Documents"
+            tooltip="Documents Tooltip"
             tooltipText={drawerTooltipText.documents}
           />
           <DrawerItem

--- a/packages/core/shared/src/engine.ts
+++ b/packages/core/shared/src/engine.ts
@@ -141,7 +141,7 @@ export type NodeCategory =
   | 'Github'
   | 'Discord'
   | 'Embedding'
-  | 'Knowledge'
+  | 'Documents'
   | 'Code'
   | 'Boolean'
   | 'Array'

--- a/packages/core/shared/src/nodes/document/GetDocuments.ts
+++ b/packages/core/shared/src/nodes/document/GetDocuments.ts
@@ -17,7 +17,7 @@ import {
 } from '../../types'
 
 const info =
-  'Gets Knowledge from the Knowledge store. The optional Type property will return only knowledge with the matching type, and the Max Count property will limit the number of knowledge returned. Knowledge are returned in order of distance.'
+  'Gets Documents from the Documents store. The optional Type property will return only Documents with the matching type, and the Max Count property will limit the number of Documents returned. Documents are returned in order of distance.'
 
 /**
  * Defines the expected return type for the input data
@@ -32,14 +32,14 @@ type InputReturn = {
 export class GetDocuments extends MagickComponent<Promise<InputReturn>> {
   constructor() {
     super(
-      'Get Knowledge',
+      'Get Documents',
       {
         outputs: {
           documents: 'output',
           trigger: 'option',
         },
       },
-      'Knowledge',
+      'Documents',
       info
     )
     // this.runFromCache = true
@@ -53,7 +53,7 @@ export class GetDocuments extends MagickComponent<Promise<InputReturn>> {
   builder(node: MagickNode) {
     // Create input and output sockets
     const embedding = new Rete.Input('embedding', 'Embedding', embeddingSocket)
-    const out = new Rete.Output('documents', 'Knowledge', documentSocket)
+    const out = new Rete.Output('documents', 'Documents', documentSocket)
     const dataInput = new Rete.Input('trigger', 'Trigger', triggerSocket, true)
     const dataOutput = new Rete.Output('trigger', 'Trigger', triggerSocket)
 

--- a/packages/core/shared/src/nodes/document/StoreDocument.ts
+++ b/packages/core/shared/src/nodes/document/StoreDocument.ts
@@ -20,14 +20,14 @@ export class StoreDocument extends MagickComponent<Promise<void>> {
    */
   constructor() {
     super(
-      'Store Knowledge',
+      'Store Documents',
       {
         outputs: {
           trigger: 'option',
         },
       },
-      'Knowledge',
-      'Store Knowledge in the Knowledge store. Stores the content, embedding, and date from the inputs as well as an optional Type property.'
+      'Documents',
+      'Store Documents in the Documents store. Stores the content, embedding, and date from the inputs as well as an optional Type property.'
     )
   }
 

--- a/packages/editor/src/screens/DocumentWindow/DocumentModal.tsx
+++ b/packages/editor/src/screens/DocumentWindow/DocumentModal.tsx
@@ -71,7 +71,7 @@ const DocumentModal = ({ createMode, setCreateMode, handleSave, setNewDocument, 
 
         <Grid container direction="row" justifyContent="space-between">
           <Grid item>
-            <Typography variant={'h5'} fontWeight={"bold"} style={{ margin: '0.5rem' }}>Add Knowledge</Typography>
+            <Typography variant={'h5'} fontWeight={"bold"} style={{ margin: '0.5rem' }}>Add Document</Typography>
           </Grid>
           <Button
             className={styles.btn}

--- a/packages/editor/src/screens/DocumentWindow/DocumentTable.tsx
+++ b/packages/editor/src/screens/DocumentWindow/DocumentTable.tsx
@@ -50,7 +50,7 @@ const GlobalFilter = ({ globalFilter, setGlobalFilter }) => {
         setValue(e.target.value)
         onChange(e.target.value)
       }}
-      placeholder="Search Knowledge..."
+      placeholder="Search Documents..."
       className={styles.search}
     />
   )
@@ -305,7 +305,7 @@ function DocumentTable({ documents, updateCallback }) {
         <Stack spacing={2} style={{ padding: '1rem', background: '#272727' }}>
           <div className={styles.flex}>
             <Typography variant="h4" className={styles.header}>
-              Knowledge
+            Documents
             </Typography>
             <div className={styles.flex}>
               <Button


### PR DESCRIPTION
## What Changed:

Reverted all Knowledge text back to Documents

## How to test:

Review Store Knowledge and Get Knowledge node and see if they have changed back to Store Document and Get Document respectively 

## Additional information:

Any other information that might be useful while reviewing.
