### PR TITLE
retry and backoff when getting a 429 from openai text/chat completions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@welldone-software/why-did-you-render": "7.0.1",
         "aws-sdk": "^2.1446.0",
         "axios": "1.4.0",
+        "axios-retry": "^3.8.0",
         "bullmq": "4.6.0",
         "class-variance-authority": "^0.7.0",
         "classnames": "2.3.2",
@@ -24558,6 +24559,15 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-retry": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.8.0.tgz",
+      "integrity": "sha512-CfIsQyWNc5/AE7x/UEReRUadiBmQeoBpSEC+4QyGLJMswTsP1tz0GW2YYPnE7w9+ESMef5zOgLDFpHynNyEZ1w==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -35850,6 +35860,17 @@
       "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-root": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@welldone-software/why-did-you-render": "7.0.1",
     "aws-sdk": "^2.1446.0",
     "axios": "1.4.0",
+    "axios-retry": "^3.8.0",
     "bullmq": "4.6.0",
     "class-variance-authority": "^0.7.0",
     "classnames": "2.3.2",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -119,6 +119,10 @@ export const AGENT_RESPONSE_TIMEOUT_MSEC =
 
 export const CLOUD_AGENT_KEY = getVarForEnvironment('CLOUD_AGENT_KEY') || v4()
 
+export const BACKOFF_RETRY_LIMIT = Number(
+  getVarForEnvironment('BACKOFF_RETRY_LIMIT') || 0
+)
+
 export const AWS_ACCESS_KEY = getVarForEnvironment('AWS_ACCESS_KEY') || ''
 export const AWS_SECRET_KEY = getVarForEnvironment('AWS_SECRET_KEY') || ''
 export const AWS_REGION = getVarForEnvironment('AWS_REGION') || ''

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -116,7 +116,7 @@ export async function makeChatCompletion(
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
       retryCondition: error => {
-        return error.code === '429'
+        return error?.response?.status === 429
       },
     })
 

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -115,6 +115,9 @@ export async function makeChatCompletion(
       retries: 5,
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
+      retryCondition: error => {
+        return error.code === '429'
+      },
     })
 
     const start = Date.now()

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -9,6 +9,7 @@ import { OPENAI_ENDPOINT } from '../constants'
 import { DEFAULT_OPENAI_KEY, PRODUCTION } from '@magickml/config'
 import { GPT4_MODELS } from '@magickml/plugin-openai-shared'
 import { trackOpenAIUsage } from '@magickml/server-core'
+import axiosRetry from 'axios-retry'
 
 /**
  * Generate a completion text based on prior chat conversation input.
@@ -109,6 +110,13 @@ export async function makeChatCompletion(
   }
 
   try {
+    // Exponential back-off retry delay between requests
+    axiosRetry(axios, {
+      retries: 5,
+      retryDelay: axiosRetry.exponentialDelay,
+      shouldResetTimeout: true,
+    })
+
     const start = Date.now()
     // Make the API call to OpenAI
     const completion = await axios.post(

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -6,7 +6,11 @@ import {
 } from '@magickml/core'
 import axios from 'axios'
 import { OPENAI_ENDPOINT } from '../constants'
-import { DEFAULT_OPENAI_KEY, PRODUCTION } from '@magickml/config'
+import {
+  DEFAULT_OPENAI_KEY,
+  PRODUCTION,
+  BACKOFF_RETRY_LIMIT,
+} from '@magickml/config'
 import { GPT4_MODELS } from '@magickml/plugin-openai-shared'
 import { trackOpenAIUsage } from '@magickml/server-core'
 import axiosRetry from 'axios-retry'
@@ -112,7 +116,7 @@ export async function makeChatCompletion(
   try {
     // Exponential back-off retry delay between requests
     axiosRetry(axios, {
-      retries: 5,
+      retries: BACKOFF_RETRY_LIMIT,
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
       retryCondition: error => {

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -2,7 +2,11 @@
 import { CompletionHandlerInputData, saveRequest } from '@magickml/core'
 import axios from 'axios'
 import { OPENAI_ENDPOINT } from '../constants'
-import { DEFAULT_OPENAI_KEY, PRODUCTION } from '@magickml/config'
+import {
+  DEFAULT_OPENAI_KEY,
+  PRODUCTION,
+  BACKOFF_RETRY_LIMIT,
+} from '@magickml/config'
 import { GPT4_MODELS } from '@magickml/plugin-openai-shared'
 import { trackOpenAIUsage } from '@magickml/server-core'
 import axiosRetry from 'axios-retry'
@@ -75,7 +79,7 @@ export async function makeTextCompletion(
   try {
     // Exponential back-off retry delay between requests
     axiosRetry(axios, {
-      retries: 5,
+      retries: BACKOFF_RETRY_LIMIT,
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
       retryCondition: error => {

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -78,6 +78,9 @@ export async function makeTextCompletion(
       retries: 5,
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
+      retryCondition: error => {
+        return error.code === '429'
+      },
     })
 
     const start = Date.now()

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -5,6 +5,7 @@ import { OPENAI_ENDPOINT } from '../constants'
 import { DEFAULT_OPENAI_KEY, PRODUCTION } from '@magickml/config'
 import { GPT4_MODELS } from '@magickml/plugin-openai-shared'
 import { trackOpenAIUsage } from '@magickml/server-core'
+import axiosRetry from 'axios-retry'
 
 /**
  * Makes an API request to an AI text completion service.
@@ -72,6 +73,13 @@ export async function makeTextCompletion(
 
   // Make the API request and handle the response.
   try {
+    // Exponential back-off retry delay between requests
+    axiosRetry(axios, {
+      retries: 5,
+      retryDelay: axiosRetry.exponentialDelay,
+      shouldResetTimeout: true,
+    })
+
     const start = Date.now()
     const resp = await axios.post(`${OPENAI_ENDPOINT}/completions`, settings, {
       headers: headers,

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -79,7 +79,7 @@ export async function makeTextCompletion(
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
       retryCondition: error => {
-        return error.code === '429'
+        return error?.response?.status === 429
       },
     })
 


### PR DESCRIPTION
Implemented exponential backoff and retry using axios-retry which wraps the axios instance. The max number of retries is specified in environment variable BACKOFF_RETRY_LIMIT (a good value seems to be 5 or 6 for this which is 10-20 seconds of retries)