### PR TITLE
adds an automatically expanding array of spellRunners for each spell

### DIFF
--- a/packages/core/server/src/hooks/spellmanagerHooks.ts
+++ b/packages/core/server/src/hooks/spellmanagerHooks.ts
@@ -52,7 +52,7 @@ export const updateSpellInManager = async (context: HookContext) => {
   const decodedId =
     (id as string).length > 36 ? (id as string).slice(0, 36) : (id as string)
 
-  const spellRunner = spellManager.getSpellRunner(decodedId)
+  const spellRunner = spellManager.getReadySpellRunner(decodedId)
 
   if (!spellRunner) return
 

--- a/packages/core/server/src/services/spell-runner/spell-runner.class.ts
+++ b/packages/core/server/src/services/spell-runner/spell-runner.class.ts
@@ -125,7 +125,7 @@ export class SpellRunnerService<
 
     const decodedId = id.length > 36 ? id.slice(0, 36) : id
 
-    const spellRunner = spellManager.getSpellRunner(decodedId)
+    const spellRunner = spellManager.getReadySpellRunner(decodedId)
     if (!spellRunner) return console.error('No spell runner found!')
 
     if (diff) {

--- a/packages/core/shared/src/spellManager/SpellRunner.ts
+++ b/packages/core/shared/src/spellManager/SpellRunner.ts
@@ -42,6 +42,7 @@ class SpellRunner {
   app: typeof FeathersApp
   agent?: any
   spellManager: SpellManager
+  busy = false
 
   log(message, data) {
     this.logger.info(`${message} %o`, data)
@@ -252,6 +253,10 @@ class SpellRunner {
     await this.engine.process(graph as GraphData, null, this.context)
   }
 
+  isBusy() {
+    return this.busy
+  }
+
   /**
    * Main spell runner for now. Processes inputs, gets the right component that starts the
    * running.  Would be even better if we just took a node identifier, got its
@@ -266,6 +271,7 @@ class SpellRunner {
     publicVariables,
     app,
   }: RunComponentArgs) {
+    this.busy = true
     // This should break us out of an infinite loop if we have circular spell dependencies.
     if (runSubspell && this.ranSpells.includes(this.currentSpell.name)) {
       this._clearRanSpellCache()
@@ -327,6 +333,7 @@ class SpellRunner {
     //
     await component.run(triggeredNode as unknown as MagickNode, inputs)
 
+    this.busy = false
     return this.outputData
   }
 }


### PR DESCRIPTION
## What Changed:

SpellRunners (the class that runs spells) can't really handle multiple spell runs at the same time. They are pretty stateful, so that causes race conditions to pop up and results in weird behavior from agents that are receiving many messages at a time.

This changes how the SpellManager gets SpellRunners to run spells.
Before we had a mapping of SpellId -> SpellRunner, but now we have a mapping of SpellId -> Array<SpellRunner>

When we try to get a SpellRunner, we get the first "ready" runner in the array a spellId maps to.
If we don't find one, we create a new SpellRunner and add it to that array.

This we we have an automatically growing pool of spell runners

In the future we'll probably want this pool to auto clean itself, but it's likely the SpellRunner abstraction won't stick around, so this should be good enough for now.

## How to test:

Make a spell with 2 generate text nodes chained into each other.
Hook that spell up to discord and send a ton of messages to it.

Observe that it _eventually_ responds to all messages.
