### PR TITLE
Avoid unstructured missing data

### DIFF
--- a/packages/core/server/src/services/documents/documents.class.ts
+++ b/packages/core/server/src/services/documents/documents.class.ts
@@ -233,8 +233,12 @@ const getUnstructuredData = async (files, docData) => {
   //iterate and format for document insert (api returns either an array or an array of arrays)
   const elements = [] as any[]
   for (const i in unstructured.data) {
+    // check for empty array
+    if (!unstructured.data[i] && unstructured.data[i] < 0) continue
     if (unstructured.data[i] instanceof Array) {
       for (const j in unstructured.data[i]) {
+        // check for undefined
+        if (!unstructured.data[i][j]) continue
         elements.push(createElement(unstructured.data[i][j], docData, j))
       }
     } else {


### PR DESCRIPTION
Supersedes #1314 
## What Changed:

- skip any fields in unstructured's return to make sure everything is defined.

## How to test:

- uploading docs to unstructured should work repeatedly.
## Additional information:

Any other information that might be useful while reviewing.
