### PR TITLE
Fix bug fetching documents

### DIFF
--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -103,6 +103,8 @@ export class DocumentService<
     ) {
       const param = params.query
 
+      console.log('param!!!!!!!', param)
+
       const querys = await db('documents')
         .select('*')
         .where({
@@ -120,7 +122,7 @@ export class DocumentService<
               .select(
                 db.raw(
                   `(embedding <=> '${JSON.stringify(
-                    param.query.embedding
+                    param.embedding
                   )}') AS distance`
                 )
               )


### PR DESCRIPTION
## What Changed:

Fetching documents via the get documents node was broken due to mis-query of a property on params.

## How to test:

Get documents node should work. 

## Additional information:

Any other information that might be useful while reviewing.
