### PR TITLE
potential typechat v2

### DIFF
--- a/packages/core/shared/src/nodes/text/TypeChat.ts
+++ b/packages/core/shared/src/nodes/text/TypeChat.ts
@@ -14,6 +14,8 @@ import {
   MagickWorkerOutputs,
   WorkerData,
 } from '../../types'
+import { FewshotControl } from '../../dataControls/FewshotControl'
+import { InputControl } from '../../dataControls/InputControl'
 
 /** Information related to the TypeChat */
 const info =
@@ -68,7 +70,129 @@ export class TypeChat extends MagickComponent<Promise<WorkerReturn>> {
       tooltip: 'Choose model name',
     })
 
-    node.inspector.add(modelName)
+    const responseType = new InputControl({
+      name: 'Response Type',
+      dataKey: 'responseType',
+      tooltip: 'Enter response type from your schema',
+    })
+
+    const fewshotControl = new FewshotControl({
+      tooltip: 'Open schema',
+      language: 'typescript',
+      name: 'Schema',
+      dataKey: 'schema',
+      defaultValue: 
+`// The following is a schema definition for ordering lattes.
+export interface Cart {
+  items: (LineItem | UnknownText)[];
+}
+
+// Use this type for order items that match nothing else
+export interface UnknownText {
+  type: 'unknown',
+  text: string; // The text that wasn't understood
+}
+
+export interface LineItem {
+  type: 'lineitem',
+  product: Product;
+  quantity: number;
+}
+
+export type Product = BakeryProducts | LatteDrinks | EspressoDrinks | CoffeeDrinks;
+
+export interface BakeryProducts {
+  type: 'BakeryProducts';
+  name: 'apple bran muffin' | 'blueberry muffin' | 'lemon poppyseed muffin' | 'bagel';
+  options: (BakeryOptions | BakeryPreparations)[];
+}
+
+export interface BakeryOptions {
+  type: 'BakeryOptions';
+  name: 'butter' | 'strawberry jam' | 'cream cheese';
+  optionQuantity?: OptionQuantity;
+}
+
+export interface BakeryPreparations {
+  type: 'BakeryPreparations';
+  name: 'warmed' | 'cut in half';
+}
+
+export interface LatteDrinks {
+  type: 'LatteDrinks';
+  name: 'cappuccino' | 'flat white' | 'latte' | 'latte macchiato' | 'mocha' | 'chai latte';
+  temperature?: CoffeeTemperature;
+  size?: CoffeeSize;  // The default is 'grande'
+  options?: (Milks | Sweeteners | Syrups | Toppings | Caffeines | LattePreparations)[];
+}
+
+export interface EspressoDrinks {
+  type: 'EspressoDrinks';
+  name: 'espresso' | 'lungo' | 'ristretto' | 'macchiato';
+  temperature?: CoffeeTemperature;
+  size?: EspressoSize;  // The default is 'doppio'
+  options?: (Creamers | Sweeteners | Syrups | Toppings | Caffeines | LattePreparations)[];
+}
+
+export interface CoffeeDrinks {
+  type: 'CoffeeDrinks';
+  name: 'americano' | 'coffee';
+  temperature?: CoffeeTemperature;
+  size?: CoffeeSize;  // The default is 'grande'
+  options?: (Creamers | Sweeteners | Syrups | Toppings | Caffeines | LattePreparations)[];
+}
+
+export interface Syrups {
+  type: 'Syrups';
+  name: 'almond syrup' | 'buttered rum syrup' | 'caramel syrup' | 'cinnamon syrup' | 'hazelnut syrup' |
+      'orange syrup' | 'peppermint syrup' | 'raspberry syrup' | 'toffee syrup' | 'vanilla syrup';
+  optionQuantity?: OptionQuantity;
+}
+
+export interface Caffeines {
+  type: 'Caffeines';
+  name: 'regular' | 'two thirds caf' | 'half caf' | 'one third caf' | 'decaf';
+}
+
+export interface Milks {
+  type: 'Milks';
+  name: 'whole milk' | 'two percent milk' | 'nonfat milk' | 'coconut milk' | 'soy milk' | 'almond milk' | 'oat milk';
+}
+
+export interface Creamers {
+  type: 'Creamers';
+  name: 'whole milk creamer' | 'two percent milk creamer' | 'one percent milk creamer' | 'nonfat milk creamer' |
+      'coconut milk creamer' | 'soy milk creamer' | 'almond milk creamer' | 'oat milk creamer' | 'half and half' |
+      'heavy cream';
+}
+
+export interface Toppings {
+  type: 'Toppings';
+  name: 'cinnamon' | 'foam' | 'ice' | 'nutmeg' | 'whipped cream' | 'water';
+  optionQuantity?: OptionQuantity;
+}
+
+export interface LattePreparations {
+  type: 'LattePreparations';
+  name: 'for here cup' | 'lid' | 'with room' | 'to go' | 'dry' | 'wet';
+}
+
+export interface Sweeteners {
+  type: 'Sweeteners';
+  name: 'equal' | 'honey' | 'splenda' | 'sugar' | 'sugar in the raw' | 'sweet n low' | 'espresso shot';
+  optionQuantity?: OptionQuantity;
+}
+
+export type CoffeeTemperature = 'hot' | 'extra hot' | 'warm' | 'iced';
+
+export type CoffeeSize = 'short' | 'tall' | 'grande' | 'venti';
+
+export type EspressoSize = 'solo' | 'doppio' | 'triple' | 'quad';
+
+export type OptionQuantity = 'no' | 'light' | 'regular' | 'extra' | number;`,
+    })
+
+    node.inspector.add(modelName).add(fewshotControl).add(responseType)
 
     node.addInput(dataInput).addOutput(dataOutput)
 
@@ -167,8 +291,6 @@ export class TypeChat extends MagickComponent<Promise<WorkerReturn>> {
     ]) as CompletionProvider[]
 
     const model = (node.data as { model: string }).model as string
-    // get the provider for the selected model
-    console.log('model', model)
     const provider = completionProviders.find(provider =>
       provider.models.includes(model)
     ) as CompletionProvider

--- a/packages/core/shared/src/nodes/text/TypeChat.ts
+++ b/packages/core/shared/src/nodes/text/TypeChat.ts
@@ -74,6 +74,7 @@ export class TypeChat extends MagickComponent<Promise<WorkerReturn>> {
       name: 'Response Type',
       dataKey: 'responseType',
       tooltip: 'Enter response type from your schema',
+      defaultValue: 'Cart',
     })
 
     const fewshotControl = new FewshotControl({

--- a/packages/plugins/openai/server/src/functions/makeTypeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTypeChatCompletion.ts
@@ -22,8 +22,8 @@ export async function makeTypeChatCompletion(
 }> {
   const { node, inputs, context } = data
   const input = inputs['input']?.[0] as string
-  const schema = inputs['schema']?.[0] as string
-  const responseType = inputs['responseType']?.[0] as string
+  const schema = node?.data?.schema as string
+  const responseType = node?.data?.responseType as string
   const modelName = node?.data?.model as string
 
   const openaiKey = context.module.secrets!['openai_api_key']

--- a/packages/plugins/openai/shared/src/index.ts
+++ b/packages/plugins/openai/shared/src/index.ts
@@ -118,16 +118,6 @@ const completionProviders: CompletionProvider[] = [
         name: 'Input',
         type: stringSocket,
       },
-      {
-        socket: 'schema',
-        name: 'Schema',
-        type: stringSocket,
-      },
-      {
-        socket: 'responseType',
-        name: 'Response Type',
-        type: stringSocket,
-      },
     ],
     outputs: [
       {


### PR DESCRIPTION
## What Changed:
DONT MERGE:  i want to add the old typechat node back in before we do
- Schema is moved into a fewshot control with typescript syntax highlighting (similar to text variable)
- Response type is moved to the inspector
- has a default value to show the user an example, and so that it works out of the box. (example ripped from here: https://github.com/microsoft/TypeChat/blob/main/examples/coffeeShop/src/coffeeShopSchema.ts)
- would break existing typechat spells :disappointed:

## How to test:

Use the typechat node and order a coffee