### PR TITLE
Discord snowflake

### DIFF
--- a/packages/plugins/discord/server/src/connectors/discord.ts
+++ b/packages/plugins/discord/server/src/connectors/discord.ts
@@ -285,7 +285,7 @@ export class DiscordConnector {
         [`Input - Discord (${inputType})`]: {
           connector: `Discord (${inputType})`,
           content: content,
-          sender: author.username,
+          sender: author.id,
           observer: this.client.user.username,
           client: 'discord',
           channel: message.channel.id,

--- a/packages/plugins/discord/server/src/connectors/discord.ts
+++ b/packages/plugins/discord/server/src/connectors/discord.ts
@@ -266,7 +266,7 @@ export class DiscordConnector {
     }
 
     // add the sender if not already in the list
-    if (!entities.includes(author.username)) {
+    if (!entities.includes(this.client.user.username)) {
       entities.push(this.client.user.username)
     }
 

--- a/packages/plugins/discord/shared/src/nodes/utils.ts
+++ b/packages/plugins/discord/shared/src/nodes/utils.ts
@@ -68,7 +68,7 @@ export async function runSpell(
       'Input - Discord (Text)': {
         connector: 'Discord (Text)',
         content: content,
-        sender: ' message.author.username',
+        sender: ' message.author.id',
         observer: ' message.author.username',
         client: 'discord',
         channel: 'message.channel.id',


### PR DESCRIPTION
Change the discord connector to use the unique discord user ID instead of the discord username. Although the discord username is unique at the time the request is made, the user can change their username which could cause overlaps. The discord user ID is always the same for the user. 
