### PR TITLE
Fix filtering to use sender and observer explicitly

### DIFF
--- a/packages/core/server/src/services/events/events.class.ts
+++ b/packages/core/server/src/services/events/events.class.ts
@@ -45,9 +45,6 @@ export class EventService<
   async find(params?: ServiceParams) {
     const db = app.get('dbClient')
 
-    const entities = params?.query?.entities
-    // entities is an array of strings
-
     const query = db.from('events').select('*')
 
     if (params?.query?.embedding) {
@@ -65,14 +62,6 @@ export class EventService<
       // If not searching by embedding, perform a normal query
       query.orderBy('date', 'desc')
     }
-
-    if (entities && entities.length > 0) {
-      // Safely check if all entities are included in the `entities` column
-      entities.forEach(entity => {
-        query.whereRaw(`'${entity}' = ANY (entities)`)
-      })
-    }
-
     const param = params?.query
 
     if (!param) {
@@ -80,6 +69,8 @@ export class EventService<
     }
 
     if (param.type) query.where({ type: param.type })
+    if (param.sender) query.where({ sender: param.sender })
+    if (param.observer) query.where({ observer: param.observer })
     if (param.id) query.where({ id: param.id })
     if (param.client) query.where({ client: param.client })
     if (param.channel) query.where({ channel: param.channel })
@@ -90,8 +81,6 @@ export class EventService<
     query.limit(param['$limit'])
 
     const res = await query
-
-
 
     return { events: res as unknown as { data: Array<any> } }
   }

--- a/packages/core/shared/src/nodes/events/EventRecall.ts
+++ b/packages/core/shared/src/nodes/events/EventRecall.ts
@@ -31,9 +31,9 @@ type InputReturn = {
 }
 
 enum FilterTypes {
-  ChannelAndSender = 'Channel And Sender (DMs OK)',
+  ChannelAndSender = 'Channel And Sender',
   AllInChannel = 'All In Channel',
-  AllFromSender = 'All From Sender (No DMs)',
+  AllFromSender = 'All From Sender',
   AllFromConnector = 'All From Connector',
   All = 'All',
 }
@@ -181,6 +181,7 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
 
       return events
     }
+
     const typeSocket = (inputs['type'] && inputs['type'][0]) as
       | string
       | undefined
@@ -197,8 +198,15 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       embedding = (embedding as string)?.split(',')
     }
 
-    const { client, channel, connector, channelType, projectId, entities } =
-      event
+    const {
+      client,
+      channel,
+      connector,
+      channelType,
+      projectId,
+      sender,
+      observer,
+    } = event
 
     const typeData = node?.data?.type as string | undefined
     const typeRaw =
@@ -217,11 +225,12 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
     const data = {
       type,
       client,
-      entities,
       channel,
       connector,
       channelType,
       projectId,
+      sender,
+      observer,
       $limit: max_count ?? 1,
     }
 
@@ -230,20 +239,20 @@ export class EventRecall extends MagickComponent<Promise<InputReturn>> {
       // no need to do anything, should just work
     } else if (filterBy === FilterTypes.AllInChannel) {
       // filter by observer but not sender
-      delete data['entities']
+      delete data['sender']
     } else if (filterBy === FilterTypes.AllFromSender) {
       // filter by sender but not channel
       delete data['channel']
       delete data['channelType']
     } else if (filterBy === FilterTypes.AllFromConnector) {
       // filter by connector but not channel or sender
+      delete data['sender']
       delete data['channel']
       delete data['channelType']
-      delete data['entities']
     } else if (filterBy === FilterTypes.All) {
       // filter by all except sender, channel, and connector -- basically all for this observer
       delete data['channel']
-      delete data['entities']
+      delete data['sender']
       delete data['connector']
       delete data['channelType']
     }


### PR DESCRIPTION
## What Changed:

Switched filtering to use observer and sender explicitly rather than relying on the entities field, which was preventing getting other messages.  Also ensure that the observer is always in the query.

## How to test:

Event recall should work normally. You can also use this spell which simulates events being added to different channels to check recall.  At minimum all normal event recall functions should work.

[event-test.spell.json](https://github.com/Oneirocom/Magick/files/13385653/event-test.spell.json)


## Additional information:

Any other information that might be useful while reviewing.
