### PR TITLE
Fine tuning

### DIFF
--- a/packages/core/shared/src/cost-calculator.ts
+++ b/packages/core/shared/src/cost-calculator.ts
@@ -5,6 +5,7 @@
 export enum ChatModel {
   GPT4 = 'gpt-4',
   GPT35Turbo = 'gpt-3.5-turbo',
+  GPT35TURBO_FINETUNE = 'fine-tuned-gpt-3.5-turbo',
   GPT4_0613 = 'gpt-4-0613',
   GPT35Turbo_0613 = 'gpt-3.5-turbo-0613',
   CLAUDE_1 = 'claude-1',
@@ -56,6 +57,7 @@ export const COST_PER_TOKEN: CostPerToken<
   [ChatModel.GPT35Turbo]: 0.002 / 1000,
   [ChatModel.GPT4_0613]: 0.06 / 1000,
   [ChatModel.GPT35Turbo_0613]: 0.002 / 1000,
+  [ChatModel.GPT35TURBO_FINETUNE]: 0.016 / 1000,
   [EmbeddingModel.ADA_002]: 0.0001 / 1000,
   [EmbeddingModel.ADA_001]: 0.0004 / 1000,
   [ChatModel.CLAUDE_1]: 11.02 / 1_000_000,

--- a/packages/core/shared/src/nodes/text/GenerateText.ts
+++ b/packages/core/shared/src/nodes/text/GenerateText.ts
@@ -73,11 +73,11 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
     })
 
     const customModel = new InputControl({
-      name: 'Custom Model',
+      name: 'Custom OpenAI Model',
       dataKey: 'customModel',
       defaultValue: '',
       tooltip:
-        'Use to use a custom model.  Will override the model dropdown. You need an API key for your service.',
+        'Use to use a custom Open AI model.  Will override the model dropdown. You need an API key for your service.',
     })
 
     node.inspector.add(modelName).add(customModel)
@@ -194,12 +194,10 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       throw new Error('ERROR: Completion handler undefined')
     }
 
-    // cvheck if custom model and regex check for word fine-tune in model
+    // check if custom model and regex check for word fine-tune in model
     if (customModel.length > 0) {
       node.data.customModel = customModel
     }
-
-    console.log('node.data.customModel', node.data.customModel)
 
     const { success, result, error } = await completionHandler({
       node,

--- a/packages/core/shared/src/nodes/text/GenerateText.ts
+++ b/packages/core/shared/src/nodes/text/GenerateText.ts
@@ -14,6 +14,7 @@ import {
   MagickWorkerOutputs,
   WorkerData,
 } from '../../types'
+import { InputControl } from '../../dataControls/InputControl'
 
 /** Information related to the GenerateText */
 const info =
@@ -71,7 +72,15 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       tooltip: 'Choose model name',
     })
 
-    node.inspector.add(modelName)
+    const customModel = new InputControl({
+      name: 'Custom Model',
+      dataKey: 'customModel',
+      defaultValue: '',
+      tooltip:
+        'Use to use a custom model.  Will override the model dropdown. You need an API key for your service.',
+    })
+
+    node.inspector.add(modelName).add(customModel)
 
     node.addInput(dataInput).addOutput(dataOutput)
 
@@ -170,9 +179,11 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       'chat',
     ]) as CompletionProvider[]
 
-    const model = (node.data as { model: string }).model as string
+    let model = (node.data as { model: string }).model as string
+    const customModel = (node.data as { customModel: string })
+      .customModel as string
+
     // get the provider for the selected model
-    console.log('model', model)
     const provider = completionProviders.find(provider =>
       provider.models.includes(model)
     ) as CompletionProvider
@@ -182,6 +193,13 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       console.error('No completion handler found for provider', provider)
       throw new Error('ERROR: Completion handler undefined')
     }
+
+    // cvheck if custom model and regex check for word fine-tune in model
+    if (customModel.length > 0) {
+      node.data.customModel = customModel
+    }
+
+    console.log('node.data.customModel', node.data.customModel)
 
     const { success, result, error } = await completionHandler({
       node,

--- a/packages/core/shared/src/nodes/text/GenerateText.ts
+++ b/packages/core/shared/src/nodes/text/GenerateText.ts
@@ -179,7 +179,7 @@ export class GenerateText extends MagickComponent<Promise<WorkerReturn>> {
       'chat',
     ]) as CompletionProvider[]
 
-    let model = (node.data as { model: string }).model as string
+    const model = (node.data as { model: string }).model as string
     const customModel = (node.data as { customModel: string })
       .customModel as string
 

--- a/packages/core/shared/src/types.ts
+++ b/packages/core/shared/src/types.ts
@@ -653,6 +653,7 @@ export type RequestPayload = {
   totalTokens?: number
   spell?: SpellInterface
   nodeId?: number
+  customModel?: string
 }
 
 export type RequestData = {

--- a/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeChatCompletion.ts
@@ -38,7 +38,7 @@ export async function makeChatCompletion(
 
   // Get or set default settings
   const settings = {
-    model: node?.data?.model,
+    model: node?.data?.customModel ?? node?.data?.model,
     temperature: parseFloat((node?.data?.temperature as string) ?? '0.0'),
     top_p: parseFloat((node?.data?.top_p as string) ?? '1.0'),
     frequency_penalty: parseFloat(
@@ -158,7 +158,7 @@ export async function makeChatCompletion(
       startTime: start,
       statusCode: completion.status,
       status: completion.statusText,
-      model: settings.model,
+      model: node?.data?.model as string,
       parameters: JSON.stringify(settings),
       type: 'completion',
       provider: 'openai',

--- a/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
+++ b/packages/plugins/openai/server/src/functions/makeTextCompletion.ts
@@ -37,7 +37,7 @@ export async function makeTextCompletion(
   const prompt = inputs['input'][0]
 
   const requestData = {
-    model: node?.data?.model,
+    model: node?.data?.customModel ?? node?.data?.model,
     temperature: parseFloat((node?.data?.temperature as string) ?? '0'),
     max_tokens: parseFloat((node?.data?.max_tokens as string) ?? '100'),
     top_p: parseFloat((node?.data?.top_p as string) ?? '1.0'),
@@ -103,7 +103,8 @@ export async function makeTextCompletion(
       startTime: start,
       statusCode: resp.status,
       status: resp.statusText,
-      model: settings.model,
+      model: node?.data?.model as string,
+      customModel: (node?.data?.customModel as string) || undefined,
       parameters: JSON.stringify(settings),
       type: 'completion',
       provider: 'openai',

--- a/packages/plugins/openai/shared/src/index.ts
+++ b/packages/plugins/openai/shared/src/index.ts
@@ -107,7 +107,7 @@ const completionProviders: CompletionProvider[] = [
         type: stringSocket,
       },
     ],
-    models: ['gpt-3.5-turbo', ...GPT4_MODELS],
+    models: ['gpt-3.5-turbo', 'fine-tuned-gpt-3.5-turbo', ...GPT4_MODELS],
   },
   {
     type: 'text',


### PR DESCRIPTION
## What Changed:

- add model fine tuning to the generate text node for OpenAI

## How to test:

- make sure you can send a request to a fine tuned open AI model 
  - select fine tuned gpt3.5 from main dropdown and then input your custom model name
- make sure normal chat generation works

## Additional information:

Any other information that might be useful while reviewing.
