### PR TITLE
Fix bug with default input

### DIFF
--- a/packages/core/shared/src/nodes/io/Input.ts
+++ b/packages/core/shared/src/nodes/io/Input.ts
@@ -66,9 +66,6 @@ export class InputComponent extends MagickComponent<InputReturn> {
       name: 'Input Name',
       icon: 'moon',
       defaultValue: 'Default',
-      onData: data => {
-        node.data.name = `Input - ${data}`
-      },
       tooltip: 'Tooltip text for Input Name',
     }
 
@@ -261,13 +258,15 @@ export class InputComponent extends MagickComponent<InputReturn> {
       if (node?._task) node._task.closed = []
 
       let output = data[node.data.name]
-      if (output === undefined && node.data.name === "Input - Default") {
+      if (output === undefined && node.data.name === 'Input - Default') {
         output = Object.values(data)[0]
       }
 
       if (!output) {
-        this.logger.error('No input recieved in input node for ' + node.data.name)
-        throw new Error("No input recieved")
+        this.logger.error(
+          'No input recieved in input node for ' + node.data.name
+        )
+        throw new Error('No input recieved')
       }
 
       return {


### PR DESCRIPTION
The bug: when you have an input set as "default - input" then change the input type, for example changing to "Task", the node itself will still say "default - input". Reloading the page fixes the display error, and changing back to another type after that doesn't cause the bug, only when changing from "default" to something else.

The fix: The inspector control loops through each data control key and overrides them. The default input passes in a data control that overrides the input name (the displayed name) when data changes. Only the default input has this onData event, and the changing of the input name (the displayed name) is handled elsewhere in the app. I removed the onData event entirely and the bug was fixed. What was happening was one part of the code would change the input name, then this onData event would fire some time later and override the display name. 