### PR TITLE
Fix spell manager updates

### DIFF
--- a/packages/core/server/src/hooks/spellmanagerHooks.ts
+++ b/packages/core/server/src/hooks/spellmanagerHooks.ts
@@ -27,6 +27,7 @@ export const checkForSpellInManager = async (context: HookContext) => {
   const decodedId =
     (id as string).length > 36 ? (id as string).slice(0, 36) : (id as string)
 
+  // load the spell if there isnt ones
   if (!spellManager.hasSpellRunner(decodedId)) {
     const spell = await getSpell({ app, id: decodedId, projectId })
     await spellManager.load(spell as SpellInterface)
@@ -64,5 +65,5 @@ export const updateSpellInManager = async (context: HookContext) => {
 
   // We just store the result here of the update
   // This hook only runs after save spell calls, so there should always be a spell to load in
-  spellManager.load(context.result)
+  spellManager.updateSpell(context.result)
 }

--- a/packages/core/server/src/services/spells/spells.ts
+++ b/packages/core/server/src/services/spells/spells.ts
@@ -106,8 +106,8 @@ export const spell = (app: Application) => {
     after: {
       all: [],
       create: [],
-      patch: [checkForSpellInManager, updateSpellInManager],
-      saveDiff: [checkForSpellInManager, updateSpellInManager],
+      patch: [checkForSpellInManager],
+      saveDiff: [checkForSpellInManager],
     },
     error: {
       all: [],

--- a/packages/core/server/src/sockets/sockets.ts
+++ b/packages/core/server/src/sockets/sockets.ts
@@ -35,7 +35,7 @@ const handleSockets = (app: any) => {
       socket.feathers.user = user
 
       // Instantiate the interface within the runner rather than the spell manager to avoid shared state issues.
-      const spellManager = new SpellManager({ socket, app })
+      const spellManager = new SpellManager({ socket, app, watchSpells: true })
 
       app.userSpellManagers.set(user.id, spellManager)
 

--- a/packages/core/shared/src/plugins/remotePlugin/index.ts
+++ b/packages/core/shared/src/plugins/remotePlugin/index.ts
@@ -98,7 +98,8 @@ function install(
           client.service('agents').on('spell', spellListener)
 
           // set the subscription into the map so we can destroy it later
-          subscriptionMap.set(node.id, spellListener)
+          if (!subscriptionMap.has(node.id))
+            subscriptionMap.set(node.id, spellListener)
 
           // call the original builder now
           builder.call(component, node)

--- a/packages/core/shared/src/spellManager/SpellRunner.ts
+++ b/packages/core/shared/src/spellManager/SpellRunner.ts
@@ -292,7 +292,7 @@ class SpellRunner {
 
     this._clearRanSpellCache()
     // ensure we run from a clean slate
-    // this._resetTasks()
+    this._resetTasks()
 
     // load the inputs into module memory
     this.module.read({


### PR DESCRIPTION
## What Changed:

Fixes issue where spell running isn't activating nodes on the IDE graph.  Changes from graph not syncing to server.  Also fixes issue with fromSocket effecting the exclusive gate.

## How to test:

IDE should work normally.  new nodes added or removed should be synced to server and the whole graph should run properly when you activate it from the playtest.  Also exclusive gate should work.

Need to test if this fixes agents.

## Additional information:

Any other information that might be useful while reviewing.
