### PR TITLE
Bind filter function in task back prop

### DIFF
--- a/packages/core/shared/src/plugins/taskPlugin/task.ts
+++ b/packages/core/shared/src/plugins/taskPlugin/task.ts
@@ -162,9 +162,8 @@ export class Task {
       await Promise.all(
         this.getInputs('output').map(async key => {
           const inputPromises = (this.inputs[key] as MagickReteInput[])
-            .filter(this.filterNextTasks)
+            .filter(this.filterNextTasks.bind(this))
             .map(async (con: MagickReteInput) => {
-              console.log('CONNECTIOn', con)
               const task = this.getTask(con.nodeId)
               // if the task has come from a node with output data that is not the calling node, use that data
               if (task.outputData && task.nodeId !== fromNodeId) {


### PR DESCRIPTION
## What Changed:

The filter function in the back propagation of the task plugin was not bound to the outer this scope, so it was failing on getting a task.  This fixes it.

## How to test:

IDE should work when using it.

## Additional information:

Any other information that might be useful while reviewing.
