### PR TITLE
adds overflow to fix the page scrolling when it shouldn't

### DIFF
--- a/packages/core/client/src/components/Drawer/index.tsx
+++ b/packages/core/client/src/components/Drawer/index.tsx
@@ -15,7 +15,7 @@ export function Drawer({ children }: DrawerProps): JSX.Element {
   const showSideBarFlag = useFeatureFlagEnabled('ide-new-sidebar')
 
   return (
-    <div style={{ display: 'flex', height: '100%' }}>
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
       {showSideBarFlag ? (
         <NewSidebar children={children} />
       ) : (


### PR DESCRIPTION
## What Changed:

Just added `overflow: hidden` to a high level div so that the page doesn't scroll when the node graph gets larger than the screen.