### PR TITLE
Stop event store and recall from lowercasing things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ data.json
 /logs
 docstore.json
 .vercel
+.nx

--- a/packages/core/shared/src/nodes/events/EventRecall.ts
+++ b/packages/core/shared/src/nodes/events/EventRecall.ts
@@ -181,7 +181,9 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
 
       return events
     }
-    const typeSocket = (inputs['type'] && inputs['type'][0]) as string
+    const typeSocket = (inputs['type'] && inputs['type'][0]) as
+      | string
+      | undefined
 
     const event = (inputs['event'] &&
       (inputs['event'][0] || inputs['event'])) as Event
@@ -198,7 +200,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
     const { client, channel, connector, channelType, projectId, entities } =
       event
 
-    const typeData = node?.data?.type as string
+    const typeData = node?.data?.type as string | undefined
     const typeRaw =
       typeSocket ??
       (typeData !== undefined && typeData.length > 0 ? typeData : 'none')

--- a/packages/core/shared/src/nodes/events/EventRecall.ts
+++ b/packages/core/shared/src/nodes/events/EventRecall.ts
@@ -181,7 +181,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
 
       return events
     }
-    const typeSocket = inputs['type'] && inputs['type'][0]
+    const typeSocket = (inputs['type'] && inputs['type'][0]) as string
 
     const event = (inputs['event'] &&
       (inputs['event'][0] || inputs['event'])) as Event
@@ -198,12 +198,11 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
     const { client, channel, connector, channelType, projectId, entities } =
       event
 
-    const typeData = (node.data as { type: string })?.type
-    const type =
-      (typeSocket as string) ??
-      (typeData !== undefined && typeData.length > 0
-        ? typeData.toLowerCase().trim()
-        : 'none')
+    const typeData = node?.data?.type as string
+    const typeRaw =
+      typeSocket ??
+      (typeData !== undefined && typeData.length > 0 ? typeData : 'none')
+    const type = typeRaw.trim()
 
     let max_count
     if (typeof node.data.max_count === 'string') {

--- a/packages/core/shared/src/nodes/events/EventStore.ts
+++ b/packages/core/shared/src/nodes/events/EventStore.ts
@@ -110,7 +110,9 @@ export class EventStore extends MagickComponent<Promise<void>> {
     const { projectId } = context
 
     const event = inputs['event'][0] as Event
-    const typeSocket = (inputs['type'] && inputs['type'][0]) as string
+    const typeSocket = (inputs['type'] && inputs['type'][0]) as
+      | string
+      | undefined
     let content = (inputs['content'] ? inputs['content'][0] : null) as string
     let embedding = (
       inputs['embedding'] ? inputs['embedding'][0] : undefined
@@ -120,7 +122,7 @@ export class EventStore extends MagickComponent<Promise<void>> {
       embedding = (embedding as string).split(',').map(x => parseFloat(x))
     }
 
-    const typeData = node?.data?.type as string
+    const typeData = node?.data?.type as string | undefined
     const typeRaw =
       typeSocket ??
       (typeData !== undefined && typeData.length > 0 ? typeData : 'none')

--- a/packages/core/shared/src/nodes/events/EventStore.ts
+++ b/packages/core/shared/src/nodes/events/EventStore.ts
@@ -110,7 +110,7 @@ export class EventStore extends MagickComponent<Promise<void>> {
     const { projectId } = context
 
     const event = inputs['event'][0] as Event
-    const typeSocket = inputs['type'] && (inputs['type'][0] as string)
+    const typeSocket = (inputs['type'] && inputs['type'][0]) as string
     let content = (inputs['content'] ? inputs['content'][0] : null) as string
     let embedding = (
       inputs['embedding'] ? inputs['embedding'][0] : undefined
@@ -121,12 +121,10 @@ export class EventStore extends MagickComponent<Promise<void>> {
     }
 
     const typeData = node?.data?.type as string
-
-    const type =
+    const typeRaw =
       typeSocket ??
-      ((typeData !== undefined && typeData.length > 0
-        ? typeData.toLowerCase().trim()
-        : 'none') as string)
+      (typeData !== undefined && typeData.length > 0 ? typeData : 'none')
+    const type = typeRaw.trim()
 
     if (!content) {
       content = (event as Event).content || 'Error'


### PR DESCRIPTION
## What Changed:

stop lowercasing events and treat inspector data same as socket data for event type

## How to test:

How can the reviewer test your changes and validate that they work as described?

## Additional information:

Any other information that might be useful while reviewing.
