### PR TITLE
fixes playtest window

### DIFF
--- a/packages/core/shared/src/spellManager/SpellManager.ts
+++ b/packages/core/shared/src/spellManager/SpellManager.ts
@@ -102,7 +102,12 @@ export default class SpellManager {
 
     await spellRunner.loadSpell(spell)
 
-    this.spellRunnerMap.get(spell.id)?.push(spellRunner)
+    const spellRunnerList = this.spellRunnerMap.get(spell.id)
+    if (spellRunnerList) {
+      spellRunnerList.push(spellRunner)
+    } else {
+      this.spellRunnerMap.set(spell.id, [spellRunner])
+    }
 
     return spellRunner
   }


### PR DESCRIPTION
## What Changed:

SpellRunners are created when an Agent is initialized.
The playtest window runs spells without an agent, so an Agent is never intialized.

The recent changes to SpellRunners changed how we store SpellRunners and ended up breaking the playtest window.

This fixes that bug and the playtest window