### PR TITLE
Adds a heartbeat to restart agents when a worker goes down.

### DIFF
--- a/apps/cloud-agent-manager/src/main.ts
+++ b/apps/cloud-agent-manager/src/main.ts
@@ -7,7 +7,7 @@ import { getPinoTransport } from '@hyperdx/node-opentelemetry'
 
 if (PRODUCTION) {
 	initLogger({
-		name: 'cloud-agent-worker',
+		name: 'cloud-agent-manager',
 		transport: {
 			targets: [
 				getPinoTransport('info')
@@ -16,7 +16,7 @@ if (PRODUCTION) {
 		level: 'info',
 	})
 } else {
-	initLogger({ name: 'cloud-agent-worker' })
+	initLogger({ name: 'cloud-agent-manager' })
 }	
 const logger = getLogger()
 

--- a/apps/cloud-agent-worker/src/main.ts
+++ b/apps/cloud-agent-worker/src/main.ts
@@ -48,4 +48,4 @@ await loadPlugins()
 
 logger.info('Starting worker')
 const worker = new CloudAgentWorker()
-worker.work()
+worker.startWork()

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,7 +231,7 @@
         "@types/deep-equal": "1.0.1",
         "@types/express": "4.17.17",
         "@types/jest": "29.5.1",
-        "@types/koa": "2.13.6",
+        "@types/koa": "^2.13.6",
         "@types/koa__router": "12.0.0",
         "@types/lodash": "4.14.195",
         "@types/mocha": "10.0.1",
@@ -21018,7 +21018,8 @@
     },
     "node_modules/@types/koa": {
       "version": "2.13.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
+      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@types/deep-equal": "1.0.1",
     "@types/express": "4.17.17",
     "@types/jest": "29.5.1",
-    "@types/koa": "2.13.6",
+    "@types/koa": "^2.13.6",
     "@types/koa__router": "12.0.0",
     "@types/lodash": "4.14.195",
     "@types/mocha": "10.0.1",

--- a/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
+++ b/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
@@ -3,7 +3,6 @@ import { diff, unique } from "radash"
 import { AGENT_DELETE, AGENT_DELETE_JOB, AGENT_UPDATE_JOB, getLogger } from "@magickml/core"
 import type { Reporter } from "./Reporters"
 import { type PubSub, type MessageQueue, app } from "@magickml/server-core"
-import type { AgentListRecord } from '@magickml/cloud-agent-worker'
 import { Agent } from "packages/core/server/src/services/agents/agents.schema"
 import { HEARTBEAT_MSEC, MANAGER_WARM_UP_MSEC } from "@magickml/config"
 
@@ -41,7 +40,6 @@ export class CloudAgentManager {
       const agent = data as Agent
 
       this.logger.info(`Agent Updated: ${agent.id}`)
-      const agentUpdatedAt = agent.updatedAt ? new Date(agent.updatedAt) : new Date()
 
       if (agent.enabled) {
         this.logger.info(`Agent ${agent.id} enabled, adding to cloud agent worker`)

--- a/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
+++ b/packages/cloud-agent-manager/src/lib/CloudAgentManager.ts
@@ -1,5 +1,5 @@
 import pino from "pino"
-import { diff } from "radash"
+import { diff, unique } from "radash"
 import { AGENT_DELETE, AGENT_DELETE_JOB, AGENT_UPDATE_JOB, getLogger } from "@magickml/core"
 import type { Reporter } from "./Reporters"
 import { type PubSub, type MessageQueue, app } from "@magickml/server-core"
@@ -22,38 +22,21 @@ export class CloudAgentManager {
     workerToAgents: AgentList = {}
 
     constructor(args: CloudAgentManagerConstructor) {
-        this.newQueue = args.newQueue
-        this.newQueue.initialize('agent:new')
-        this.agentStateReporter = args.agentStateReporter
-        this.pubSub = app.get('pubsub')
+      this.logger.info('Cloud Agent Manager Startup')
+      this.newQueue = args.newQueue
+      this.newQueue.initialize('agent:new')
+      this.agentStateReporter = args.agentStateReporter
+      this.pubSub = app.get('pubsub')
 
-        this.startup()
-    }
+      this.run = this.run.bind(this)
+      this.heartbeat = this.heartbeat.bind(this)
+      this.dedupeAgents = this.dedupeAgents.bind(this)
 
-    async startup() {
-        this.logger.info('Cloud Agent Manager Startup')
-
-        const enabledAgents = await app.service('agents').find({
-            query: {
-                enabled: true,
-            },
-        })
-
-        this.logger.info(`Found ${enabledAgents.data.length} enabled agents`)
-        const agentPromises: Promise<any>[] = []
-        for (const agent of enabledAgents.data) {
-            this.logger.debug(`Adding agent ${agent.id} to cloud agent worker`)
-            agentPromises.push(this.newQueue.addJob('agent:new', {
-                agentId: agent.id,
-            }, `agent-new-${agent.id}-${new Date().getTime()}}`))
-        }
-
-        await Promise.all(agentPromises)
+      this.heartbeat()
     }
 
     async run() {
         this.agentStateReporter.on('agent:updated', async (data: unknown) => {
-
             const agent = data as Agent
 
             this.logger.info(`Agent Updated: ${agent.id}`)
@@ -61,9 +44,7 @@ export class CloudAgentManager {
 
             if (agent.enabled) {
                 this.logger.info(`Agent ${agent.id} enabled, adding to cloud agent worker`)
-                await this.newQueue.addJob('agent:new', {
-                    agentId: agent.id,
-                }, `agent-new-${agent.id}-${agentUpdatedAt.getTime()}`)
+                await this.newQueue.addJob('agent:new', {agentId: agent.id})
                 this.logger.debug(`Agent create job for ${agent.id} added`)
                 return
             }
@@ -77,46 +58,52 @@ export class CloudAgentManager {
         })
     }
 
+    async dedupeAgents(agents: string[]) {
+      const deduped = unique(agents)
+      const diffAgents = diff(agents, deduped)
+
+      this.logger.info("deduping agents %o", diffAgents)
+      diffAgents.forEach(async (agentId) => {
+        await this.pubSub.publish(AGENT_DELETE_JOB(agentId), JSON.stringify({ agentId: agentId }))
+        await this.newQueue.addJob('agent:new', {agentId: agentId})
+      })
+
+      return deduped
+    }
+
     // Eventually we'll need this heartbeat to keep track of running agents on workers
     async heartbeat() {
-        this.pubSub.subscribe('cloud-agent-manager:pong', async (list) => {
-            const listData = JSON.parse(list) as AgentListRecord
+      this.logger.debug("Started heartbeat")
+      let agentsOfWorkers: string[] = []
+      this.pubSub.subscribe("heartbeat-pong", async (agents: string[]) => {
+        this.logger.info("Got heartbeat pong")
+        agents.forEach(a => agentsOfWorkers.push(a))
+        agentsOfWorkers = await this.dedupeAgents(agentsOfWorkers)
+      })
+      await this.pubSub.publish("heartbeat-ping", "{}")
 
-            const lastAgentsOnWorker = this.workerToAgents[listData.id] || []
-            const agentsOnWorker = listData.currentAgents
-
-            const agentsDiff = diff(lastAgentsOnWorker, agentsOnWorker)
-
-            const agentsRestarted: string[] = []
-
-            if (agentsDiff.length > 0) {
-                this.logger.info(`Agents on worker ${listData.id} changed: ${agentsDiff}`)
-                const agents = await app.service('agents').find({
-                    query: {
-                        id: {
-                            $in: agentsDiff,
-                        },
-                    },
-                })
-
-                for (const agent of agents.data) {
-                    if (agent.enabled) {
-                        this.pubSub.publish('agent:updated', JSON.stringify({
-                            agentId: agent.id,
-                        }))
-                        agentsRestarted.push(agent.id)
-                    }
-                }
-
-                this.workerToAgents[listData.id] = agentsOnWorker
-            } else {
-                this.workerToAgents[listData.id] = [...agentsOnWorker, ...agentsRestarted]
-            }
-        })
-
+      setTimeout(() => 
         setInterval(async () => {
-            this.logger.trace('Heartbeat')
-            this.pubSub.publish('cloud-agent-manager:ping', "")
-        }, 1000 * 60 * 5)
+          this.logger.info(`Starting Heartbeat update`)
+          const enabledAgents = await app.service('agents').find({
+              query: {
+                  enabled: true,
+              },
+          })
+
+          const agentDiff = diff(enabledAgents.data.map(a => a.id), Array.from(agentsOfWorkers))
+          const agentsToUpdate = enabledAgents.data.filter(a => agentDiff.includes(a.id))
+
+          this.logger.info(`Found ${agentDiff.length} agents to Update`)
+          const agentPromises: Promise<any>[] = []
+          for (const agent of agentsToUpdate) {
+              this.logger.debug(`Adding agent ${agent.id} to cloud agent worker`)
+              agentPromises.push(this.newQueue.addJob('agent:new', {agentId: agent.id}))
+          }
+
+          await Promise.all(agentPromises)
+          agentsOfWorkers = [];
+          this.pubSub.publish("heartbeat-ping", "{}")
+        }, 3000), 5000)
     }
 }

--- a/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
+++ b/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
@@ -138,22 +138,22 @@ export class CloudAgentWorker extends AgentManager {
     this.logger.debug(`Listening for run for agent ${agentId}`)
     this.logger.debug(AGENT_RUN_JOB(agentId))
     this.pubSub.subscribe(AGENT_RUN_JOB(agentId),
-      async (data: AgentRunJob) => {
-        this.logger.info(`Running spell ${data.spellId} for agent ${data.agentId}`)
-        try {
-          const agent = this.currentAgents[agentId]
+                          async (data: AgentRunJob) => {
+                            this.logger.info(`Running spell ${data.spellId} for agent ${data.agentId}`)
+                            try {
+                              const agent = this.currentAgents[agentId]
 
-          if (!agent) {
-            this.logger.error(`Agent ${agentId} not found when running spell ${data.spellId}`)
-            throw new Error(`Agent ${agentId} not found when running spell ${data.spellId}`)
-          }
+                              if (!agent) {
+                                this.logger.error(`Agent ${agentId} not found when running spell ${data.spellId}`)
+                                throw new Error(`Agent ${agentId} not found when running spell ${data.spellId}`)
+                              }
 
-          agent?.runWorker({ data: { ...data, agentId } })
-        } catch (e) {
-            this.logger.error(`Error loading or running spell ${data.spellId} for agent ${data.agentId}`)
-            throw e
-          }
-      })
+                              agent?.runWorker({ data: { ...data, agentId } })
+                            } catch (e) {
+                              this.logger.error(`Error loading or running spell ${data.spellId} for agent ${data.agentId}`)
+                              throw e
+                            }
+                          })
   }
 
   async listenForChanges(agentId: string) {

--- a/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
+++ b/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
@@ -28,7 +28,7 @@ export class CloudAgentWorker extends AgentManager {
     })
 
     this.pubSub.subscribe("heartbeat-ping", async () => {
-      this.logger.info("Got heartbeat ping")
+      this.logger.debug("Got heartbeat ping")
       const agentIds = Object.keys(this.currentAgents)
       this.pubSub.publish("heartbeat-pong", JSON.stringify(agentIds))
     });

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -99,7 +99,7 @@ export const bullMQConnection = {
   db: REDISCLOUD_DB,
 }
 
-export const PINO_LOG_LEVEL = 'debug'//getVarForEnvironment('PINO_LOG_LEVEL') || 'info'
+export const PINO_LOG_LEVEL = getVarForEnvironment('PINO_LOG_LEVEL') || 'info'
 
 export const OPENMETER_ENDPOINT =
   getVarForEnvironment('OPENMETER_ENDPOINT') || 'http://localhost:8888'

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -128,3 +128,6 @@ export const FEATURE_FLAGS = {
   // Enable the new editor
   SHOW_SIDEBAR: getVarForEnvironment('SHOW_SIDEBAR') === 'true' || false,
 }
+
+export const HEARTBEAT_MSEC = getVarForEnvironment('HEARTBEAT_MSEC') || 3000
+export const MANAGER_WARM_UP_MSEC = getVarForEnvironment('MANAGER_WARM_UP_MSEC') || 5000

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -99,7 +99,7 @@ export const bullMQConnection = {
   db: REDISCLOUD_DB,
 }
 
-export const PINO_LOG_LEVEL = getVarForEnvironment('PINO_LOG_LEVEL') || 'info'
+export const PINO_LOG_LEVEL = 'debug'//getVarForEnvironment('PINO_LOG_LEVEL') || 'info'
 
 export const OPENMETER_ENDPOINT =
   getVarForEnvironment('OPENMETER_ENDPOINT') || 'http://localhost:8888'


### PR DESCRIPTION
## What Changed:

Added a mechanism to restart agents when a worker goes down.

## How to test:

Have an enabled agent locally.

run `npx nx serve @magickml/cloud-agent-manager-app`
run `npx nx serve @magickml/cloud-agent-worker-app`

wait for the worker to start an agent.
Kill the worker.

Run `npx nx serve @magickml/cloud-agent-worker-app`

After a few seconds, the worker should start the agent again.
