### PR TITLE
Wait long enough for all workers to start before starting the manager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: npm run start-server
 worker: npm run start-cloud-agent-worker
-manager: npm run start-cloud-agent-manager
+manager: sleep 30; npm run start-cloud-agent-manager


### PR DESCRIPTION
## What Changed:

Currently 1 worker tries to start all the agents, this causes the dyno to run out of memory then crash.
This tells the manager to wait for probably long enough for all workers to come online before starting agents.