### PR TITLE
disableInteractive on tooltips so they disappear

### DIFF
--- a/packages/core/client/src/components/Drawer/Newsidebar/index.tsx
+++ b/packages/core/client/src/components/Drawer/Newsidebar/index.tsx
@@ -138,7 +138,7 @@ const DrawerItem: React.FC<DrawerItemProps> = ({
   tooltipText,
 }) => (
   <ListItem key={text} disablePadding sx={{ display: 'block' }}>
-    <Tooltip title={tooltipText} placement="top" enterDelay={500} arrow>
+    <Tooltip title={tooltipText} placement="top" enterDelay={500} disableInteractive arrow>
       <ListItemButton
         sx={{
           py: 0.2,
@@ -233,7 +233,7 @@ export function NewSidebar(DrawerProps): JSX.Element {
   const globalConfig = useSelector((state: any) => state.globalConfig)
   const token = globalConfig?.token
   const { treeData, setTreeData,
-    setAgentUpdate} = useTreeData()
+    setAgentUpdate } = useTreeData()
   const handleDrop = (newTree: NodeModel[]) => {
     setTreeData(newTree)
   }
@@ -317,33 +317,33 @@ export function NewSidebar(DrawerProps): JSX.Element {
 
   useEffect(() => {
     if (!config.apiUrl) return
-    ;(async () => {
-      const res = await fetch(
-        `${config.apiUrl}/agents?projectId=${config.projectId}`,
-        {
-          headers: STANDALONE
-            ? { Authorization: `Bearer ${DEFAULT_USER_TOKEN}` }
-            : { Authorization: `Bearer ${token}` },
+      ; (async () => {
+        const res = await fetch(
+          `${config.apiUrl}/agents?projectId=${config.projectId}`,
+          {
+            headers: STANDALONE
+              ? { Authorization: `Bearer ${DEFAULT_USER_TOKEN}` }
+              : { Authorization: `Bearer ${token}` },
+          }
+        )
+        const json = await res.json()
+        // if data.length === 0  create new agent
+        if (json.data.length === 0) {
+          await createNew({
+            name: "Default Agent",
+            projectId: config.projectId,
+            enabled: false,
+            publicVariables: '{}',
+            secrets: '{}',
+            default: true,
+          })
+          setData(json.data)
+        } else {
+          setData(json.data)
         }
-      )
-      const json = await res.json()
-      // if data.length === 0  create new agent
-      if (json.data.length === 0) {
-        await createNew({
-          name: "Default Agent",
-          projectId: config.projectId,
-          enabled: false,
-          publicVariables: '{}',
-          secrets: '{}',
-          default: true,
-        })
-        setData(json.data)
-      } else {
-        setData(json.data)
-      }
 
-      // setIsLoading(false)
-    })()
+        // setIsLoading(false)
+      })()
   }, [config?.apiUrl])
 
   useEffect(() => {

--- a/packages/core/client/src/components/Drawer/OldSidebar/index.tsx
+++ b/packages/core/client/src/components/Drawer/OldSidebar/index.tsx
@@ -116,7 +116,7 @@ const DrawerItem: React.FC<DrawerItemProps> = ({
   tooltipText,
 }) => (
   <ListItem key={text} disablePadding sx={{ display: 'block' }}>
-    <Tooltip title={tooltipText} placement="top" enterDelay={500} arrow>
+    <Tooltip title={tooltipText} placement="top" enterDelay={500} disableInteractive arrow>
       <ListItemButton
         sx={{
           minHeight: 48,

--- a/packages/core/client/src/components/Tooltip/index.tsx
+++ b/packages/core/client/src/components/Tooltip/index.tsx
@@ -19,7 +19,7 @@ interface Props {
  * @returns {React.ReactElement} A Tooltip component with title and placement options.
  */
 export const Tooltip = ({ title, placement = 'top', children }: Props): React.ReactElement => (
-  <MUITooltip title={title} placement={placement}>
+  <MUITooltip title={title} placement={placement} disableInteractive>
     {children}
   </MUITooltip>
 );

--- a/packages/editor/src/DataControls/DataControls.tsx
+++ b/packages/editor/src/DataControls/DataControls.tsx
@@ -123,7 +123,7 @@ const DataControls = ({
               borderRadius: '5px',
             }}
           >
-            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top-start" arrow>
+            <Tooltip title={control.tooltip ? control.tooltip : control.name} placement="top-start" disableInteractive arrow>
 
             <p style={{ margin: 0, marginBottom: '10px' }}>
               {control.name || key}

--- a/packages/editor/src/components/Node/Node.tsx
+++ b/packages/editor/src/components/Node/Node.tsx
@@ -66,14 +66,12 @@ export class MyNode extends Node {
     `
     return (
       <div
-        className={`${css['node']} ${css[selected]} ${
-          css[hasError ? 'error' : '']
-        } ${css[hasSuccess ? 'success' : '']}`}
+        className={`${css['node']} ${css[selected]} ${css[hasError ? 'error' : '']
+          } ${css[hasSuccess ? 'success' : '']}`}
       >
         <div
-          className={`${css['node-id']} ${hasError ? css['error'] : ''} ${
-            hasSuccess ? css['success'] : ''
-          }`}
+          className={`${css['node-id']} ${hasError ? css['error'] : ''} ${hasSuccess ? css['success'] : ''
+            }`}
         >
           <p>{node.id}</p>
         </div>
@@ -112,7 +110,8 @@ export class MyNode extends Node {
                     <StyleTooltip
                       title={`Input:${input.name}`}
                       placement="left"
-                      enterNextDelay={2000} 
+                      enterNextDelay={500}
+                      disableInteractive
                     >
                       <div className="input-title">{input.name}</div>
                     </StyleTooltip>
@@ -139,7 +138,8 @@ export class MyNode extends Node {
                   <StyleTooltip
                     title={`output: ${output.name}`}
                     placement="right"
-                    enterNextDelay={2000} 
+                    enterNextDelay={500}
+                    disableInteractive
                   >
                     <div className="output-title">{output.name}</div>
                   </StyleTooltip>

--- a/packages/editor/src/screens/agents/AgentWindow/AgentDetails.tsx
+++ b/packages/editor/src/screens/agents/AgentWindow/AgentDetails.tsx
@@ -258,6 +258,7 @@ const AgentDetails = ({
             }
 
             placement="right-start"
+            disableInteractive
             arrow
           >
             <span style={{ marginLeft: '20px' }}>
@@ -296,7 +297,7 @@ const AgentDetails = ({
         </div>
       </div>
       <div className="form-item agent-select">
-        <Tooltip title={tooltip_text.rootSpell} placement="right" arrow>
+        <Tooltip title={tooltip_text.rootSpell} placement="right" disableInteractive arrow>
           <span className="form-item-label">Root Spell</span>
         </Tooltip>
         <select
@@ -339,7 +340,7 @@ const AgentDetails = ({
 
           return (
             <div key={value.name + index} style={{ marginBottom: '1em' }}>
-              <Tooltip title={tooltip_text[value.name]} placement="right" arrow>
+              <Tooltip title={tooltip_text[value.name]} placement="right" disableInteractive arrow>
                 <div style={{ width: '100%', marginBottom: '1em' }}>
                   {value.name}
                 </div>
@@ -392,7 +393,7 @@ const AgentDetails = ({
           console.log(value);
 
           return (
-            <Tooltip title="kkkk" arrow>
+            <Tooltip title="kkkk" disableInteractive arrow>
               <RenderComp
                 key={index}
                 enable={enable}

--- a/packages/editor/src/screens/settings/SettingsWindow.tsx
+++ b/packages/editor/src/screens/settings/SettingsWindow.tsx
@@ -28,7 +28,7 @@ const SettingsWindowChild = ({
   getKey,
 }) => {
   const [clear, setClear] = useState('Clear');
- 
+
 
   return (
     <div className={styles['child']}>
@@ -100,7 +100,7 @@ const SettingsWindow = () => {
     window.localStorage.setItem('secrets', JSON.stringify(secretKeys));
 
     pluginManager.getSecrets(true).forEach((value) => {
-      const { name, displayName }:any = value;
+      const { name, displayName }: any = value;
       const secretName = displayName || name;
       const valueName = secretKeys[value.key];
 

--- a/packages/editor/src/windows/InspectorWindow.tsx
+++ b/packages/editor/src/windows/InspectorWindow.tsx
@@ -66,14 +66,14 @@ const Inspector = (props) => {
 
   const toolbar = (
     <>
-    <Tooltip title={inspectorData?.name} placement="top-start"> 
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
-        <Icon
-          name={componentCategories[inspectorData?.category || 0]}
-          style={{ marginRight: 'var(--extraSmall)' }}
-        />
-        {inspectorData?.name}
-      </div>
+      <Tooltip title={inspectorData?.name} placement="top-start">
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
+          <Icon
+            name={componentCategories[inspectorData?.category || 0]}
+            style={{ marginRight: 'var(--extraSmall)' }}
+          />
+          {inspectorData?.name}
+        </div>
       </Tooltip>
       {inspectorData?.info && (
         <Tooltip title="Help" placement="bottom">

--- a/packages/plugins/bluesky/client/src/components/VariableModal.tsx
+++ b/packages/plugins/bluesky/client/src/components/VariableModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@magickml/client-core'
 import Grid from '@mui/material/Grid'
 import { useState } from 'react'
-import {Tooltip} from '@mui/material'
+import { Tooltip } from '@mui/material'
 
 const VariableModal = ({
   selectedAgentData,
@@ -52,8 +52,8 @@ const VariableModal = ({
       </Grid>
       <div style={{ marginBottom: '1em' }}>
         <div>
-          <Tooltip title="add your bluesky user identifier" placement='bottom' arrow>
-          <span className="form-item-label">User Identifier</span>
+          <Tooltip title="add your bluesky user identifier" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">User Identifier</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -67,8 +67,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="add your bluesky password" placement='bottom' arrow>
-          <span className="form-item-label">Password</span>
+          <Tooltip title="add your bluesky password" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">Password</span>
           </Tooltip>
           <input
             className="modal-element"

--- a/packages/plugins/bluesky/client/src/components/agent.component.tsx
+++ b/packages/plugins/bluesky/client/src/components/agent.component.tsx
@@ -42,7 +42,7 @@ export const BlueskyAgentWindow: FC<any> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-        <Tooltip title="Add your Bluesky settings" placement='left' arrow>
+        <Tooltip title="Add your Bluesky settings" placement='left' disableInteractive arrow>
           <h3>Bluesky</h3>
         </Tooltip>
         <div

--- a/packages/plugins/discord/client/src/components/VariableModal.tsx
+++ b/packages/plugins/discord/client/src/components/VariableModal.tsx
@@ -41,8 +41,8 @@ const VariableModal = ({
       <Modal open={editMode} onClose={setEditMode} showSaveBtn={true} handleAction={handleSave}>
         <div style={{ marginBottom: '1em' }}>
           <div>
-            <Tooltip title="add your api key here and save" placement='bottom' arrow >
-            <span className="form-item-label">API Key</span>
+            <Tooltip title="add your api key here and save" placement='bottom' disableInteractive arrow >
+              <span className="form-item-label">API Key</span>
             </Tooltip>
             <input
               type="password"

--- a/packages/plugins/discord/client/src/components/agent.component.tsx
+++ b/packages/plugins/discord/client/src/components/agent.component.tsx
@@ -104,7 +104,7 @@ export const DiscordAgentWindow: FC<any> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-        <Tooltip title="Add discord Api key here" placement='left' arrow>
+        <Tooltip title="Add discord Api key here" placement='left' disableInteractive arrow>
           <h3>Discord</h3>
         </Tooltip>
         <div

--- a/packages/plugins/github/client/src/components/VariableModal.tsx
+++ b/packages/plugins/github/client/src/components/VariableModal.tsx
@@ -1,6 +1,6 @@
 import { Modal } from '@magickml/client-core'
 import { useState } from 'react'
-import {Tooltip} from "@mui/material"
+import { Tooltip } from "@mui/material"
 
 const VariableModal = ({
   selectedAgentData,
@@ -59,8 +59,8 @@ const VariableModal = ({
       <Modal open={editMode} onClose={setEditMode} handleAction={handleSave} showSaveBtn={true}>
         <>
           <div style={{ marginBottom: '1em' }}>
-            <Tooltip title={" Add your Github access "} placement="bottom" arrow>
-            <span className="form-item-label">Personal Access Token</span>
+            <Tooltip title={" Add your Github access "} placement="bottom" disableInteractive arrow>
+              <span className="form-item-label">Personal Access Token</span>
             </Tooltip>
             <input
               type="text"
@@ -72,8 +72,8 @@ const VariableModal = ({
             />
           </div>
           <div style={{ marginBottom: '1em' }}>
-            <Tooltip title={" Add your Github repositories "} placement="bottom" arrow>
-            <span className="form-item-label">Repositories (Comma separated, i.e. org/repo, org/repo)</span>
+            <Tooltip title={" Add your Github repositories "} placement="bottom" disableInteractive arrow>
+              <span className="form-item-label">Repositories (Comma separated, i.e. org/repo, org/repo)</span>
             </Tooltip>
             <input
               type="text"

--- a/packages/plugins/github/client/src/components/agent.component.tsx
+++ b/packages/plugins/github/client/src/components/agent.component.tsx
@@ -3,7 +3,7 @@ import { debounce } from 'lodash'
 
 import { Switch } from '@magickml/client-core'
 import VariableModal from './VariableModal'
-import {Tooltip} from "@mui/material"
+import { Tooltip } from "@mui/material"
 
 export const GithubAgentWindow: FC<any> = props => {
   props = props.props
@@ -42,9 +42,9 @@ export const GithubAgentWindow: FC<any> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-         <Tooltip title={" Add your Github access "} placement="left" arrow>
-        <h3>Github</h3>
-         </Tooltip>
+        <Tooltip title={" Add your Github access "} placement="left" disableInteractive arrow>
+          <h3>Github</h3>
+        </Tooltip>
         <div
           style={{
             display: 'flex',

--- a/packages/plugins/loop/client/src/components/loop.component.tsx
+++ b/packages/plugins/loop/client/src/components/loop.component.tsx
@@ -88,8 +88,8 @@ export const AgentLoopWindow: FC<PluginProps> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-        <Tooltip title="Add your loop settings" placement="left" arrow>
-        <h3>Agent Update Loop</h3>
+        <Tooltip title="Add your loop settings" placement="left" disableInteractive arrow>
+          <h3>Agent Update Loop</h3>
         </Tooltip>
         <div
           style={{
@@ -133,8 +133,8 @@ export const AgentLoopWindow: FC<PluginProps> = props => {
         <Modal open={editMode} onClose={handleClose} handleAction={handleSave}>
           <div>
             <div>
-              <Tooltip title="add number of seconds to run the loop" placement="bottom" arrow>
-              <span className="form-item-label">Loop Interval</span>
+              <Tooltip title="add number of seconds to run the loop" placement="bottom" disableInteractive arrow>
+                <span className="form-item-label">Loop Interval</span>
               </Tooltip>
               <input
                 type="text"

--- a/packages/plugins/rest/client/src/components/rest.component.tsx
+++ b/packages/plugins/rest/client/src/components/rest.component.tsx
@@ -10,7 +10,7 @@ import { API_ROOT_URL } from '@magickml/config'
 import { Tooltip } from "@mui/material"
 
 
-const fetchGetExample = (selectedAgentData, content) =>`
+const fetchGetExample = (selectedAgentData, content) => `
     fetch("${API_ROOT_URL}/api/${selectedAgentData.id}?content=${encodeURIComponent(content)}", {
     method: 'GET',
     headers: {
@@ -24,7 +24,7 @@ const fetchGetExample = (selectedAgentData, content) =>`
     });
 `;
 
-const fetchDeleteExample = (selectedAgentData, content) =>`
+const fetchDeleteExample = (selectedAgentData, content) => `
     fetch("${API_ROOT_URL}/api/${selectedAgentData.id}?content=${encodeURIComponent(content)}", {
     method: 'GET',
     headers: {
@@ -116,7 +116,7 @@ export const RestAgentWindow: FC<any> = props => {
                     opacity: disable ? 0.2 : 1,
                 }}
             >
-                <Tooltip title="add your rest Api seetings here" placement='left' arrow >
+                <Tooltip title="add your rest Api seetings here" placement='left' disableInteractive arrow >
                     <h3>REST API</h3>
                 </Tooltip>
                 <div
@@ -161,7 +161,7 @@ export const RestAgentWindow: FC<any> = props => {
                     <div className="form-item">
                         <Grid container>
                             <Grid item xs={12}>
-                                <Tooltip title="add your agentId here" placement='bottom' arrow >
+                                <Tooltip title="add your agentId here" placement='bottom' disableInteractive arrow >
                                     <span className="form-item-label modal-element">Agent ID</span>
                                 </Tooltip>
                                 <Input
@@ -177,7 +177,7 @@ export const RestAgentWindow: FC<any> = props => {
                                 />
                             </Grid>
                             <Grid item xs={12}>
-                                <Tooltip title="add your api key here" placement='bottom' arrow >
+                                <Tooltip title="add your api key here" placement='bottom' disableInteractive arrow >
                                     <span
                                         style={{ marginTop: '2em' }}
                                         className="form-item-label modal-element"
@@ -200,7 +200,7 @@ export const RestAgentWindow: FC<any> = props => {
                                 />
                             </Grid>
                             <Grid item xs={12}>
-                                <Tooltip title="add your url here" placement='bottom' arrow >
+                                <Tooltip title="add your url here" placement='bottom' disableInteractive arrow >
                                     <span
                                         style={{ marginTop: '2em' }}
                                         className="form-item-label modal-element"
@@ -244,7 +244,7 @@ export const RestAgentWindow: FC<any> = props => {
                                     >
                                         {showGetExample ? 'Hide' : 'Show'}
                                     </Button>
-                                    <Tooltip title="Your Get url" placement='bottom' arrow >
+                                    <Tooltip title="Your Get url" placement='bottom' disableInteractive arrow >
 
                                         <h4>GET Example</h4>
                                     </Tooltip>
@@ -294,7 +294,7 @@ export const RestAgentWindow: FC<any> = props => {
                                     >
                                         {showPostExample ? 'Hide' : 'Show'}
                                     </Button>
-                                    <Tooltip title="Your Post url" placement='bottom' arrow >
+                                    <Tooltip title="Your Post url" placement='bottom' disableInteractive arrow >
                                         <h4>POST Example</h4>
                                     </Tooltip>
                                 </span>
@@ -342,7 +342,7 @@ export const RestAgentWindow: FC<any> = props => {
                                     >
                                         {showPutExample ? 'Hide' : 'Show'}
                                     </Button>
-                                    <Tooltip title="Your Put url" placement='bottom' arrow >
+                                    <Tooltip title="Your Put url" placement='bottom' disableInteractive arrow >
                                         <h4>PUT Example</h4>
                                     </Tooltip>
                                 </span>
@@ -392,7 +392,7 @@ export const RestAgentWindow: FC<any> = props => {
                                     >
                                         {showDeleteExample ? 'Hide' : 'Show'}
                                     </Button>
-                                    <Tooltip title="Your Delete url" placement='bottom' arrow >
+                                    <Tooltip title="Your Delete url" placement='bottom' disableInteractive arrow >
                                         <h4>DELETE Example</h4>
                                     </Tooltip>
                                 </span>

--- a/packages/plugins/task/client/src/components/task.component.tsx
+++ b/packages/plugins/task/client/src/components/task.component.tsx
@@ -56,8 +56,8 @@ export const AgentTaskWindow: FC<PluginProps> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-        <Tooltip title="Enable/Disable Task Plugin" placement="left" arrow>
-        <h3>Agent Task Runner</h3>
+        <Tooltip title="Enable/Disable Task Plugin" placement="left" disableInteractive arrow>
+          <h3>Agent Task Runner</h3>
         </Tooltip>
         <div
           style={{

--- a/packages/plugins/twitter/client/src/components/VariableModal.tsx
+++ b/packages/plugins/twitter/client/src/components/VariableModal.tsx
@@ -1,7 +1,7 @@
 import { Modal, Switch } from '@magickml/client-core'
 import Grid from '@mui/material/Grid'
 import { useState } from 'react'
-import {Tooltip} from '@mui/material'
+import { Tooltip } from '@mui/material'
 
 const VariableModal = ({
   selectedAgentData,
@@ -64,8 +64,8 @@ const VariableModal = ({
       </Grid>
       <div style={{ marginBottom: '1em' }}>
         <div>
-          <Tooltip title="Your Twitter userID" placement='bottom' arrow>
-          <span className="form-item-label">User ID</span>
+          <Tooltip title="Your Twitter userID" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">User ID</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -79,8 +79,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="Your Twitter bearer token" placement='bottom' arrow>
-          <span className="form-item-label">Bearer Token (API v2)</span>
+          <Tooltip title="Your Twitter bearer token" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">Bearer Token (API v2)</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -93,8 +93,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="Your Twitter API key" placement='bottom' arrow>
-          <span className="form-item-label">API Key</span>
+          <Tooltip title="Your Twitter API key" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">API Key</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -107,8 +107,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="Your Twitter API key secret" placement='bottom' arrow>
-          <span className="form-item-label">API Key Secret</span>
+          <Tooltip title="Your Twitter API key secret" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">API Key Secret</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -121,8 +121,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="Your Twitter access token" placement='bottom' arrow>
-          <span className="form-item-label">Access Token</span>
+          <Tooltip title="Your Twitter access token" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">Access Token</span>
           </Tooltip>
           <input
             className="modal-element"
@@ -135,8 +135,8 @@ const VariableModal = ({
       </div>
       <div>
         <div style={{ marginBottom: '1em' }}>
-          <Tooltip title="Your Twitter access token secret" placement='bottom' arrow>
-          <span className="form-item-label">Access Token Secret</span>
+          <Tooltip title="Your Twitter access token secret" placement='bottom' disableInteractive arrow>
+            <span className="form-item-label">Access Token Secret</span>
           </Tooltip>
           <input
             className="modal-element"

--- a/packages/plugins/twitter/client/src/components/agent.component.tsx
+++ b/packages/plugins/twitter/client/src/components/agent.component.tsx
@@ -2,7 +2,7 @@ import { Switch } from '@magickml/client-core'
 import { debounce } from 'lodash'
 import { FC, useEffect, useState } from 'react'
 import VariableModal from './VariableModal'
-import {Tooltip} from '@mui/material'
+import { Tooltip } from '@mui/material'
 
 export const TwitterAgentWindow: FC<any> = props => {
   props = props.props
@@ -38,8 +38,8 @@ export const TwitterAgentWindow: FC<any> = props => {
           opacity: disable ? 0.2 : 1,
         }}
       >
-        <Tooltip title="Add your twitter account details here" placement='left' arrow>
-        <h3>Twitter</h3>
+        <Tooltip title="Add your twitter account details here" placement='left' disableInteractive arrow>
+          <h3>Twitter</h3>
         </Tooltip>
         <div
           style={{


### PR DESCRIPTION
Added disableInteractive prop to every Tooltip element so that the tooltip disappears when you hover off the element that triggers the popup. Previous behavior was that you would move your mouse from the element onto the tooltip and the tooltip would stay until you hover off the tooltip OR the element. If the tooltip goes on top of another button it gets in the way, especially annoying on the left nav bar.