### PR TITLE
Display event in reverse chronological order

### DIFF
--- a/packages/core/server/src/services/events/events.class.ts
+++ b/packages/core/server/src/services/events/events.class.ts
@@ -91,9 +91,7 @@ export class EventService<
 
     const res = await query
 
-    if (!param.embedding) {
-      res.reverse()
-    }
+
 
     return { events: res as unknown as { data: Array<any> } }
   }

--- a/packages/editor/src/screens/EventWindow/index.tsx
+++ b/packages/editor/src/screens/EventWindow/index.tsx
@@ -67,7 +67,7 @@ const EventWindow = (): JSX.Element => {
       )
 
       const data = await response.json()
-      setEvents(reverseRows(data.events))
+      setEvents(data.events)
       setLoading(false)
     } catch (error) {
       console.error('ERROR', error)

--- a/packages/editor/src/screens/EventWindow/index.tsx
+++ b/packages/editor/src/screens/EventWindow/index.tsx
@@ -37,20 +37,7 @@ const EventWindow = (): JSX.Element => {
     await fetchEvents()
   }
 
-  function reverseRows(arr) {
-    
-    const len = arr.length
-   
-    for (let i = 0; i < len / 2; i++) {
-      
-      const temp = {}
-      Object.assign(temp, arr[i])
-      Object.assign(arr[i], arr[len - i - 1])
-      Object.assign(arr[len - i - 1], temp)
-    }
 
-    return arr
-  }
 
   /**
    * Fetches the events of the current project.

--- a/packages/editor/src/screens/EventWindow/index.tsx
+++ b/packages/editor/src/screens/EventWindow/index.tsx
@@ -37,6 +37,21 @@ const EventWindow = (): JSX.Element => {
     await fetchEvents()
   }
 
+  function reverseRows(arr) {
+    
+    let len = arr.length
+   
+    for (let i = 0; i < len / 2; i++) {
+      
+      let temp = {}
+      Object.assign(temp, arr[i])
+      Object.assign(arr[i], arr[len - i - 1])
+      Object.assign(arr[len - i - 1], temp)
+    }
+
+    return arr
+  }
+
   /**
    * Fetches the events of the current project.
    */
@@ -52,7 +67,7 @@ const EventWindow = (): JSX.Element => {
       )
 
       const data = await response.json()
-      setEvents(data.events)
+      setEvents(reverseRows(data.events))
       setLoading(false)
     } catch (error) {
       console.error('ERROR', error)

--- a/packages/editor/src/screens/EventWindow/index.tsx
+++ b/packages/editor/src/screens/EventWindow/index.tsx
@@ -39,11 +39,11 @@ const EventWindow = (): JSX.Element => {
 
   function reverseRows(arr) {
     
-    let len = arr.length
+    const len = arr.length
    
     for (let i = 0; i < len / 2; i++) {
       
-      let temp = {}
+      const temp = {}
       Object.assign(temp, arr[i])
       Object.assign(arr[i], arr[len - i - 1])
       Object.assign(arr[len - i - 1], temp)


### PR DESCRIPTION
## What Changed:

Added a function with uses swap algorithm to reverse events array and display them from the recent last one 

## How to test:

1. Create a discord bot 
2. interact with it in spell text input
3. navigate to events window and check if the recent request you made is the one on the top on of events table

## Additional information:

Any other information that might be useful while reviewing.
