### PR TITLE
Fix subspells

### DIFF
--- a/packages/core/shared/src/nodes/io/Input.ts
+++ b/packages/core/shared/src/nodes/io/Input.ts
@@ -41,8 +41,7 @@ export class InputComponent extends MagickComponent<InputReturn> {
         },
       },
       'I/O',
-      info,
-    
+      info
     )
 
     this.module = {
@@ -255,14 +254,14 @@ export class InputComponent extends MagickComponent<InputReturn> {
     node: WorkerData,
     _inputs: MagickWorkerInputs,
     outputs: MagickWorkerOutputs,
-    { data }: { data: string | undefined }
+    { data }: { data: Record<string, unknown> }
   ) {
     node.data.isInput = true
     // handle data subscription.  If there is data, this is from playtest
-    if (data && !isEmpty(data)) {
+    if (data && !isEmpty(data) && node.data.name) {
       this._task.closed = []
 
-      const output = Object.values(data)[0] as string
+      const output = data[node.data.name]
 
       return {
         output,

--- a/packages/core/shared/src/nodes/io/Spell.ts
+++ b/packages/core/shared/src/nodes/io/Spell.ts
@@ -119,7 +119,7 @@ export class SpellComponent extends MagickComponent<
       name: 'Spell Select',
       write: false,
       defaultValue: (node.data.spell as string) || '',
-      tooltip: 'Select/Choose the created spell'
+      tooltip: 'Select/Choose the created spell',
     })
 
     node.inspector.add(spellControl)
@@ -145,7 +145,7 @@ export class SpellComponent extends MagickComponent<
             dataKey: data.name,
             language: 'plaintext',
             defaultValue: publicVar || data.value || '',
-            tooltip: 'Directive for the spell'
+            tooltip: 'Directive for the spell',
           })
           if (!node.inspector.dataControls.has(fewshotInputControl.dataKey)) {
             node.inspector.add(fewshotInputControl)
@@ -180,7 +180,7 @@ export class SpellComponent extends MagickComponent<
             name: data.name,
             dataKey: data.name,
             defaultValue: data.value,
-            tooltip:""
+            tooltip: '',
           })
           if (!node.inspector.dataControls.has(numberInputControl.dataKey)) {
             node.inspector.add(numberInputControl)
@@ -344,10 +344,9 @@ export class SpellComponent extends MagickComponent<
     }
 
     if (agent) {
-
-      const outputs = await app.get('agentCommander').runSpellWithResponse(
-        runComponentArgs
-      )
+      const outputs = await app
+        .get('agentCommander')
+        .runSpellWithResponse(runComponentArgs)
 
       const output = this.formatOutputs(node, outputs)
 


### PR DESCRIPTION
## What Changed:

The input node was referencing the value from the incoming data in a dumb way, just turning the object into an array and grabbing the zeroth index. This likely wasn't caught before since it only happens if you want to use more than one input node for a subspell. Since the entire run input object is passed into the run function, we needed to reference it differently.  

Now, we are using the node name from the nodes data (node.data.name) to properly reference the value for that input and returning that from the input.

## How to test:

Make sure you can pass a string value into a subspell from a second input node and then reference it internally in the subspell.

This image shows the subspell that was causing issues.

<img width="1372" alt="Screenshot 2023-09-05 at 12 05 03 AM" src="https://github.com/Oneirocom/Magick/assets/2397603/50424d21-f07b-4175-bd3e-d79914a873b6">


## Additional information:

Rob Lennon is blocked by this, so we should get it in fast.  Hotfix to prod would be good.
