### PR TITLE
Agent api overrides

### DIFF
--- a/packages/agents/src/lib/Agent.ts
+++ b/packages/agents/src/lib/Agent.ts
@@ -231,7 +231,10 @@ export class Agent implements AgentInterface {
       const output = await spellRunner.runComponent({
         ...data,
         agent: this,
-        secrets: this.secrets,
+        secrets: {
+          ...this.secrets,
+          ...data.secrets,
+        },
         publicVariables: this.publicVariables,
         runSubspell: data.runSubspell,
         app,

--- a/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
+++ b/packages/cloud-agent-worker/src/lib/cloud-agent-worker.ts
@@ -158,7 +158,7 @@ export class CloudAgentWorker extends AgentManager {
         `Running spell ${data.spellId} for agent ${data.agentId}`
       )
       try {
-        const agent = this.currentAgents[agentId]
+        const agent = this.currentAgents[agentId] as Agent
 
         if (!agent) {
           this.logger.error(

--- a/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
+++ b/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
@@ -1,3 +1,4 @@
+import { agent } from './../../../../../../core/server/src/services/agents/agents'
 // DOCUMENTED
 /**
  * For more information about this file see
@@ -17,6 +18,7 @@ import { BadRequest, NotFound } from '@feathersjs/errors/lib'
 import { pino } from 'pino'
 import { getLogger } from '@magickml/core'
 import { CLOUD_AGENT_KEY, STANDALONE } from '@magickml/config'
+import { type } from 'os'
 
 export type { AgentHttp, AgentHttpData, AgentHttpPatch, AgentHttpQuery }
 
@@ -77,12 +79,24 @@ const formatRequest = async (method, agentId, data, params) => {
     channel = 'rest',
   } = data
 
+  console.log('incoming public variables', publicVariables)
+
   const agent = await getAgent(
     agentId,
     (params?.headers && params.headers['authorization']) as string,
     isCloud || false
   )
 
+  // check if public variables are a string, if they are parse them as json. Otherwise do nothing.
+  const formattedPublicVariables =
+    typeof publicVariables === 'string'
+      ? JSON.parse(publicVariables)
+      : publicVariables
+
+  const agentPublicVariables =
+    typeof agent.publicVariables === 'string'
+      ? JSON.parse(agent.publicVariables)
+      : agent.publicVariables
   method = method.toUpperCase()
 
   return {
@@ -102,8 +116,8 @@ const formatRequest = async (method, agentId, data, params) => {
         rawData: '{}',
       },
       publicVariables: {
-        ...agent.publicVariables,
-        ...publicVariables,
+        ...agentPublicVariables,
+        ...formattedPublicVariables,
       },
       runSubspell: true,
       secrets: {

--- a/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
+++ b/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
@@ -70,11 +70,12 @@ const formatRequest = async (method, agentId, data, params) => {
     spellId,
     content,
     isCloud,
+    secrets = {},
+    publicVariables = {},
     sender = 'api',
     client = 'rest',
     channel = 'rest',
   } = data
-  let { publicVariables } = data
 
   const agent = await getAgent(
     agentId,
@@ -105,6 +106,10 @@ const formatRequest = async (method, agentId, data, params) => {
         ...publicVariables,
       },
       runSubspell: true,
+      secrets: {
+        ...agent.secrets,
+        ...secrets,
+      },
     },
   }
 }

--- a/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
+++ b/packages/plugins/rest/server/src/services/agentHttp/agentHttp.class.ts
@@ -1,4 +1,3 @@
-import { agent } from './../../../../../../core/server/src/services/agents/agents'
 // DOCUMENTED
 /**
  * For more information about this file see
@@ -18,7 +17,6 @@ import { BadRequest, NotFound } from '@feathersjs/errors/lib'
 import { pino } from 'pino'
 import { getLogger } from '@magickml/core'
 import { CLOUD_AGENT_KEY, STANDALONE } from '@magickml/config'
-import { type } from 'os'
 
 export type { AgentHttp, AgentHttpData, AgentHttpPatch, AgentHttpQuery }
 


### PR DESCRIPTION
## What Changed:

Adds support for API calls to add properties to the event to they can set the sender, the client, the channel, etc.  Also adds support for passing through public variables, and secret overrides.

## How to test:

You can add these properties to a rest request, or try using the cloud PR here to send the properites via REST:

https://github.com/Oneirocom/Cloud/pull/495

## Additional information:

Any other information that might be useful while reviewing.
